### PR TITLE
Add right-click context menu for market tiles

### DIFF
--- a/src/features/advanced/index.ts
+++ b/src/features/advanced/index.ts
@@ -28,6 +28,7 @@ import './inv-shorten-storage-types';
 import './lm-clean-ads';
 import './lm-hide-rating';
 import './mat-clean-info';
+import './market-contextmenu/market-contextmenu';
 import './minimize-headers/minimize-headers';
 import './nots-clean-notifications';
 import './prod-hide-percent';

--- a/src/features/advanced/market-contextmenu/MarketMenu.vue
+++ b/src/features/advanced/market-contextmenu/MarketMenu.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import { userData } from '@src/store/user-data';
+import { store } from './market-contextmenu';
+
+const exchanges: UserData.Exchange[] = ['AI1', 'CI1', 'CI2', 'IC1', 'NC1', 'NC2'];
+const buttons: [string, string][] = [
+  ['Info', 'CXP'],
+  ['Chart', 'CXPC'],
+  ['Orders', 'CXOB'],
+  ['Trade', 'CXPO'],
+  ['CXM', 'CXM'],
+];
+</script>
+
+<template>
+  <div id="market_contextmenu" :class="$style.contextMenu" :style="store.menuStyle">
+    <div v-if="store.materialID">
+      <div>
+        <div :class="[C.Frame.toggle, $style.exchangeHover]">
+          <span
+            :class="[
+              C.Frame.toggleLabel,
+              C.type.typeRegular,
+              C.fonts.fontRegular,
+              $style.exchangeSelect,
+            ]"
+            >{{ userData.settings.contextMenuExchange }}</span
+          >
+          <span
+            :class="[
+              C.Frame.toggleLabel,
+              C.type.typeRegular,
+              C.fonts.fontRegular,
+              $style.exchangeIcon,
+            ]"
+            >🞂</span
+          >
+          <div :class="[$style.exchangeList, $style.contextMenu]">
+            <PrunButton
+              v-for="exchange in exchanges"
+              :key="exchange"
+              :dark="userData.settings.contextMenuExchange !== exchange"
+              :primary="userData.settings.contextMenuExchange === exchange"
+              :class="$style.prunButton"
+              @click="userData.settings.contextMenuExchange = exchange">
+              {{ exchange }}
+            </PrunButton>
+          </div>
+        </div>
+      </div>
+      <div>
+        <PrunButton
+          v-for="cmd in buttons"
+          :key="cmd[1]"
+          :dark="true"
+          :class="$style.prunButton"
+          @click="store.showBuffer(cmd[1])">
+          {{ cmd[0] }}
+        </PrunButton>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style module>
+.exchangeHover:hover {
+  .exchangeList {
+    display: block;
+  }
+
+  > span {
+    color: #ddd;
+  }
+}
+
+.exchangeHover {
+  border-bottom: 1px solid rgb(196, 132, 0);
+  margin-bottom: 0;
+}
+
+.exchangeList {
+  position: absolute;
+  display: none;
+  top: 0%;
+  left: 100%;
+}
+
+.exchangeSelect {
+  width: 3em;
+  text-wrap: nowrap;
+  display: flex;
+  justify-content: center;
+}
+
+.exchangeIcon {
+  padding-left: 0;
+}
+
+.market_contextmenu_divider {
+  border-bottom: 2px solid currentColor;
+}
+
+.prunButton {
+  display: block;
+  margin-left: 0 !important;
+  font-size: 10px;
+  line-height: 11px;
+  text-transform: none;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 6px;
+  padding-right: 6px;
+  width: 100%;
+}
+
+.contextMenu {
+  background: rgb(38, 38, 38);
+  border: 2px solid rgb(196, 132, 0);
+  border-radius: 4px;
+  color: rgb(238, 238, 238);
+  position: absolute;
+  z-index: 99998;
+}
+</style>

--- a/src/features/advanced/market-contextmenu/MarketMenu.vue
+++ b/src/features/advanced/market-contextmenu/MarketMenu.vue
@@ -17,6 +17,16 @@ const buttons: [string, string][] = [
   <div id="market_contextmenu" :class="$style.contextMenu" :style="store.menuStyle">
     <div v-if="store.materialID">
       <div>
+        <PrunButton
+          v-for="cmd in buttons"
+          :key="cmd[1]"
+          :dark="true"
+          :class="$style.prunButton"
+          @click="store.showBuffer(cmd[1])">
+          {{ cmd[0] }}
+        </PrunButton>
+      </div>
+      <div>
         <div :class="[C.Frame.toggle, $style.exchangeHover]">
           <span
             :class="[
@@ -49,16 +59,6 @@ const buttons: [string, string][] = [
           </div>
         </div>
       </div>
-      <div>
-        <PrunButton
-          v-for="cmd in buttons"
-          :key="cmd[1]"
-          :dark="true"
-          :class="$style.prunButton"
-          @click="store.showBuffer(cmd[1])">
-          {{ cmd[0] }}
-        </PrunButton>
-      </div>
     </div>
   </div>
 </template>
@@ -75,8 +75,13 @@ const buttons: [string, string][] = [
 }
 
 .exchangeHover {
-  border-bottom: 1px solid rgb(196, 132, 0);
+  border-top: 1px solid rgb(196, 132, 0);
   margin-bottom: 0;
+}
+
+.exchangeHover span {
+  font-size: 10px;
+  line-height: 11px;
 }
 
 .exchangeList {

--- a/src/features/advanced/market-contextmenu/market-contextmenu.ts
+++ b/src/features/advanced/market-contextmenu/market-contextmenu.ts
@@ -1,0 +1,82 @@
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { userData } from '@src/store/user-data';
+import { refTextContent } from '@src/utils/reactive-dom';
+import { ComponentPublicInstance, reactive } from 'vue';
+import MarketMenu from './MarketMenu.vue';
+
+export const store = reactive({
+  materialID: '',
+  menuElement: {} as HTMLElement,
+  menuStyle: {
+    display: 'none',
+    left: '0px',
+    top: '0px',
+  },
+  async showMenu(event: MouseEvent, ticker: string) {
+    this.materialID = ticker;
+    this.menuStyle.display = 'block';
+    await nextTick();
+    store.setLocation(event);
+  },
+  hideMenu() {
+    this.menuStyle.display = 'none';
+  },
+  showBuffer(cmd: string) {
+    this.hideMenu();
+    if (cmd === 'CXM') {
+      return showBuffer(`CXM ${this.materialID}`);
+    } else if (['CXP', 'CXPC', 'CXPO', 'CXOB'].includes(cmd)) {
+      return showBuffer(`${cmd} ${this.materialID}.${userData.settings.contextMenuExchange}`);
+    }
+    return;
+  },
+  setMenuElement(componentInstance: ComponentPublicInstance) {
+    this.menuElement = componentInstance.$el as HTMLElement;
+  },
+  setLocation(event: MouseEvent) {
+    const documentRect = this.menuElement.parentElement!.getBoundingClientRect();
+    const tooltipRect = this.menuElement.getBoundingClientRect();
+    if (event.clientX + tooltipRect.width > documentRect.right) {
+      this.menuStyle.left = (documentRect.right - tooltipRect.width).toString() + 'px';
+    } else {
+      this.menuStyle.left = event.clientX.toString() + 'px';
+    }
+    if (event.clientY + tooltipRect.height > documentRect.bottom) {
+      this.menuStyle.top = (event.clientY - tooltipRect.height).toString() + 'px';
+    } else {
+      this.menuStyle.top = event.clientY.toString() + 'px';
+    }
+  },
+  checkClickedMenu(event: MouseEvent): void {
+    const target = event.target as Node;
+    if (target && !this.menuElement.contains(target)) {
+      this.hideMenu();
+    }
+  },
+});
+
+async function init() {
+  const container = document.getElementById('container');
+  if (container?.parentElement) {
+    store.setMenuElement(createFragmentApp(MarketMenu).appendTo(container));
+    container.addEventListener('click', event => store.checkClickedMenu(event));
+  }
+  document.addEventListener('contextmenu', event => {
+    const container = (event.target as HTMLElement).closest(
+      `.${C.ColoredIcon.container}`,
+    ) as HTMLElement;
+    if (container) {
+      event.preventDefault();
+      const ticker = refTextContent(container);
+      store.showMenu(event, ticker.value!);
+      return;
+    }
+    store.hideMenu();
+  });
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'Right click any material to quickly see material market buttons.',
+);

--- a/src/features/advanced/market-contextmenu/market-contextmenu.ts
+++ b/src/features/advanced/market-contextmenu/market-contextmenu.ts
@@ -49,7 +49,7 @@ export const store = reactive({
   },
   checkClickedMenu(event: MouseEvent): void {
     const target = event.target as Node;
-    if (target && !this.menuElement.contains(target)) {
+    if (!this.menuElement.contains(target)) {
       this.hideMenu();
     }
   },
@@ -62,10 +62,10 @@ async function init() {
     container.addEventListener('click', event => store.checkClickedMenu(event));
   }
   document.addEventListener('contextmenu', event => {
-    const container = (event.target as HTMLElement).closest(
+    const container = (event.target as HTMLElement).closest<HTMLElement>(
       `.${C.ColoredIcon.container}`,
-    ) as HTMLElement;
-    if (container) {
+    );
+    if (container !== null) {
       event.preventDefault();
       const ticker = refTextContent(container);
       store.showMenu(event, ticker.value!);

--- a/src/store/user-data-migrations.ts
+++ b/src/store/user-data-migrations.ts
@@ -7,6 +7,12 @@ type Migration = [id: string, migration: (userData: any) => void];
 // New migrations should be added to the top of the list.
 const migrations: Migration[] = [
   [
+    '09.03.2026 Add contextMenuExchange setting',
+    userData => {
+      userData.settings.contextMenuExchange = 'AI1' as UserData.Exchange;
+    },
+  ],
+  [
     '24.01.2026 Remove cxpc-default-1y',
     userData => {
       removeFeature(userData, 'cxpc-default-1y');

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -51,6 +51,7 @@ export const initialUserData = deepFreeze({
       ['HELP', 'XIT HELP'],
     ] as [string, string][],
     buffers: [] as [string, number, number][],
+    contextMenuExchange: 'AI1' as UserData.Exchange,
     audioVolume: 0.4,
   },
   sorting: {} as Record<string, UserData.StoreSortingData>,

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -7,6 +7,8 @@ declare namespace UserData {
 
   type PricingMethod = 'ASK' | 'BID' | 'AVG' | 'VWAP7D' | 'VWAP30D' | 'DEFAULT' | string;
 
+  export type Exchange = 'AI1' | 'CI1' | 'CI2' | 'IC1' | 'NC1' | 'NC2';
+
   interface StoreSortingData {
     modes: SortingMode[];
     active?: string;


### PR DESCRIPTION
## Summary
- Adds a right-click context menu on material/commodity icons that lets users quickly open CX buffers (Info, Chart, Orders, Trade, CXM) for the selected material
- Adds a `contextMenuExchange` user setting (default: AI1) to select which exchange is used, with a dropdown selector in the menu
- Exchange selector is positioned at the bottom of the menu (rarely changed) with font size matching the action buttons

## Test plan
- [ ] Right-click a material icon in-game — custom context menu should appear
- [ ] Click Info, Chart, Orders, Trade, CXM buttons — correct buffers should open using the selected exchange
- [ ] Hover the exchange selector at the bottom — dropdown should appear with all 6 exchange options
- [ ] Change exchange and confirm subsequent buffer commands use the new exchange
- [ ] Right-click outside a material icon — default browser context menu should appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)