### PR TITLE
Fix INP regression from market context menu click listener

### DIFF
--- a/src/features/advanced/market-contextmenu/market-contextmenu.ts
+++ b/src/features/advanced/market-contextmenu/market-contextmenu.ts
@@ -1,6 +1,5 @@
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { userData } from '@src/store/user-data';
-import { refTextContent } from '@src/utils/reactive-dom';
 import { ComponentPublicInstance, reactive } from 'vue';
 import MarketMenu from './MarketMenu.vue';
 
@@ -48,6 +47,7 @@ export const store = reactive({
     }
   },
   checkClickedMenu(event: MouseEvent): void {
+    if (this.menuStyle.display === 'none') return;
     const target = event.target as Node;
     if (!this.menuElement.contains(target)) {
       this.hideMenu();
@@ -67,8 +67,7 @@ async function init() {
     );
     if (container !== null) {
       event.preventDefault();
-      const ticker = refTextContent(container);
-      store.showMenu(event, ticker.value!);
+      store.showMenu(event, container.textContent ?? '');
       return;
     }
     store.hideMenu();


### PR DESCRIPTION
Two issues caused slow pointer feedback on every click:
- refTextContent() was called on every right-click, leaking a MutationObserver per invocation since they were never disconnected. Replaced with a direct container.textContent read.
- checkClickedMenu fired a Vue reactive update (hideMenu) on every single click even when the menu was already hidden. Added an early return guard when display is already 'none'.