### PR TITLE
Fix FLT buffer crash when sending a ship

### DIFF
--- a/src/features/advanced/flt-flight-status-detailed/FleetStatusCell.vue
+++ b/src/features/advanced/flt-flight-status-detailed/FleetStatusCell.vue
@@ -46,7 +46,7 @@ const posData = computed(() => {
   const location = getLocationLineFromAddress(address);
   const prefix = location?.type === 'STATION' ? 'STNS' : 'PLI';
   return {
-    name: getEntityNameFromAddress(address) || address?.lines[0]?.entity.naturalId || '',
+    name: getEntityNameFromAddress(address) || address?.lines[0]?.entity?.naturalId || '',
     command: `${prefix} ${location?.entity.naturalId}`,
     invCommand: `INV ${location?.entity.naturalId}`,
   };
@@ -77,7 +77,7 @@ const handleUnloadAction = () => {
 </script>
 
 <template>
-  <div :class="$style.mainContainer">
+  <div :class="$style.mainContainer" data-rp>
     <div :class="[$style.columnContainer, $style.alignLeft]">
       <div :class="$style.gapContainer">
         <span

--- a/src/features/advanced/flt-flight-status-detailed/flt-flight-status-detailed.ts
+++ b/src/features/advanced/flt-flight-status-detailed/flt-flight-status-detailed.ts
@@ -15,7 +15,11 @@ function onRowReady(row: HTMLTableRowElement) {
 
   statusCell.style.display = 'table-cell';
   statusCell.classList.remove(C.Link.link);
-  statusCell.replaceChildren();
+  for (const child of Array.from(statusCell.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      child.textContent = '';
+    }
+  }
 
   createFragmentApp(FleetStatusCell, {
     shipId: id.value,
@@ -42,6 +46,9 @@ function onRowReady(row: HTMLTableRowElement) {
 function init() {
   const selectors = ['FLT', 'FLTS', 'FLTP'];
   tiles.observe(selectors, onTileReady);
+
+  // Hide game-managed content inside the status cell, keeping our Vue wrapper visible
+  applyCssRule(selectors, 'tr > :nth-child(4) > :not([data-rp])', css.hidden);
 
   // Hide unnecessary original columns to make room for our custom cell
   applyCssRule(selectors, 'tr > :nth-child(1)', css.hidden); // Transponder

--- a/src/features/basic/flt-cargo-breakdown/CargoBar.vue
+++ b/src/features/basic/flt-cargo-breakdown/CargoBar.vue
@@ -121,7 +121,7 @@ function enhanceSegmentVisibility(segments: Segment[], loadRatio: number) {
     }
   }
 
-  if (!isAlmostFull) {
+  if (!isAlmostFull && segments.length > 0) {
     const last = segments[segments.length - 1];
     last.borderClasses ??= [];
     last.borderClasses.push($style.borderRight);


### PR DESCRIPTION
## Summary
- Fix TypeError crash from accessing `entity.naturalId` without optional chaining on address lines where `entity` is now optional (after parent repo type refactor)
- Fix `NotFoundError: removeChild` crash by replacing `replaceChildren()` with a CSS-based approach that hides game-managed DOM content while preserving React's ability to update its own nodes
- Guard against empty segments array crash in CargoBar's `enhanceSegmentVisibility`

## Test plan
- [ ] Open FLT buffer and verify rows display correctly (no extra "⦁" or height issues)
- [ ] Send a ship while FLT buffer is open — buffer should not crash
- [ ] Verify status cell updates correctly (destination, ETA, status icon) after sending
- [ ] Check FLTS and FLTP buffer variants also work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)