### PR TITLE
Approach C: independent floating buffers

### DIFF
--- a/docs/linkedbuffers-approaches.md
+++ b/docs/linkedbuffers-approaches.md
@@ -69,21 +69,45 @@ Inspired by `cxpo-order-book`, the control panel is a floating overlay appended 
 
 ---
 
-## Recommended Next Steps
+## Approach 3: Independent Floating Buffers (CURRENT - branch `xit-linkedbuffers-approach-c`)
 
-1. **Revert to Approach 1** (split tile)
-2. **Improve the left panel appearance** within the split tile approach:
-   - Hide the tile frame header (`C.TileFrame.header`) via CSS or DOM manipulation after re-mount
-   - This removes the title bar and control buttons, making it look more like a frameless sidebar
-   - The content (input + commands) would be all that's visible
-3. **Alternative**: Instead of hiding the frame, observe the XIT tile after re-mount and apply CSS to make the header ultra-compact (single-line, no padding)
+The control panel is a small floating CMDL-like buffer. Each child command gets its own independent floating window, positioned in a grid next to the control panel.
+
+### How it works
+1. `XIT LB <preset>` opens as a compact floating buffer (220x400)
+2. On mount, if floating and preset has commands, spawns independent child windows via `showBuffer()` sequentially
+3. After all children are created, positions them in a grid to the right of the control panel using direct DOM `style.left`/`style.top` manipulation
+4. Each child window is sized via `setBufferSize()` (400x300)
+5. Clicking a command in the control panel resolves the `{input}` template and updates the corresponding child window via `UI_TILES_CHANGE_COMMAND`
+6. Closing the control panel automatically closes all child windows
+
+### Pros
+- Full control over individual child window size and position
+- No frame overhead on the control panel (it's its own buffer, naturally compact)
+- No split ratio issues — each buffer is independently sized
+- Children can be freely rearranged by the user after initial layout
+- Simpler component lifecycle — no split/remount dance
+
+### Cons
+- Child windows are created sequentially (showBuffer mutex), so initial spawn takes 1-2 seconds for 4-6 commands
+- Game may reposition windows on certain events (needs testing)
+- More floating windows = more dock bar entries
+
+### Key insight
+Floating windows in PrUn use inline `style="left: Xpx; top: Ypx"` for positioning (confirmed via `PmmgMigrationGuide.vue`). This means we can reposition windows after creation by setting `window.style.left`/`style.top` directly.
+
+### Key commit
+```
+(current HEAD on xit-linkedbuffers-approach-c)
+```
+
+---
 
 ## File Structure
 ```
 src/features/XIT/LINKEDBUFFERS/
 ├── LINKEDBUFFERS.ts          # XIT registration (command: LINKEDBUFFERS/LB)
 ├── LINKEDBUFFERS.vue         # Main component
-├── ControlPanel.vue          # Overlay panel (Approach 2, can be deleted if reverting)
 ├── PresetList.vue            # Preset list view (XIT LB with no params)
 └── CreatePresetOverlay.vue   # Create preset dialog
 ```
@@ -95,7 +119,6 @@ interface LinkedBuffersPreset {
   id: string;
   name: string;
   commands: LinkedBuffersCommand[];
-  lastBufferSize?: [number, number];  // saved window dimensions
 }
 
 interface LinkedBuffersCommand {
@@ -106,7 +129,9 @@ interface LinkedBuffersCommand {
 ```
 
 ## Key Patterns Used
-- **ACT tile-allocator**: `splitBuffer()` pattern for initial split, `getCompanionTile()` for finding sibling, `changeTileCommand()` for updating child tiles
+- **showBuffer()**: Creates independent floating windows programmatically
+- **setBufferSize()**: Controls child window dimensions via `UI_WINDOWS_UPDATE_SIZE`
+- **DOM positioning**: `window.style.left`/`style.top` for grid layout
+- **changeTileCommand()**: Updates child tile commands via `UI_TILES_CHANGE_COMMAND`
+- **onNodeDisconnected()**: Tracks child window lifecycle for cleanup
 - **CMDL**: Command list UI with edit mode, drag-to-reorder, add/delete
-- **Tile controls**: `|` = horizontal split, `–` (en-dash U+2013) = vertical split, `:` = change command, `x` = close
-- **Buffer sizing**: `setBufferSize(id, w, h)` via `UI_WINDOWS_UPDATE_SIZE` client message

--- a/src/features/XIT/LINKEDBUFFERS/EditPreset.vue
+++ b/src/features/XIT/LINKEDBUFFERS/EditPreset.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import Header from '@src/components/Header.vue';
+import ActionBar from '@src/components/ActionBar.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { userData } from '@src/store/user-data';
+import { createId } from '@src/store/create-id';
+import { isEmpty } from 'ts-extras';
+import { vDraggable } from 'vue-draggable-plus';
+import { grip } from '@src/components/grip';
+import GripCell from '@src/components/grip/GripCell.vue';
+import GripHeaderCell from '@src/components/grip/GripHeaderCell.vue';
+
+const rawParameters = useXitParameters();
+// Parameters arrive as ["EDIT", "<presetId>", ...] — skip the "EDIT" prefix.
+const parameters = rawParameters.slice(1);
+
+const preset = computed(() => {
+  if (isEmpty(parameters)) {
+    return undefined;
+  }
+  const byId = userData.linkedBuffersPresets.find(x => x.id.startsWith(parameters[0]));
+  if (byId) {
+    return byId;
+  }
+  const name = parameters.join(' ');
+  return userData.linkedBuffersPresets.find(x => x.name === name);
+});
+
+function addCommand() {
+  if (!preset.value) {
+    return;
+  }
+  preset.value.commands.push({
+    id: createId(),
+    label: 'CMD',
+    template: 'CMD {input}',
+  });
+}
+
+function deleteCommand(cmd: UserData.LinkedBuffersCommand) {
+  if (!preset.value) {
+    return;
+  }
+  preset.value.commands = preset.value.commands.filter(x => x !== cmd);
+}
+</script>
+
+<template>
+  <div v-if="!preset" :class="$style.center">
+    <span>Preset not found.</span>
+  </div>
+  <div v-else :class="$style.root">
+    <Header>Edit: {{ preset.name }}</Header>
+    <table>
+      <thead>
+        <tr>
+          <GripHeaderCell />
+          <th>Label</th>
+          <th>Template</th>
+          <th />
+        </tr>
+      </thead>
+      <template v-if="preset.commands.length === 0">
+        <tbody>
+          <tr>
+            <td colspan="4">No commands.</td>
+          </tr>
+        </tbody>
+      </template>
+      <template v-else>
+        <tbody v-draggable="[preset.commands, grip.draggable]">
+          <tr v-for="cmd in preset.commands" :key="cmd.id">
+            <GripCell />
+            <td>
+              <input
+                v-model="cmd.label"
+                type="text"
+                :class="[$style.gameInput, $style.labelInput]"
+                autocomplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true" />
+            </td>
+            <td>
+              <input
+                v-model="cmd.template"
+                type="text"
+                :class="[$style.gameInput, $style.templateInput]"
+                autocomplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true" />
+            </td>
+            <td>
+              <PrunButton danger @click="deleteCommand(cmd)">DELETE</PrunButton>
+            </td>
+          </tr>
+        </tbody>
+      </template>
+    </table>
+    <ActionBar>
+      <PrunButton primary @click="addCommand">ADD COMMAND</PrunButton>
+    </ActionBar>
+    <div :class="$style.hint">Close and reopen the LB control panel to apply layout changes.</div>
+  </div>
+</template>
+
+<style module>
+.root {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+}
+
+.center {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gameInput {
+  box-sizing: border-box;
+  padding: 3px 6px;
+  background: #222e31;
+  border: 1px solid #5a8a4a;
+  color: #bfbfbf;
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+  outline: none;
+
+  &:focus {
+    border-color: #8cc63f;
+  }
+}
+
+.labelInput {
+  width: 10ch;
+}
+
+.templateInput {
+  width: 20ch;
+}
+
+.hint {
+  padding: 4px;
+  opacity: 0.5;
+  font-size: 0.9em;
+}
+</style>

--- a/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.ts
+++ b/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.ts
@@ -1,6 +1,19 @@
 import LINKEDBUFFERS from '@src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue';
+import EditPreset from '@src/features/XIT/LINKEDBUFFERS/EditPreset.vue';
 import { userData } from '@src/store/user-data';
 import { isEmpty } from 'ts-extras';
+
+function findPreset(parameters: string[]) {
+  const byId = userData.linkedBuffersPresets.find(x => x.id.startsWith(parameters[0]));
+  if (byId) {
+    return byId;
+  }
+  return userData.linkedBuffersPresets.find(x => x.name === parameters.join(' '));
+}
+
+function isEditMode(parameters: string[]) {
+  return parameters[0]?.toUpperCase() === 'EDIT';
+}
 
 xit.add({
   command: ['LINKEDBUFFERS', 'LB'],
@@ -8,13 +21,20 @@ xit.add({
     if (isEmpty(parameters)) {
       return 'LINKED BUFFERS';
     }
-    const preset =
-      userData.linkedBuffersPresets.find(x => x.id.startsWith(parameters[0])) ??
-      userData.linkedBuffersPresets.find(x => x.name === parameters.join(' '));
+    if (isEditMode(parameters)) {
+      const preset = findPreset(parameters.slice(1));
+      return preset ? `LB EDIT: ${preset.name}` : 'LB EDIT';
+    }
+    const preset = findPreset(parameters);
     return preset ? `LB: ${preset.name}` : 'LINKED BUFFERS';
   },
   description: 'Opens a dashboard with linked child buffers driven by a text input.',
   optionalParameters: 'Preset Name',
-  component: () => LINKEDBUFFERS,
-  bufferSize: [900, 500],
+  component: parameters => {
+    if (isEditMode(parameters)) {
+      return EditPreset;
+    }
+    return LINKEDBUFFERS;
+  },
+  bufferSize: [205, 400],
 });

--- a/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue
+++ b/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import TextInput from '@src/components/forms/TextInput.vue';
 import Header from '@src/components/Header.vue';
 import ActionBar from '@src/components/ActionBar.vue';
 import PrunButton from '@src/components/PrunButton.vue';
@@ -9,16 +8,16 @@ import { useTile } from '@src/hooks/use-tile';
 import { userData } from '@src/store/user-data';
 import { createId } from '@src/store/create-id';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
-import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
-import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { showBuffer, setBufferSize } from '@src/infrastructure/prun-ui/buffers';
+import {
+  UI_TILES_CHANGE_COMMAND,
+  UI_WINDOWS_REQUEST_FOCUS,
+} from '@src/infrastructure/prun-api/client-messages';
 import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
-import { clickElement, changeInputValue } from '@src/util';
+import { changeInputValue } from '@src/util';
 import { sleep } from '@src/utils/sleep';
 import { isEmpty } from 'ts-extras';
-import { vDraggable } from 'vue-draggable-plus';
-import { grip } from '@src/components/grip';
-import GripCell from '@src/components/grip/GripCell.vue';
-import GripHeaderCell from '@src/components/grip/GripHeaderCell.vue';
+import onNodeDisconnected from '@src/utils/on-node-disconnected';
 
 const tile = useTile();
 const parameters = useXitParameters();
@@ -37,148 +36,189 @@ const preset = computed(() => {
 
 const inputText = ref('');
 const isProcessing = ref(false);
-const edit = ref(false);
-const childTiles = ref<HTMLElement[]>([]);
-const gridReady = ref(false);
+const spawning = ref(false);
 
-// Split immediately if this is a solo buffer.
-const isSoloBuffer = tile.container.classList.contains(C.Window.body);
-const goingToSplit = ref(false);
-
-if (isSoloBuffer && preset.value && preset.value.commands.length > 0) {
-  goingToSplit.value = true;
-  const saved = preset.value.lastBufferSize;
-  if (saved) {
-    setBufferSize(tile.id, saved[0], saved[1]);
-  } else {
-    const width = parseInt(tile.container.style.width.replace('px', ''), 10);
-    const height = parseInt(tile.container.style.height.replace('px', ''), 10);
-    setBufferSize(tile.id, width + 500, height);
-  }
-  const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
-  void clickElement(splitButton);
+interface ChildWindow {
+  window: HTMLDivElement;
+  commandIndex: number;
+  commandId: string;
 }
+const childWindows = ref<ChildWindow[]>([]);
 
-// After re-mount (post-split), build the grid.
+const isFloating = tile.container.classList.contains(C.Window.body);
+
+const DEFAULT_CHILD_WIDTH = 400;
+const DEFAULT_CHILD_HEIGHT = 300;
+const H_GAP = 15;
+const V_GAP = 35;
+
 onMounted(async () => {
-  if (goingToSplit.value || !preset.value) {
+  if (!isFloating || !preset.value) {
     return;
   }
 
-  const rightSibling = getRightSibling();
-  if (!rightSibling) {
-    gridReady.value = true;
-    return;
+  // Position control panel near top-left.
+  const controlWindow = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+  if (controlWindow) {
+    const saved = preset.value.controlPosition;
+    if (saved) {
+      controlWindow.style.left = `${saved[0]}px`;
+      controlWindow.style.top = `${saved[1]}px`;
+    } else {
+      controlWindow.style.left = '30px';
+      controlWindow.style.top = '50px';
+    }
   }
 
-  const commandCount = preset.value.commands.length;
-  if (commandCount > 1) {
-    await buildGrid(rightSibling, commandCount);
+  if (preset.value.commands.length > 0) {
+    await spawnChildWindows();
   }
-
-  childTiles.value = _$$(rightSibling, C.Tile.tile) as HTMLElement[];
-  gridReady.value = true;
 });
 
-// Save window size when the component unmounts (captures user's resize).
 onBeforeUnmount(() => {
-  saveBufferSize();
+  closeAllChildren();
 });
 
-function getWindowElement(): HTMLElement | null {
-  return tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+function getSavedLayout(commandId: string): UserData.LinkedBuffersChildLayout | undefined {
+  return preset.value?.childLayouts?.find(l => l.commandId === commandId);
 }
 
-function saveBufferSize() {
-  if (!preset.value) {
+function getChildSize(commandId: string): [number, number] {
+  const saved = getSavedLayout(commandId);
+  if (saved) {
+    return [saved.width, saved.height];
+  }
+  return [DEFAULT_CHILD_WIDTH, DEFAULT_CHILD_HEIGHT];
+}
+
+async function spawnChildWindows() {
+  spawning.value = true;
+  const commands = preset.value!.commands;
+  const created: ChildWindow[] = [];
+
+  for (let i = 0; i < commands.length; i++) {
+    const window = await showBuffer(' ', { force: true, autoSubmit: false });
+    const input = _$(window, C.PanelSelector.input) as HTMLInputElement | undefined;
+    if (input) {
+      changeInputValue(input, '');
+    }
+    const child: ChildWindow = {
+      window: window as HTMLDivElement,
+      commandIndex: i,
+      commandId: commands[i].id,
+    };
+    created.push(child);
+
+    onNodeDisconnected(window, () => {
+      childWindows.value = childWindows.value.filter(c => c !== child);
+    });
+  }
+
+  childWindows.value = created;
+  layoutChildren();
+
+  // Size each child window.
+  for (const child of created) {
+    const tileEl = _$(child.window, C.Tile.tile);
+    if (tileEl) {
+      const id = getPrunId(tileEl);
+      if (id) {
+        const [w, h] = getChildSize(child.commandId);
+        setBufferSize(id, w, h);
+      }
+    }
+  }
+
+  dispatchClientPrunMessage(UI_WINDOWS_REQUEST_FOCUS(tile.id));
+  spawning.value = false;
+}
+
+function layoutChildren() {
+  const controlWindow = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+  if (!controlWindow) {
     return;
   }
-  const win = getWindowElement();
-  if (!win) {
-    return;
-  }
-  const width = win.offsetWidth;
-  const height = win.offsetHeight;
-  if (width > 0 && height > 0) {
-    preset.value.lastBufferSize = [width, height];
+  const rect = controlWindow.getBoundingClientRect();
+  const count = childWindows.value.length;
+  const hasSavedLayouts = preset.value?.childLayouts && preset.value.childLayouts.length > 0;
+
+  for (let i = 0; i < count; i++) {
+    const child = childWindows.value[i];
+    const saved = getSavedLayout(child.commandId);
+    const win = child.window;
+
+    if (hasSavedLayouts && saved) {
+      // Use saved position.
+      win.style.left = `${saved.left}px`;
+      win.style.top = `${saved.top}px`;
+    } else {
+      // Default grid layout: 2 columns when 3+ commands.
+      const cols = count <= 2 ? count : 2;
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const [w, h] = getChildSize(child.commandId);
+      const left = rect.right + H_GAP + col * (w + H_GAP);
+      const top = rect.top + row * (h + V_GAP);
+      win.style.left = `${left}px`;
+      win.style.top = `${top}px`;
+    }
   }
 }
 
-function getRightSibling(): HTMLElement | undefined {
-  const isInNodeChild = tile.container.classList.contains(C.Node.child);
-  const isInNode = tile.container.parentElement?.classList.contains(C.Node.node);
-  const isInWindow = tile.container.parentElement?.parentElement?.classList.contains(C.Window.body);
-  if (!isInNodeChild || !isInNode || !isInWindow) {
-    return undefined;
+function closeAllChildren() {
+  for (const child of childWindows.value) {
+    if (child.window.isConnected) {
+      const closeButton = _$$(child.window, C.Window.button).find(x => x.textContent === 'x');
+      closeButton?.click();
+    }
   }
-
-  const node = tile.container.parentElement!;
-  return _$$(node, C.Node.child).find(x => x !== tile.container) as HTMLElement | undefined;
-}
-
-async function splitTileElement(tileEl: HTMLElement, direction: '|' | '\u2013') {
-  const button = _$$(tileEl, C.TileControls.control).find(x => x.textContent === direction);
-  if (!button) {
-    return;
-  }
-  await clickElement(button);
-  await sleep(200);
-}
-
-async function buildGrid(container: HTMLElement, count: number) {
-  if (count <= 1) {
-    return;
-  }
-
-  const rows = Math.ceil(count / 2);
-
-  // Create rows by splitting the last tile vertically.
-  for (let i = 1; i < rows; i++) {
-    const tiles = _$$(container, C.Tile.tile) as HTMLElement[];
-    const lastTile = tiles[tiles.length - 1];
-    // En-dash for vertical split.
-    await splitTileElement(lastTile, '\u2013');
-  }
-
-  if (count <= rows) {
-    return;
-  }
-
-  // Split rows that need 2 columns, from the last row upward.
-  const currentTiles = _$$(container, C.Tile.tile) as HTMLElement[];
-  let splitsNeeded = count - rows;
-  for (let i = currentTiles.length - 1; i >= 0 && splitsNeeded > 0; i--) {
-    await splitTileElement(currentTiles[i], '|');
-    splitsNeeded--;
-  }
+  childWindows.value = [];
 }
 
 function resolveCommand(template: string) {
   return template.replace(/\{input\}/g, inputText.value.trim()).toUpperCase();
 }
 
-async function changeTileCommand(tileEl: HTMLElement, command: string) {
+async function changeTileCommand(windowEl: HTMLDivElement, command: string, commandId: string) {
+  const tileEl = _$(windowEl, C.Tile.tile) as HTMLElement | undefined;
+  if (!tileEl) {
+    return;
+  }
   const id = getPrunId(tileEl)!;
-  // Clear current command.
+  const [w, h] = getChildSize(commandId);
+
+  const existingInput = _$(windowEl, C.PanelSelector.input) as HTMLInputElement | undefined;
+  if (existingInput?.form?.isConnected) {
+    changeInputValue(existingInput, command);
+    existingInput.form.requestSubmit();
+    await sleep(200);
+    setBufferSize(id, w, h);
+    return;
+  }
+
   let message = UI_TILES_CHANGE_COMMAND(id, null);
   if (!dispatchClientPrunMessage(message)) {
     const changeButton = _$$(tileEl, C.TileControls.control).find(x => x.textContent === ':');
-    await clickElement(changeButton);
+    if (changeButton) {
+      changeButton.click();
+    }
   } else {
     await sleep(0);
   }
-  // Set new command.
   message = UI_TILES_CHANGE_COMMAND(id, command);
   if (!dispatchClientPrunMessage(message)) {
-    const input = (await $(tileEl, C.PanelSelector.input)) as HTMLInputElement;
+    const input = (await $(windowEl, C.PanelSelector.input)) as HTMLInputElement;
     changeInputValue(input, command);
     input.form!.requestSubmit();
   }
-  await $(tileEl, C.TileFrame.frame);
+  await sleep(200);
+  const newTileEl = _$(windowEl, C.Tile.tile) as HTMLElement | undefined;
+  const newId = newTileEl ? getPrunId(newTileEl) : id;
+  setBufferSize(newId ?? id, w, h);
 }
 
 async function onCommandClick(cmd: UserData.LinkedBuffersCommand, index: number) {
-  if (!inputText.value.trim() || isProcessing.value || edit.value) {
+  if (!inputText.value.trim() || isProcessing.value) {
     return;
   }
 
@@ -186,31 +226,57 @@ async function onCommandClick(cmd: UserData.LinkedBuffersCommand, index: number)
   isProcessing.value = true;
 
   try {
-    const child = childTiles.value[index];
-    if (child?.isConnected) {
-      await changeTileCommand(child, resolved);
+    const child = childWindows.value.find(c => c.commandIndex === index);
+    if (child?.window.isConnected) {
+      await changeTileCommand(child.window, resolved, child.commandId);
     }
   } finally {
     isProcessing.value = false;
   }
 }
 
-function addCommand() {
+function saveLayout() {
   if (!preset.value) {
     return;
   }
-  preset.value.commands.push({
-    id: createId(),
-    label: 'CMD',
-    template: 'CMD {input}',
-  });
+
+  // Save control panel position.
+  const controlWindow = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+  if (controlWindow) {
+    const rect = controlWindow.getBoundingClientRect();
+    preset.value.controlPosition = [Math.round(rect.left), Math.round(rect.top)];
+  }
+
+  // Save child window positions and sizes.
+  const layouts: UserData.LinkedBuffersChildLayout[] = [];
+  for (const child of childWindows.value) {
+    if (!child.window.isConnected) {
+      continue;
+    }
+    const rect = child.window.getBoundingClientRect();
+    layouts.push({
+      commandId: child.commandId,
+      left: Math.round(rect.left),
+      top: Math.round(rect.top),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    });
+  }
+  preset.value.childLayouts = layouts;
 }
 
-function deleteCommand(cmd: UserData.LinkedBuffersCommand) {
+async function openEditor() {
   if (!preset.value) {
     return;
   }
-  preset.value.commands = preset.value.commands.filter(x => x !== cmd);
+  const window = await showBuffer(`XIT LB EDIT ${preset.value.id.substring(0, 8)}`);
+  const tileEl = _$(window, C.Tile.tile);
+  if (tileEl) {
+    const id = getPrunId(tileEl);
+    if (id) {
+      setBufferSize(id, 500, 400);
+    }
+  }
 }
 
 function onCreateClick() {
@@ -227,8 +293,7 @@ function onCreateClick() {
 </script>
 
 <template>
-  <div v-if="goingToSplit" />
-  <PresetList v-else-if="isEmpty(parameters)" />
+  <PresetList v-if="isEmpty(parameters)" />
   <div v-else-if="!preset" :class="$style.create">
     <span>Preset "{{ parameters.join(' ') }}" not found.</span>
     <PrunButton primary :class="$style.createButton" @click="onCreateClick">CREATE</PrunButton>
@@ -240,85 +305,40 @@ function onCreateClick() {
       <input
         v-model="inputText"
         type="text"
-        :class="$style.input"
+        :class="$style.gameInput"
         autocomplete="off"
         data-1p-ignore="true"
         data-lpignore="true" />
     </div>
-    <div v-if="!gridReady" :class="$style.status">Setting up grid...</div>
-    <template v-if="!edit">
-      <table>
-        <thead>
-          <tr>
-            <th>Commands</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-if="preset.commands.length === 0">
-            <td>No commands. Click EDIT to add some.</td>
-          </tr>
-          <template v-else>
-            <tr
-              v-for="(cmd, index) in preset.commands"
-              :key="cmd.id"
-              @click="onCommandClick(cmd, index)">
-              <td :class="$style.commandCell">
-                <span :class="[C.Link.link, $style.commandLink]">
-                  {{ resolveCommand(cmd.template) || cmd.template }}
-                </span>
-              </td>
-            </tr>
-          </template>
-        </tbody>
-      </table>
-      <ActionBar>
-        <PrunButton primary @click="edit = true">EDIT</PrunButton>
-      </ActionBar>
-    </template>
-    <template v-else>
-      <table>
-        <thead>
-          <tr>
-            <GripHeaderCell />
-            <th>Label</th>
-            <th>Template</th>
-            <th />
-          </tr>
-        </thead>
-        <template v-if="preset.commands.length === 0">
-          <tbody>
-            <tr>
-              <td>No commands.</td>
-            </tr>
-          </tbody>
-        </template>
+    <div v-if="spawning" :class="$style.status">Opening buffers...</div>
+    <table>
+      <thead>
+        <tr>
+          <th>Commands</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-if="preset.commands.length === 0">
+          <td>No commands.</td>
+        </tr>
         <template v-else>
-          <tbody v-draggable="[preset.commands, grip.draggable]">
-            <tr v-for="cmd in preset.commands" :key="cmd.id">
-              <GripCell />
-              <td>
-                <div :class="[C.forms.input, $style.inline]">
-                  <TextInput v-model="cmd.label" />
-                </div>
-              </td>
-              <td>
-                <div :class="C.forms.input">
-                  <TextInput v-model="cmd.template" />
-                </div>
-              </td>
-              <td>
-                <PrunButton danger @click="deleteCommand(cmd)">DELETE</PrunButton>
-              </td>
-            </tr>
-          </tbody>
+          <tr
+            v-for="(cmd, index) in preset.commands"
+            :key="cmd.id"
+            @click="onCommandClick(cmd, index)">
+            <td :class="$style.commandCell">
+              <span :class="[C.Link.link, $style.commandLink]">
+                {{ resolveCommand(cmd.template) || cmd.template }}
+              </span>
+            </td>
+          </tr>
         </template>
-      </table>
-      <ActionBar>
-        <PrunButton primary @click="addCommand">ADD COMMAND</PrunButton>
-        <PrunButton primary @click="edit = false">DONE</PrunButton>
-      </ActionBar>
-      <div :class="$style.hint">Close and reopen buffer to apply layout changes.</div>
-    </template>
+      </tbody>
+    </table>
+    <ActionBar>
+      <PrunButton primary @click="saveLayout">SAVE LAYOUT</PrunButton>
+      <PrunButton primary @click="openEditor">EDIT</PrunButton>
+    </ActionBar>
   </div>
 </template>
 
@@ -344,17 +364,23 @@ function onCreateClick() {
   font-size: 0.9em;
 }
 
-.input {
-  width: 80px;
-  max-width: 80px;
-  text-transform: uppercase;
-  text-align: left;
-  background: #1a1f22;
-  border: 1px solid #2b485a;
+.gameInput {
+  width: 20ch;
+  max-width: 20ch;
+  box-sizing: border-box;
+  padding: 3px 6px;
+  background: #222e31;
+  border: 1px solid #5a8a4a;
   color: #bfbfbf;
-  padding: 2px 4px;
   font-family: inherit;
   font-size: inherit;
+  text-transform: uppercase;
+  text-align: left;
+  outline: none;
+
+  &:focus {
+    border-color: #8cc63f;
+  }
 }
 
 .commandCell {
@@ -383,15 +409,5 @@ function onCreateClick() {
 
 .createButton {
   margin-top: 5px;
-}
-
-.inline {
-  display: inline-block;
-}
-
-.hint {
-  padding: 4px;
-  opacity: 0.5;
-  font-size: 0.9em;
 }
 </style>

--- a/src/features/XIT/LINKEDBUFFERS/PresetList.vue
+++ b/src/features/XIT/LINKEDBUFFERS/PresetList.vue
@@ -3,7 +3,8 @@ import { showTileOverlay, showConfirmationOverlay } from '@src/infrastructure/pr
 import CreatePresetOverlay from './CreatePresetOverlay.vue';
 import PrunButton from '@src/components/PrunButton.vue';
 import ActionBar from '@src/components/ActionBar.vue';
-import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { showBuffer, setBufferSize } from '@src/infrastructure/prun-ui/buffers';
+import { useTile } from '@src/hooks/use-tile';
 import { userData } from '@src/store/user-data';
 import { vDraggable } from 'vue-draggable-plus';
 import { grip } from '@src/components/grip';
@@ -11,6 +12,12 @@ import GripCell from '@src/components/grip/GripCell.vue';
 import GripHeaderCell from '@src/components/grip/GripHeaderCell.vue';
 import PrunLink from '@src/components/PrunLink.vue';
 import { createId } from '@src/store/create-id';
+
+const tile = useTile();
+const isFloating = tile.container.classList.contains(C.Window.body);
+if (isFloating) {
+  setBufferSize(tile.id, 400, 300);
+}
 
 function createNew(ev: Event) {
   showTileOverlay(ev, CreatePresetOverlay, {

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -137,11 +137,21 @@ declare namespace UserData {
     name: string;
     commands: LinkedBuffersCommand[];
     lastBufferSize?: [number, number];
+    controlPosition?: [number, number];
+    childLayouts?: LinkedBuffersChildLayout[];
   }
 
   interface LinkedBuffersCommand {
     id: string;
     label: string;
     template: string;
+  }
+
+  interface LinkedBuffersChildLayout {
+    commandId: string;
+    left: number;
+    top: number;
+    width: number;
+    height: number;
   }
 }


### PR DESCRIPTION
## Summary
- Rework LINKEDBUFFERS from split-tile approach to independent floating windows via `showBuffer()`
- Add `EditPreset.vue` for editing presets in a separate buffer (`XIT LB EDIT <preset>`)
- Save/restore child window positions and sizes (layout persistence)
- Auto-resize preset list when opened as a floating buffer
- Update approaches documentation with Approach C details

## Test plan
- [ ] Open `XIT LB` — preset list should display and auto-resize if floating
- [ ] Create a preset with commands, open it — child windows should spawn in a grid
- [ ] Click commands — child tiles should update with resolved `{input}` template
- [ ] Drag/resize child windows, click SAVE LAYOUT — positions should persist on reopen
- [ ] Click EDIT — opens EditPreset in a new buffer
- [ ] Close control panel — all child windows should close automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)