### PR TITLE
Clarify that multiple CX Buy actions with different exchanges are sup…

### DIFF
--- a/docs-jack/action-package-json-format.md
+++ b/docs-jack/action-package-json-format.md
@@ -127,7 +127,7 @@ Each entry in the `actions` array is an object with a `type` field and type-spec
 
 ### Type: `"CX Buy"`
 
-Buy materials from a commodity exchange.
+Buy materials from a commodity exchange. A single action package can contain multiple `"CX Buy"` actions, each targeting a different exchange — the `exchange` field is per-action, not global.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -252,7 +252,7 @@ Create a buy/sell trade contract draft for a material group. Requires a material
 
 ## Complete Example
 
-A full action package that resupplies a planet by buying from CI1 and shipping:
+A full action package that resupplies a planet by buying consumables from CI1, repair materials from AI1, and shipping everything:
 
 ```json
 {
@@ -290,7 +290,7 @@ A full action package that resupplies a planet by buying from CI1 and shipping:
       "type": "CX Buy",
       "name": "buy-repair-mats",
       "group": "montem-repair",
-      "exchange": "CI1",
+      "exchange": "AI1",
       "buyPartial": true,
       "useCXInv": true
     },


### PR DESCRIPTION
…ported

- Add explicit note under CX Buy section that exchange is per-action
- Update complete example to use CI1 for consumables and AI1 for repair mats

https://claude.ai/code/session_01XQQFs9Lk4o18tAPAk5k2S8

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
