### PR TITLE
MTRA config: filter destination list based on selected origin

### DIFF
--- a/src/features/XIT/ACT/actions/mtra/Configure.vue
+++ b/src/features/XIT/ACT/actions/mtra/Configure.vue
@@ -18,11 +18,10 @@ const allStorages = computed(() => storagesStore.nonFuelStores.value ?? []);
 
 const originStorages = computed(() => {
   let storages = [...allStorages.value];
-  if (data.dest !== configurableValue) {
-    const destination = deserializeStorage(data.dest);
-    if (destination) {
-      storages = storages.filter(x => atSameLocation(x, destination) && x !== destination);
-    }
+  const destRef = data.dest !== configurableValue ? data.dest : config.destination;
+  const destination = deserializeStorage(destRef);
+  if (destination) {
+    storages = storages.filter(x => atSameLocation(x, destination) && x !== destination);
   }
   return storages.sort(storageSort);
 });
@@ -37,13 +36,11 @@ if (data.origin === configurableValue && !config.origin && originStorages.value.
 
 const destinationStorages = computed(() => {
   let storages = [...allStorages.value];
-  if (data.origin !== configurableValue) {
-    const origin = deserializeStorage(data.origin);
-    if (origin) {
-      storages = storages.filter(x => atSameLocation(x, origin) && x !== origin);
-    }
+  const originRef = data.origin !== configurableValue ? data.origin : config.origin;
+  const origin = deserializeStorage(originRef);
+  if (origin) {
+    storages = storages.filter(x => atSameLocation(x, origin) && x !== origin);
   }
-
   return storages.sort(storageSort);
 });
 


### PR DESCRIPTION
## Summary

- When both origin and destination are set to \"Configure on Execution\", selecting an origin now filters the destination dropdown to same-location storages only (and vice versa).
- Previously, no filtering was applied in the dual-configurable case — the full storage list was shown for both dropdowns regardless of what the user had selected for the other field.

## How it works

The existing `atSameLocation` utility already encodes all the transfer rules correctly:
- Planet base / planet warehouse → only storages at the same planet (other bases, warehouses, and ships currently there)
- CX warehouse (station) → only ships docked at that station
- Ship cargo → only storages at the ship's current location

The change is two lines in `Configure.vue`. Each computed (`originStorages`, `destinationStorages`) now falls back to the configured value (`config.destination` / `config.origin`) when the action-level field is set to `configurableValue`, rather than skipping the filter entirely.

The existing `watchEffect` autofix already handles cascading resets: if the user changes origin to a different location, any previously selected destination that is now invalid is automatically cleared.

## Test plan

- [ ] Action with both origin and destination as \"Configure on Execution\": selecting an origin filters the destination list to same-location storages only
- [ ] Changing origin clears a destination that is no longer at the same location
- [ ] CX warehouse as origin shows only ships at that station in the destination list
- [ ] Action with one field hardcoded and one configurable: existing filtering behaviour unchanged
- [ ] Both fields hardcoded: configure screen shows passive labels, no regression

https://claude.ai/code/session_017jK6qFcbYh221VGxteCcJY