### PR TITLE
ACT resupply: weight/volume preview, Fit to Ship buttons, MTRA ship SFC handling

### DIFF
--- a/src/features/XIT/ACT/ConfigureWindow.vue
+++ b/src/features/XIT/ACT/ConfigureWindow.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ActionPackageConfig } from '@src/features/XIT/ACT/shared-types';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import { deserializeStorage } from '@src/features/XIT/ACT/actions/utils';
 import SectionHeader from '@src/components/SectionHeader.vue';
 import { act } from '@src/features/XIT/ACT/act-registry';
 
@@ -13,6 +15,7 @@ interface Block {
   component: Component;
   data: unknown;
   config: unknown;
+  shipStore?: PrunApi.Store;
 }
 
 const blocks = computed(() => {
@@ -27,11 +30,23 @@ const blocks = computed(() => {
     if (!groupConfig) {
       continue;
     }
+    const mtraAction = pkg.actions.find(a => a.type === 'MTRA' && a.group === group.name);
+    let shipStore: PrunApi.Store | undefined;
+    if (mtraAction) {
+      const mtraConfig = config.actions[mtraAction.name!] as { destination?: string } | undefined;
+      const destRef =
+        mtraAction.dest !== configurableValue ? mtraAction.dest : mtraConfig?.destination;
+      const store = deserializeStorage(destRef);
+      if (store?.type === 'SHIP_STORE') {
+        shipStore = store;
+      }
+    }
     blocks.push({
       name: `[${name}]: ${info.type} Material Group`,
       component: info.configureComponent,
       data: group,
       config: groupConfig,
+      shipStore,
     });
   }
   for (const action of pkg.actions) {
@@ -59,7 +74,11 @@ const blocks = computed(() => {
   <div :class="$style.config">
     <template v-for="block in blocks" :key="block.name">
       <SectionHeader :class="$style.sectionHeader">{{ block.name }}</SectionHeader>
-      <component :is="block.component" :data="block.data" :config="block.config" />
+      <component
+        :is="block.component"
+        :data="block.data"
+        :config="block.config"
+        :shipStore="block.shipStore" />
     </template>
   </div>
 </template>

--- a/src/features/XIT/ACT/ConfigureWindow.vue
+++ b/src/features/XIT/ACT/ConfigureWindow.vue
@@ -78,7 +78,7 @@ const blocks = computed(() => {
         :is="block.component"
         :data="block.data"
         :config="block.config"
-        :shipStore="block.shipStore" />
+        :ship-store="block.shipStore" />
     </template>
   </div>
 </template>

--- a/src/features/XIT/ACT/action-steps/OPEN_SFC.ts
+++ b/src/features/XIT/ACT/action-steps/OPEN_SFC.ts
@@ -1,0 +1,70 @@
+import { act } from '@src/features/XIT/ACT/act-registry';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { focusElement, changeInputValue, clickElement } from '@src/util';
+import { AssertFn } from '@src/features/XIT/ACT/shared-types';
+
+interface Data {
+  shipId: string;
+  destination?: string;
+}
+
+export const OPEN_SFC = act.addActionStep<Data>({
+  type: 'OPEN_SFC',
+  description: data => {
+    const ship = shipsStore.getById(data.shipId);
+    const shipLabel = ship?.name ?? ship?.registration ?? 'unknown ship';
+    return data.destination
+      ? `Open SFC for ${shipLabel}, set destination to ${data.destination}`
+      : `Open SFC for ${shipLabel}`;
+  },
+  execute: async ctx => {
+    const { data, log, waitAct, requestTile, complete } = ctx;
+    const assert: AssertFn = ctx.assert;
+
+    const ship = shipsStore.getById(data.shipId);
+    assert(ship, 'Ship not found');
+
+    const tile = await requestTile(`SFC ${ship.registration}`);
+    if (!tile) {
+      return;
+    }
+
+    if (data.destination) {
+      const input = _$$(document.documentElement, C.AddressSelector.input)[0] as
+        | HTMLInputElement
+        | undefined;
+      if (!input) {
+        log.warning('SFC address input not found — set destination manually');
+        complete();
+        return;
+      }
+
+      await waitAct(`Set destination to ${data.destination}?`);
+      focusElement(input);
+      changeInputValue(input, data.destination);
+
+      await waitAct('Select destination?');
+      const portal = document.getElementById('autosuggest-portal');
+      const suggestion = _$$(portal!, C.AddressSelector.suggestionContent)[0] as
+        | HTMLElement
+        | undefined;
+      if (suggestion) {
+        await clickElement(suggestion);
+        log.info(`Destination set: ${data.destination}`);
+      } else {
+        log.warning(`No suggestion found for ${data.destination} — select manually`);
+      }
+    }
+
+    // Resize the companion window by directly setting Window.body dimensions.
+    // UI_WINDOWS_UPDATE_SIZE doesn't work for docked tiles; direct style
+    // manipulation on Window.body is the reliable approach for split windows.
+    const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+    const bodyEl = windowEl ? (_$(windowEl, C.Window.body) as HTMLElement | null) : null;
+    if (bodyEl) {
+      bodyEl.style.width = '975px';
+      bodyEl.style.height = '750px';
+    }
+    complete();
+  },
+});

--- a/src/features/XIT/ACT/actions/mtra/mtra.ts
+++ b/src/features/XIT/ACT/actions/mtra/mtra.ts
@@ -2,6 +2,7 @@ import { act } from '@src/features/XIT/ACT/act-registry';
 import Edit from '@src/features/XIT/ACT/actions/mtra/Edit.vue';
 import Configure from '@src/features/XIT/ACT/actions/mtra/Configure.vue';
 import { MTRA_TRANSFER } from '@src/features/XIT/ACT/action-steps/MTRA_TRANSFER';
+import { OPEN_SFC } from '@src/features/XIT/ACT/action-steps/OPEN_SFC';
 import { atSameLocation, deserializeStorage } from '@src/features/XIT/ACT/actions/utils';
 import { Config } from '@src/features/XIT/ACT/actions/mtra/config';
 import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
@@ -36,7 +37,7 @@ act.addAction<Config>({
     );
   },
   generateSteps: async ctx => {
-    const { data, config, getMaterialGroup, emitStep } = ctx;
+    const { data, config, getMaterialGroup, getMaterialGroupPlanet, emitStep } = ctx;
     const assert: AssertFn = ctx.assert;
 
     const materials = await getMaterialGroup(data.group);
@@ -62,6 +63,11 @@ act.addAction<Config>({
           amount: materials[ticker],
         }),
       );
+    }
+
+    if (dest.type === 'SHIP_STORE') {
+      const planet = getMaterialGroupPlanet(data.group);
+      emitStep(OPEN_SFC({ shipId: dest.addressableId, destination: planet }));
     }
   },
 });

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -130,7 +130,6 @@ const canFit = computed(() => bill.value !== undefined);
     <PrunButton
       v-for="ship in shipSizes"
       :key="ship.label"
-      inline
       primary
       :disabled="!canFit"
       @click="fitToShip(ship.weight, ship.volume)">

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -11,9 +11,14 @@ import { comparePlanets } from '@src/util';
 import { configurableValue } from '@src/features/XIT/ACT/shared-types';
 import { userData } from '@src/store/user-data';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { fixed02 } from '@src/utils/format';
 
-const { data, config } = defineProps<{ data: UserData.MaterialGroupData; config: Config }>();
+const { data, config, shipStore } = defineProps<{
+  data: UserData.MaterialGroupData;
+  config: Config;
+  shipStore?: PrunApi.Store;
+}>();
 
 const planets = computed(() =>
   (sitesStore.all.value ?? [])
@@ -100,6 +105,20 @@ function fitToShip(maxWeight: number, maxVolume: number) {
 }
 
 const canFit = computed(() => bill.value !== undefined);
+
+const shipFree = computed(() => {
+  if (!shipStore) return undefined;
+  return {
+    weight: shipStore.weightCapacity - shipStore.weightLoad,
+    volume: shipStore.volumeCapacity - shipStore.volumeLoad,
+  };
+});
+
+const shipName = computed(() => {
+  if (!shipStore) return undefined;
+  const ship = shipsStore.getById(shipStore.addressableId);
+  return ship?.name ?? ship?.registration;
+});
 </script>
 
 <template>
@@ -135,6 +154,12 @@ const canFit = computed(() => bill.value !== undefined);
       @click="fitToShip(ship.weight, ship.volume)">
       {{ ship.label }}
     </PrunButton>
+    <template v-if="shipName && shipFree">
+      <span>Fit Selected</span>
+      <PrunButton primary :disabled="!canFit" @click="fitToShip(shipFree.weight, shipFree.volume)">
+        {{ shipName }}
+      </PrunButton>
+    </template>
   </div>
 </template>
 

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -107,7 +107,9 @@ function fitToShip(maxWeight: number, maxVolume: number) {
 const canFit = computed(() => bill.value !== undefined);
 
 const shipFree = computed(() => {
-  if (!shipStore) return undefined;
+  if (!shipStore) {
+    return undefined;
+  }
   return {
     weight: shipStore.weightCapacity - shipStore.weightLoad,
     volume: shipStore.volumeCapacity - shipStore.volumeLoad,
@@ -115,7 +117,9 @@ const shipFree = computed(() => {
 });
 
 const shipName = computed(() => {
-  if (!shipStore) return undefined;
+  if (!shipStore) {
+    return undefined;
+  }
   const ship = shipsStore.getById(shipStore.addressableId);
   return ship?.name ?? ship?.registration;
 });

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -3,11 +3,14 @@ import SelectInput from '@src/components/forms/SelectInput.vue';
 import Active from '@src/components/forms/Active.vue';
 import NumberInput from '@src/components/forms/NumberInput.vue';
 import { Config } from '@src/features/XIT/ACT/material-groups/resupply/config';
+import { computeResupplyBill } from '@src/features/XIT/ACT/material-groups/resupply/bill';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { comparePlanets } from '@src/util';
 import { configurableValue } from '@src/features/XIT/ACT/shared-types';
 import { userData } from '@src/store/user-data';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { fixed02 } from '@src/utils/format';
 
 const { data, config } = defineProps<{ data: UserData.MaterialGroupData; config: Config }>();
 
@@ -25,6 +28,40 @@ if (data.planet === configurableValue && !config.planet) {
 if (data.days === configurableValue && config.days === undefined) {
   config.days = userData.settings.burn.resupply ?? 10;
 }
+
+const effectivePlanet = computed(() =>
+  data.planet === configurableValue ? config.planet : data.planet,
+);
+
+const effectiveDays = computed(() => {
+  if (data.days === configurableValue) {
+    return config.days;
+  }
+  if (typeof data.days === 'number') {
+    return data.days;
+  }
+  const parsed = parseFloat(data.days as string);
+  return isNaN(parsed) ? undefined : parsed;
+});
+
+const bill = computed(() => computeResupplyBill(data, effectivePlanet.value, effectiveDays.value));
+
+const totals = computed(() => {
+  const entries = bill.value;
+  if (!entries) {
+    return undefined;
+  }
+  let weight = 0;
+  let volume = 0;
+  for (const [ticker, amount] of Object.entries(entries)) {
+    const mat = materialsStore.getByTicker(ticker);
+    if (mat) {
+      weight += mat.weight * amount;
+      volume += mat.volume * amount;
+    }
+  }
+  return { weight, volume };
+});
 </script>
 
 <template>
@@ -39,4 +76,25 @@ if (data.days === configurableValue && config.days === undefined) {
       <NumberInput v-model="config.days" />
     </Active>
   </form>
+  <div :class="$style.totals">
+    <template v-if="totals">
+      <span>Total Weight </span>
+      <span :class="$style.value">{{ fixed02(totals.weight) }}t</span>
+      <span>, Total Volume </span>
+      <span :class="$style.value">{{ fixed02(totals.volume) }}m³</span>
+    </template>
+    <template v-else>
+      <span>Total Weight --, Total Volume --</span>
+    </template>
+  </div>
 </template>
+
+<style module>
+.totals {
+  margin: 4px 4px 4px 8px;
+}
+
+.value {
+  color: #f7a600;
+}
+</style>

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -2,6 +2,7 @@
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import Active from '@src/components/forms/Active.vue';
 import NumberInput from '@src/components/forms/NumberInput.vue';
+import PrunButton from '@src/components/PrunButton.vue';
 import { Config } from '@src/features/XIT/ACT/material-groups/resupply/config';
 import { computeResupplyBill } from '@src/features/XIT/ACT/material-groups/resupply/bill';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
@@ -46,11 +47,7 @@ const effectiveDays = computed(() => {
 
 const bill = computed(() => computeResupplyBill(data, effectivePlanet.value, effectiveDays.value));
 
-const totals = computed(() => {
-  const entries = bill.value;
-  if (!entries) {
-    return undefined;
-  }
+function billTotals(entries: Record<string, number>) {
   let weight = 0;
   let volume = 0;
   for (const [ticker, amount] of Object.entries(entries)) {
@@ -61,7 +58,48 @@ const totals = computed(() => {
     }
   }
   return { weight, volume };
+}
+
+const totals = computed(() => {
+  const entries = bill.value;
+  if (!entries) {
+    return undefined;
+  }
+  return billTotals(entries);
 });
+
+const shipSizes = [
+  { label: '2k/2k', weight: 2000, volume: 2000 },
+  { label: '3k/1k', weight: 3000, volume: 1000 },
+  { label: '5k/5k', weight: 5000, volume: 5000 },
+];
+
+// Binary search for the maximum whole-day count whose bill fits the ship.
+function fitToShip(maxWeight: number, maxVolume: number) {
+  const planet = effectivePlanet.value;
+  if (!planet) {
+    return;
+  }
+  // Quick check that burn data is loaded.
+  if (!computeResupplyBill(data, planet, 1)) {
+    return;
+  }
+  let lo = 0;
+  let hi = 999;
+  while (lo < hi) {
+    const mid = lo + Math.ceil((hi - lo) / 2);
+    const entries = computeResupplyBill(data, planet, mid)!;
+    const t = billTotals(entries);
+    if (t.weight <= maxWeight && t.volume <= maxVolume) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  config.days = lo;
+}
+
+const canFit = computed(() => bill.value !== undefined);
 </script>
 
 <template>
@@ -87,6 +125,18 @@ const totals = computed(() => {
       <span>Total Weight --, Total Volume --</span>
     </template>
   </div>
+  <div v-if="data.days === configurableValue" :class="$style.fitRow">
+    <span>Fit to Ship</span>
+    <PrunButton
+      v-for="ship in shipSizes"
+      :key="ship.label"
+      inline
+      primary
+      :disabled="!canFit"
+      @click="fitToShip(ship.weight, ship.volume)">
+      {{ ship.label }}
+    </PrunButton>
+  </div>
 </template>
 
 <style module>
@@ -96,5 +146,12 @@ const totals = computed(() => {
 
 .value {
   color: #f7a600;
+}
+
+.fitRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 2px 4px 4px 8px;
 }
 </style>

--- a/src/features/XIT/ACT/material-groups/resupply/bill.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/bill.ts
@@ -1,0 +1,53 @@
+import { calculatePlanetBurn } from '@src/core/burn';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { workforcesStore } from '@src/infrastructure/prun-api/data/workforces';
+import { productionStore } from '@src/infrastructure/prun-api/data/production';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+
+// Computes the resupply material bill for a given planet and day count.
+// Returns undefined when inputs are missing or when the site's burn data is
+// not yet loaded. Kept synchronous so it can be driven reactively from the
+// Configure window.
+export function computeResupplyBill(
+  data: UserData.MaterialGroupData,
+  planet: string | undefined,
+  days: number | undefined,
+): Record<string, number> | undefined {
+  if (!planet || days === undefined || isNaN(days)) {
+    return undefined;
+  }
+  const site = sitesStore.getByPlanetNaturalIdOrName(planet);
+  if (!site) {
+    return undefined;
+  }
+  const workforce = workforcesStore.getById(site.siteId)?.workforces;
+  const production = productionStore.getBySiteId(site.siteId);
+  if (workforce === undefined || production === undefined) {
+    return undefined;
+  }
+  const stores = storagesStore.getByAddressableId(site.siteId);
+
+  const planetBurn = calculatePlanetBurn(
+    data.consumablesOnly ? undefined : production,
+    workforce,
+    (data.useBaseInv ?? true) ? stores : undefined,
+  );
+
+  const exclusions = data.exclusions ?? [];
+  const bill: Record<string, number> = {};
+  for (const ticker of Object.keys(planetBurn)) {
+    if (exclusions.includes(ticker)) {
+      continue;
+    }
+    const matBurn = planetBurn[ticker];
+    if (matBurn.dailyAmount >= 0) {
+      continue;
+    }
+    const consumed = days * -matBurn.dailyAmount;
+    const need = Math.max(0, Math.ceil(consumed - matBurn.inventory + 1));
+    if (need > 0) {
+      bill[ticker] = need;
+    }
+  }
+  return bill;
+}

--- a/src/features/XIT/ACT/material-groups/resupply/resupply.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/resupply.ts
@@ -5,9 +5,8 @@ import { Config } from '@src/features/XIT/ACT/material-groups/resupply/config';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { workforcesStore } from '@src/infrastructure/prun-api/data/workforces';
 import { productionStore } from '@src/infrastructure/prun-api/data/production';
-import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { configurableValue } from '@src/features/XIT/ACT/shared-types';
-import { calculatePlanetBurn } from '@src/core/burn';
+import { computeResupplyBill } from '@src/features/XIT/ACT/material-groups/resupply/bill';
 import { watchWhile } from '@src/utils/watch';
 import {
   getEntityNameFromAddress,
@@ -39,7 +38,6 @@ act.addMaterialGroup<Config>({
       log.error('Missing resupply days');
     }
 
-    const exclusions = data.exclusions ?? [];
     const planet = data.planet === configurableValue ? config.planet : data.planet;
     const days =
       data.days === configurableValue
@@ -66,29 +64,7 @@ act.addMaterialGroup<Config>({
         toRef(() => workforce.value === undefined || production.value === undefined),
       );
     }
-    const stores = storagesStore.getByAddressableId(site.siteId);
 
-    const planetBurn = calculatePlanetBurn(
-      data.consumablesOnly ? undefined : production.value,
-      workforce.value,
-      (data.useBaseInv ?? true) ? stores : undefined,
-    );
-
-    const parsedGroup = {};
-    for (const ticker of Object.keys(planetBurn)) {
-      if (exclusions.includes(ticker)) {
-        continue;
-      }
-      const matBurn = planetBurn[ticker];
-      if (matBurn.dailyAmount >= 0) {
-        continue;
-      }
-      const consumed = days * -matBurn.dailyAmount;
-      const need = Math.max(0, Math.ceil(consumed - matBurn.inventory + 1));
-      if (need > 0) {
-        parsedGroup[ticker] = need;
-      }
-    }
-    return parsedGroup;
+    return computeResupplyBill(data, planet, days);
   },
 });


### PR DESCRIPTION
## Summary

- Live weight/volume preview in the Configure buffer showing total cargo needed for the resupply bill
- Fit to Ship buttons (2k/2k, 3k/1k, 5k/5k) that binary-search the maximum days that fit within the ship's cargo limits
- **Fit Selected** button that dynamically shows the designated MTRA destination ship's name and fits days to its current free cargo capacity
- When an MTRA action transfers to a ship store, automatically emits an `OPEN_SFC` step to open the ship's flight computer and set the destination planet

## Test plan

- [ ] Configure buffer shows correct total weight/volume for resupply bill
- [ ] Fit to Ship buttons correctly set days to fill a 2k/2k, 3k/1k, or 5k/5k ship
- [ ] When MTRA destination is a ship store, "Fit Selected [Ship Name]" button appears and fits to that ship's free cargo
- [ ] Button updates if the MTRA destination dropdown is changed
- [ ] Button is absent when MTRA destination is not a ship store
- [ ] After MTRA transfer to ship store completes, SFC buffer opens and destination planet is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)