### PR TITLE
Fix context menu ticker extraction including quantity subLabel text

### DIFF
--- a/src/features/advanced/market-contextmenu/market-contextmenu.ts
+++ b/src/features/advanced/market-contextmenu/market-contextmenu.ts
@@ -83,7 +83,7 @@ async function init() {
     const target = (event.target as HTMLElement).closest<HTMLElement>(materialSelector);
     if (target !== null) {
       event.preventDefault();
-      store.showMenu(event, target.textContent ?? '');
+      store.showMenu(event, _$(target, C.ColoredIcon.label)?.textContent ?? '');
       return;
     }
     if (isOpen) {


### PR DESCRIPTION
target.textContent on C.ColoredIcon.container concatenates the ticker and subLabel (quantity), producing e.g. "RAT1000" instead of "RAT". Use C.ColoredIcon.label child element to get only the ticker, consistent with every other ticker extraction in the codebase.

https://claude.ai/code/session_011eaTpMiHtrRDYjzzkMaYTR

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
