### PR TITLE
Remove dist.zip hook, build artifact on PRs instead

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,19 +1,3 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "if": "Bash(git commit*)",
-            "timeout": 240,
-            "statusMessage": "Rebuilding dist.zip",
-            "command": "bash -c 'set -e; cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\"; branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo); [ \"$branch\" = \"main\" ] && exit 0; last_msg=$(git log -1 --pretty=%s 2>/dev/null || echo); case \"$last_msg\" in *\"[auto-dist]\"*) exit 0;; esac; if ! ./scripts/build-dist.sh >/tmp/rprun-build-dist.log 2>&1; then echo \"build-dist.sh failed (see /tmp/rprun-build-dist.log):\" >&2; tail -20 /tmp/rprun-build-dist.log >&2; exit 1; fi; git add -f dist.zip 2>/dev/null || true; if ! git diff --cached --quiet -- dist.zip 2>/dev/null; then git commit -m \"Update dist.zip [auto-dist]\"; fi'"
-          }
-        ]
-      }
-    ]
-  }
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
 }

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -3,6 +3,7 @@ name: Build Refined PrUn ZIP
 on:
   push:
     branches: [ main ]
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes the PostToolUse hook that committed dist.zip to feature branches
after every commit, which caused merge conflicts with main.

Adds pull_request trigger to build-extension.yml so a downloadable
artifact is produced per PR via the Actions tab instead.

https://claude.ai/code/session_011nD3EfRpdn1wALx6gGdvNr