### PR TITLE
XIT BS: add repair column

### DIFF
--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -12,14 +12,17 @@ import { comparePlanets } from '@src/util';
 import { useTileState } from '@src/store/user-data-tiles';
 import { getPlanetBurn } from '@src/core/burn';
 import { countDays } from '@src/features/XIT/BURN/utils';
+import { getPlanetRepairAge } from '@src/features/XIT/REP/entries';
+import { timestampEachMinute } from '@src/utils/dayjs';
 
-type SortKey = 'name' | 'burn';
+type SortKey = 'name' | 'burn' | 'repair';
 type SortDirection = 'asc' | 'desc';
 
 const sortKey = useTileState<SortKey>('sortKey', 'burn');
 const sortDirection = useTileState<SortDirection>('sortDirection', 'asc');
 const showBurn = useTileState('showBurn', true);
 const showProd = useTileState('showProd', true);
+const showRepair = useTileState('showRepair', true);
 
 function setSort(key: SortKey) {
   if (sortKey.value === key) {
@@ -47,6 +50,7 @@ interface BaseEntry {
   planetName: string;
   storeId: string;
   days: number | undefined;
+  repairDays: number | undefined;
 }
 
 const bases = computed<BaseEntry[] | undefined>(() => {
@@ -55,6 +59,7 @@ const bases = computed<BaseEntry[] | undefined>(() => {
     return undefined;
   }
 
+  const now = timestampEachMinute.value;
   const entries = sites
     .map(site => {
       const burn = getPlanetBurn(site.siteId);
@@ -64,6 +69,7 @@ const bases = computed<BaseEntry[] | undefined>(() => {
         planetName: getEntityNameFromAddress(site.address) ?? '',
         storeId: storagesStore.getByAddressableId(site.siteId)?.[0]?.id ?? '',
         days: burn ? countDays(burn.burn) : undefined,
+        repairDays: getPlanetRepairAge(site.siteId, now),
       };
     })
     .filter(x => x.naturalId);
@@ -76,6 +82,13 @@ const bases = computed<BaseEntry[] | undefined>(() => {
       const daysB = b.days ?? Infinity;
       if (daysA !== daysB) {
         return (daysA - daysB) * dir;
+      }
+    }
+    if (sortKey.value === 'repair') {
+      const repA = a.repairDays ?? -Infinity;
+      const repB = b.repairDays ?? -Infinity;
+      if (repA !== repB) {
+        return (repB - repA) * dir;
       }
     }
     return comparePlanets(a.naturalId, b.naturalId) * dir;
@@ -91,6 +104,7 @@ const bases = computed<BaseEntry[] | undefined>(() => {
     <div :class="C.ComExOrdersPanel.filter">
       <RadioItem v-model="showBurn" horizontal>Burn</RadioItem>
       <RadioItem v-model="showProd" horizontal>Prod</RadioItem>
+      <RadioItem v-model="showRepair" horizontal>Repair</RadioItem>
     </div>
     <table :class="$style.table">
       <thead>
@@ -112,6 +126,15 @@ const bases = computed<BaseEntry[] | undefined>(() => {
             }}</span>
           </th>
           <th v-if="showProd" :class="$style.narrowCol">Prod</th>
+          <th
+            v-if="showRepair"
+            :class="[$style.narrowCol, $style.sortable, $style.repairCol]"
+            @click="setSort('repair')">
+            Repair
+            <span :class="isSorted('repair') ? $style.sortActive : $style.sortInactive">{{
+              getSortIndicator('repair')
+            }}</span>
+          </th>
           <th :class="$style.invCol">Inv</th>
           <th :class="$style.warCol">War</th>
         </tr>
@@ -125,7 +148,8 @@ const bases = computed<BaseEntry[] | undefined>(() => {
           :planet-name="base.planetName"
           :store-id="base.storeId"
           :show-burn="showBurn"
-          :show-prod="showProd" />
+          :show-prod="showProd"
+          :show-repair="showRepair" />
       </tbody>
     </table>
   </template>
@@ -164,6 +188,11 @@ const bases = computed<BaseEntry[] | undefined>(() => {
 }
 
 .burnCol {
+  border-left: 2px solid #3fa2de;
+  border-right: 2px solid #3fa2de;
+}
+
+.repairCol {
   border-left: 2px solid #3fa2de;
   border-right: 2px solid #3fa2de;
 }

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -71,7 +71,9 @@ const repairAge = computed(() => getPlanetRepairAge(siteId, timestampEachMinute.
 
 const repairBgClass = computed(() => {
   const age = repairAge.value;
-  if (age === undefined) return {};
+  if (age === undefined) {
+    return {};
+  }
   const { threshold, offset } = userData.settings.repair;
   const d = Math.floor(age);
   return {
@@ -83,7 +85,9 @@ const repairBgClass = computed(() => {
 
 const repairDaysText = computed(() => {
   const age = repairAge.value;
-  if (age === undefined) return undefined;
+  if (age === undefined) {
+    return undefined;
+  }
   return String(Math.floor(age));
 });
 

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -9,14 +9,17 @@ import { getPlanetProduction } from '@src/core/production';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { userData } from '@src/store/user-data';
+import { getPlanetRepairAge } from '@src/features/XIT/REP/entries';
+import { timestampEachMinute } from '@src/utils/dayjs';
 
-const { siteId, naturalId, planetName, storeId, showBurn, showProd } = defineProps<{
+const { siteId, naturalId, planetName, storeId, showBurn, showProd, showRepair } = defineProps<{
   siteId: string;
   naturalId: string;
   planetName: string;
   storeId: string;
   showBurn: boolean;
   showProd: boolean;
+  showRepair: boolean;
 }>();
 
 const burn = computed(() => getPlanetBurn(siteId));
@@ -62,6 +65,26 @@ const prodBgClass = computed(() => {
     [C.Workforces.daysMissing]: totals.orders < totals.capacity,
     [C.Workforces.daysSupplied]: totals.orders >= totals.capacity,
   };
+});
+
+const repairAge = computed(() => getPlanetRepairAge(siteId, timestampEachMinute.value));
+
+const repairBgClass = computed(() => {
+  const age = repairAge.value;
+  if (age === undefined) return {};
+  const { threshold, offset } = userData.settings.repair;
+  const d = Math.floor(age);
+  return {
+    [C.Workforces.daysMissing]: d >= threshold,
+    [C.Workforces.daysWarning]: d >= threshold - offset,
+    [C.Workforces.daysSupplied]: d < threshold - offset,
+  };
+});
+
+const repairDaysText = computed(() => {
+  const age = repairAge.value;
+  if (age === undefined) return undefined;
+  return String(Math.floor(age));
 });
 
 const warehouse = computed(() => warehousesStore.getByEntityNaturalId(naturalId));
@@ -114,6 +137,22 @@ const warehouseStore = computed(() =>
         </div>
       </template>
       <span v-else>-</span>
+    </td>
+    <td
+      v-if="showRepair"
+      :style="{ position: 'relative' }"
+      :class="$style.repairCell"
+      @click="showBuffer(`XIT REP ${naturalId}`)">
+      <div
+        v-if="repairDaysText !== undefined"
+        :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
+        :class="repairBgClass" />
+      <div :class="$style.repairContent">
+        <PrunButton dark inline @click.stop="showBuffer(`XIT REPAIRACT ${naturalId}`)">
+          REP
+        </PrunButton>
+        <span :class="$style.daysNum">{{ repairDaysText ?? '-' }}</span>
+      </div>
     </td>
     <td :class="$style.invCell">
       <InvBar
@@ -206,6 +245,22 @@ const warehouseStore = computed(() =>
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.repairCell {
+  cursor: pointer;
+  width: 0;
+  white-space: nowrap;
+  padding: 2px 4px;
+  border-left: 2px solid #3fa2de;
+  border-right: 2px solid #3fa2de;
+}
+
+.repairContent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .invCell {

--- a/src/features/XIT/REP/entries.ts
+++ b/src/features/XIT/REP/entries.ts
@@ -92,13 +92,19 @@ export function calculateShipEntries(ships?: PrunApi.Ship[]) {
 
 export function getPlanetRepairAge(siteId: string, now: number) {
   const site = sitesStore.getById(siteId);
-  if (!site) return undefined;
+  if (!site) {
+    return undefined;
+  }
   const buildings = site.platforms.filter(isRepairableBuilding);
-  if (buildings.length === 0) return undefined;
+  if (buildings.length === 0) {
+    return undefined;
+  }
   let maxAge = 0;
   for (const building of buildings) {
     const age = diffDays(getBuildingLastRepair(building), now, true);
-    if (age > maxAge) maxAge = age;
+    if (age > maxAge) {
+      maxAge = age;
+    }
   }
   return maxAge;
 }

--- a/src/features/XIT/REP/entries.ts
+++ b/src/features/XIT/REP/entries.ts
@@ -5,6 +5,7 @@ import {
   getEntityNaturalIdFromAddress,
 } from '@src/infrastructure/prun-api/data/addresses';
 import { getBuildingBuildMaterials, isRepairableBuilding } from '@src/core/buildings';
+import { diffDays } from '@src/utils/time-diff';
 import { isEmpty } from 'ts-extras';
 
 export interface RepairEntry {
@@ -87,6 +88,19 @@ export function calculateShipEntries(ships?: PrunApi.Ship[]) {
   }
   entries.sort((a, b) => a.condition - b.condition);
   return entries;
+}
+
+export function getPlanetRepairAge(siteId: string, now: number) {
+  const site = sitesStore.getById(siteId);
+  if (!site) return undefined;
+  const buildings = site.platforms.filter(isRepairableBuilding);
+  if (buildings.length === 0) return undefined;
+  let maxAge = 0;
+  for (const building of buildings) {
+    const age = diffDays(getBuildingLastRepair(building), now, true);
+    if (age > maxAge) maxAge = age;
+  }
+  return maxAge;
 }
 
 function isShipParameter(parameter: string) {


### PR DESCRIPTION
## Summary

- Adds a **Repair** column to XIT BS, mirroring the Burn column in structure and style
- Each planet's cell is color-coded: red if the oldest building's age ≥ repair threshold, yellow if within the offset window, green otherwise — using the player's existing XIT REP settings (read-only, never overwritten)
- Cell includes a **REP** button (opens `XIT REPAIRACT <planet>`) and the max building age in days; clicking the cell opens `XIT REP <planet>`
- Column is sortable (ascending = most urgent first, i.e. highest age first) and toggleable via a new **Repair** radio item

## Implementation

- `entries.ts` — new `getPlanetRepairAge(siteId, now)` helper: finds all repairable buildings on a site and returns the age (days since last repair) of the oldest one
- `BS.vue` — adds `repair` sort key, `showRepair` tile state, `repairDays` in `BaseEntry`, repair sort logic, Repair RadioItem toggle, sortable column header, and passes `showRepair` to `BaseRow`
- `BaseRow.vue` — adds `showRepair` prop, repair age/color computeds, and the repair cell with background, REP button, and age display

## Test plan

- [ ] Open XIT BS — Repair column appears with correct day counts per planet
- [ ] Color coding matches XIT REP threshold/offset settings (change settings in XIT REP and verify BS updates)
- [ ] REP button opens `XIT REPAIRACT <planet>`
- [ ] Clicking the cell (not the button) opens `XIT REP <planet>`
- [ ] Sorting by Repair shows most-urgent (highest age) planets first on first click
- [ ] Toggling the Repair radio item hides/shows the column
- [ ] Player's repair threshold and offset settings are unchanged after using XIT BS

https://claude.ai/code/session_01GVfNNrG3FxpdPJzcH4YwyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVfNNrG3FxpdPJzcH4YwyW)_