### PR TITLE
feat: Add drag-and-drop reordering to CXM buffer

### DIFF
--- a/src/features/basic/cxm-reorder/cxm-reorder.ts
+++ b/src/features/basic/cxm-reorder/cxm-reorder.ts
@@ -123,11 +123,15 @@ function setupDragAndDrop(tbody: Element) {
 function getExchange(row: HTMLTableRowElement) {
   for (const cell of _$$(row, 'td')) {
     const text = cell.textContent?.trim();
-    if (!text) continue;
+    if (!text) {
+      continue;
+    }
     const match = exchanges.find(
       ex => text === ex || text.startsWith(ex + '\n') || text.startsWith(ex + ' '),
     );
-    if (match) return match;
+    if (match) {
+      return match;
+    }
   }
   return '';
 }

--- a/src/features/basic/cxm-reorder/cxm-reorder.ts
+++ b/src/features/basic/cxm-reorder/cxm-reorder.ts
@@ -123,9 +123,11 @@ function setupDragAndDrop(tbody: Element) {
 function getExchange(row: HTMLTableRowElement) {
   for (const cell of _$$(row, 'td')) {
     const text = cell.textContent?.trim();
-    if (text && exchanges.includes(text as UserData.Exchange)) {
-      return text;
-    }
+    if (!text) continue;
+    const match = exchanges.find(
+      ex => text === ex || text.startsWith(ex + '\n') || text.startsWith(ex + ' '),
+    );
+    if (match) return match;
   }
   return '';
 }


### PR DESCRIPTION
## Summary

- Adds drag-and-drop row reordering to the CXM buffer via HTML5 Drag and Drop API
- Injects grip handle cells into each row; persists custom exchange order to `userData.settings.cxmOrder`
- Applies saved order reactively on tile load via `watchEffectWhileNodeAlive`
- Adds `cxmOrder` field to `initialUserData` and a seed migration for existing users

## Review fixes applied

- **#1** Moved `draggedRow` into `setupDragAndDrop` closure — was module-level, causing cross-tile DOM corruption when multiple CXM tiles were open simultaneously
- **#2** Moved feature from `advanced/` to `basic/` — adds UI, does not hide information
- **#4** Fixed feature description prefix from `'CXM Reordering: ...'` to `'CXM: ...'`
- **#5** Replaced `querySelectorAll`/`.cells` with `_$$` throughout
- **#8** Applied `watchEffectWhileNodeAlive` so order is restored reactively when `cxmOrder` changes in any open tile

## Bug fix

CXM exchange cells contain the exchange code and station name together on separate lines (`"AI1\nAntares Station"`), so exact `textContent` equality against `"AI1"` always failed. `getExchange` now matches codes at the start of cell text, which fixes order persistence across new CXM buffers.

## Test plan

- [ ] Open `CXM RAT`, drag exchanges to a custom order, close and reopen — order should be preserved
- [ ] Open two CXM tiles simultaneously, drag in one — the other tile should not be corrupted
- [ ] Reorder in one open tile — other open CXM tiles should reactively update to the new order

https://claude.ai/code/session_01WqEM87apU2n63uZesaMdjM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEM87apU2n63uZesaMdjM)_