### PR TITLE
Disable PR Documentation Standards Review action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,8 +1,9 @@
 name: PR Documentation Standards Review
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+# Disabled - this action was failing and needs investigation
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
The PR Documentation Standards Review action was consistently failing and needs investigation. This PR disables the action by commenting out its trigger, keeping the workflow file intact for future re-enablement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFZRgcDjnzqPK8b8P6G7iX)_