### PR TITLE
fix(cxm-reorder): match exchange code as prefix of cell text

### DIFF
--- a/src/features/basic/cxm-reorder/cxm-reorder.ts
+++ b/src/features/basic/cxm-reorder/cxm-reorder.ts
@@ -126,9 +126,7 @@ function getExchange(row: HTMLTableRowElement) {
     if (!text) {
       continue;
     }
-    const match = exchanges.find(
-      ex => text === ex || text.startsWith(ex + '\n') || text.startsWith(ex + ' '),
-    );
+    const match = exchanges.find(ex => text.startsWith(ex));
     if (match) {
       return match;
     }


### PR DESCRIPTION
CXM cells render code and station name in adjacent block elements (e.g. "AI1Antares Station" with no separator in textContent). Previous checks required a trailing newline or space and always missed, so getExchange returned '' for every row — saveOrder never updated cxmOrder, and each game price re-render reset the table to the natural order.

Exchange codes (AI1, CI1 …) share no prefix with currency codes (AIC, CIS …) or numeric columns, so startsWith without a separator is unambiguous.

https://claude.ai/code/session_01WqEM87apU2n63uZesaMdjM

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
