### PR TITLE
Refactor XIT base row layout to separate indicators and buttons

### DIFF
--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -118,17 +118,29 @@ const bases = computed<BaseEntry[] | undefined>(() => {
           <th :class="[$style.narrowCol, $style.centered]">CMD</th>
           <th
             v-if="showBurn"
-            :class="[$style.narrowCol, $style.sortable, $style.burnCol, $style.centered]"
+            colspan="2"
+            :class="[$style.narrowCol, $style.sortable, $style.centered]"
             @click="setSort('burn')">
             Burn
             <span :class="isSorted('burn') ? $style.sortActive : $style.sortInactive">{{
               getSortIndicator('burn')
             }}</span>
           </th>
-          <th v-if="showProd" :class="[$style.narrowCol, $style.centered]">Prod</th>
+          <th
+            v-if="showProd"
+            colspan="2"
+            :class="[$style.narrowCol, $style.centered, showBurn && $style.groupSeparator]">
+            Prod
+          </th>
           <th
             v-if="showRepair"
-            :class="[$style.narrowCol, $style.sortable, $style.repairCol, $style.centered]"
+            colspan="2"
+            :class="[
+              $style.narrowCol,
+              $style.sortable,
+              $style.centered,
+              (showBurn || showProd) && $style.groupSeparator,
+            ]"
             @click="setSort('repair')">
             Repair
             <span :class="isSorted('repair') ? $style.sortActive : $style.sortInactive">{{
@@ -191,13 +203,7 @@ const bases = computed<BaseEntry[] | undefined>(() => {
   color: rgb(63, 162, 222);
 }
 
-.burnCol {
-  border-left: 2px solid #3fa2de;
-  border-right: 2px solid #3fa2de;
-}
-
-.repairCol {
-  border-left: 2px solid #3fa2de;
-  border-right: 2px solid #3fa2de;
+.groupSeparator {
+  border-left: 1px solid #2b485a;
 }
 </style>

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -115,20 +115,20 @@ const bases = computed<BaseEntry[] | undefined>(() => {
               getSortIndicator('name')
             }}</span>
           </th>
-          <th :class="$style.narrowCol">CMD</th>
+          <th :class="[$style.narrowCol, $style.centered]">CMD</th>
           <th
             v-if="showBurn"
-            :class="[$style.narrowCol, $style.sortable, $style.burnCol]"
+            :class="[$style.narrowCol, $style.sortable, $style.burnCol, $style.centered]"
             @click="setSort('burn')">
             Burn
             <span :class="isSorted('burn') ? $style.sortActive : $style.sortInactive">{{
               getSortIndicator('burn')
             }}</span>
           </th>
-          <th v-if="showProd" :class="$style.narrowCol">Prod</th>
+          <th v-if="showProd" :class="[$style.narrowCol, $style.centered]">Prod</th>
           <th
             v-if="showRepair"
-            :class="[$style.narrowCol, $style.sortable, $style.repairCol]"
+            :class="[$style.narrowCol, $style.sortable, $style.repairCol, $style.centered]"
             @click="setSort('repair')">
             Repair
             <span :class="isSorted('repair') ? $style.sortActive : $style.sortInactive">{{
@@ -176,6 +176,10 @@ const bases = computed<BaseEntry[] | undefined>(() => {
 .sortable {
   cursor: pointer;
   user-select: none;
+}
+
+.centered {
+  text-align: center;
 }
 
 .sortActive {

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -125,8 +125,9 @@ const warehouseStore = computed(() =>
     </td>
     <td
       v-if="showBurn"
-      :class="[$style.indicatorCell, $style.clickable, burnBgClass]"
+      :class="[$style.indicatorCell, $style.clickable]"
       @click="showBuffer(`XIT BURN ${naturalId}`)">
+      <div :class="[$style.overlay, burnBgClass]" />
       <span :class="$style.indicatorText">{{ daysText ?? '-' }}</span>
     </td>
     <td v-if="showBurn" :class="$style.buttonCell">
@@ -134,7 +135,13 @@ const warehouseStore = computed(() =>
     </td>
     <td
       v-if="showProd"
-      :class="[$style.indicatorCell, prodBgClass, showBurn && $style.groupSeparator]">
+      :class="[
+        $style.indicatorCell,
+        $style.clickable,
+        showBurn && $style.groupSeparator,
+      ]"
+      @click="showBuffer(`XIT PROD ${naturalId}`)">
+      <div :class="[$style.overlay, prodBgClass]" />
       <span :class="$style.indicatorText">{{ prodText ?? '-' }}</span>
     </td>
     <td v-if="showProd" :class="$style.buttonCell">
@@ -145,10 +152,10 @@ const warehouseStore = computed(() =>
       :class="[
         $style.indicatorCell,
         $style.clickable,
-        repairBgClass,
         (showBurn || showProd) && $style.groupSeparator,
       ]"
       @click="showBuffer(`XIT REP ${naturalId}`)">
+      <div :class="[$style.overlay, repairBgClass]" />
       <span :class="$style.indicatorText">{{ repairDaysText ?? '-' }}</span>
     </td>
     <td v-if="showRepair" :class="$style.buttonCell">
@@ -172,6 +179,8 @@ const warehouseStore = computed(() =>
 <style module>
 .planetCell {
   max-width: 30ch;
+  font-weight: bold;
+  font-size: 12px;
 }
 
 .planetLink {
@@ -212,13 +221,23 @@ const warehouseStore = computed(() =>
 }
 
 .indicatorCell {
+  position: relative;
   width: 0;
   white-space: nowrap;
   padding: 2px 4px;
   text-align: center;
 }
 
+.overlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .indicatorText {
+  position: relative;
   display: inline-block;
   min-width: 4ch;
 }

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -125,10 +125,10 @@ const warehouseStore = computed(() =>
         :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
         :class="burnBgClass" />
       <div :class="$style.burnContent">
+        <span :class="$style.daysNum">{{ daysText ?? '-' }}</span>
         <PrunButton dark inline @click.stop="showBuffer(`XIT BURNACT ${naturalId}`)">
           RESUPPLY
         </PrunButton>
-        <span :class="$style.daysNum">{{ daysText ?? '-' }}</span>
       </div>
     </td>
     <td v-if="showProd" :style="{ position: 'relative' }" :class="$style.prodCell">
@@ -152,10 +152,10 @@ const warehouseStore = computed(() =>
         :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
         :class="repairBgClass" />
       <div :class="$style.repairContent">
+        <span :class="$style.daysNum">{{ repairDaysText ?? '-' }}</span>
         <PrunButton dark inline @click.stop="showBuffer(`XIT REPAIRACT ${naturalId}`)">
           REP
         </PrunButton>
-        <span :class="$style.daysNum">{{ repairDaysText ?? '-' }}</span>
       </div>
     </td>
     <td :class="$style.invCell">

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -125,47 +125,34 @@ const warehouseStore = computed(() =>
     </td>
     <td
       v-if="showBurn"
-      :style="{ position: 'relative' }"
-      :class="$style.burnCell"
+      :class="[$style.indicatorCell, $style.clickable, burnBgClass]"
       @click="showBuffer(`XIT BURN ${naturalId}`)">
-      <div
-        v-if="daysText !== undefined"
-        :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
-        :class="burnBgClass" />
-      <div :class="$style.burnContent">
-        <span :class="$style.daysNum">{{ daysText ?? '-' }}</span>
-        <PrunButton dark inline @click.stop="showBuffer(`XIT BURNACT ${naturalId}`)">
-          RESUPPLY
-        </PrunButton>
-      </div>
+      <span :class="$style.indicatorText">{{ daysText ?? '-' }}</span>
     </td>
-    <td v-if="showProd" :style="{ position: 'relative' }" :class="$style.prodCell">
-      <template v-if="prodTotals">
-        <div
-          :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
-          :class="prodBgClass" />
-        <div :class="$style.prodContent">
-          <span :class="$style.daysNum">{{ prodText }}</span>
-          <PrunButton dark inline @click="showBuffer(`XIT PROD ${naturalId}`)">PROD</PrunButton>
-        </div>
-      </template>
-      <span v-else>-</span>
+    <td v-if="showBurn" :class="$style.buttonCell">
+      <PrunButton dark inline @click="showBuffer(`XIT BURNACT ${naturalId}`)">RES</PrunButton>
+    </td>
+    <td
+      v-if="showProd"
+      :class="[$style.indicatorCell, prodBgClass, showBurn && $style.groupSeparator]">
+      <span :class="$style.indicatorText">{{ prodText ?? '-' }}</span>
+    </td>
+    <td v-if="showProd" :class="$style.buttonCell">
+      <PrunButton dark inline @click="showBuffer(`XIT PROD ${naturalId}`)">PROD</PrunButton>
     </td>
     <td
       v-if="showRepair"
-      :style="{ position: 'relative' }"
-      :class="$style.repairCell"
+      :class="[
+        $style.indicatorCell,
+        $style.clickable,
+        repairBgClass,
+        (showBurn || showProd) && $style.groupSeparator,
+      ]"
       @click="showBuffer(`XIT REP ${naturalId}`)">
-      <div
-        v-if="repairDaysText !== undefined"
-        :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
-        :class="repairBgClass" />
-      <div :class="$style.repairContent">
-        <span :class="$style.daysNum">{{ repairDaysText ?? '-' }}</span>
-        <PrunButton dark inline @click.stop="showBuffer(`XIT REPAIRACT ${naturalId}`)">
-          REP
-        </PrunButton>
-      </div>
+      <span :class="$style.indicatorText">{{ repairDaysText ?? '-' }}</span>
+    </td>
+    <td v-if="showRepair" :class="$style.buttonCell">
+      <PrunButton dark inline @click="showBuffer(`XIT REPAIRACT ${naturalId}`)">REP</PrunButton>
     </td>
     <td :class="$style.invCell">
       <InvBar
@@ -220,61 +207,34 @@ const warehouseStore = computed(() =>
   display: flex;
 }
 
-.burnCell {
-  cursor: pointer;
-  width: 0;
-  white-space: nowrap;
-  padding: 2px 4px;
-  border-left: 2px solid #3fa2de;
-  border-right: 2px solid #3fa2de;
-}
-
 .row {
   border-bottom: 1px solid #2b485a;
 }
 
-.burnContent {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.daysNum {
-  display: inline-block;
-  min-width: 3ch;
-  text-align: right;
-}
-
-.prodCell {
+.indicatorCell {
   width: 0;
   white-space: nowrap;
   padding: 2px 4px;
   text-align: center;
 }
 
-.prodContent {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
+.indicatorText {
+  display: inline-block;
+  min-width: 4ch;
 }
 
-.repairCell {
-  cursor: pointer;
+.buttonCell {
   width: 0;
   white-space: nowrap;
   padding: 2px 4px;
-  border-left: 2px solid #3fa2de;
-  border-right: 2px solid #3fa2de;
 }
 
-.repairContent {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 4px;
+.clickable {
+  cursor: pointer;
+}
+
+.groupSeparator {
+  border-left: 1px solid #2b485a;
 }
 
 .invCell {

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -67,6 +67,14 @@ const prodBgClass = computed(() => {
   };
 });
 
+const prodText = computed(() => {
+  const totals = prodTotals.value;
+  if (!totals) {
+    return undefined;
+  }
+  return totals.orders >= totals.capacity ? '✓' : '∅';
+});
+
 const repairAge = computed(() => getPlanetRepairAge(siteId, timestampEachMinute.value));
 
 const repairBgClass = computed(() => {
@@ -137,6 +145,7 @@ const warehouseStore = computed(() =>
           :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
           :class="prodBgClass" />
         <div :class="$style.prodContent">
+          <span :class="$style.daysNum">{{ prodText }}</span>
           <PrunButton dark inline @click="showBuffer(`XIT PROD ${naturalId}`)">PROD</PrunButton>
         </div>
       </template>
@@ -249,6 +258,7 @@ const warehouseStore = computed(() =>
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
 }
 
 .repairCell {


### PR DESCRIPTION
## Summary

Refactored the XIT base station row layout to separate indicator cells (showing status with background colors) from action button cells. This improves visual clarity and maintainability by:

- Creating reusable `indicatorCell`, `overlay`, and `indicatorText` styles to eliminate duplication across burn, prod, and repair cells
- Splitting each indicator into two columns: one for the status display (clickable) and one for the action button
- Adding a `prodText` computed property to display production status as a checkmark (✓) or empty symbol (∅)
- Updating table headers to use `colspan="2"` for indicator groups with consistent styling
- Replacing hardcoded inline styles with semantic CSS classes
- Adding visual group separators between indicator groups using `groupSeparator` class

The layout now follows a consistent pattern: [Indicator Display] [Action Button] for each metric (Burn, Prod, Repair).

## Standards Checklist

- [x] No upward imports across layers
- [x] No explicit imports of auto-imported symbols
- [x] CSS rules scoped to commands where applicable
- [x] No `title=` attributes
- [x] Feature has single responsibility
- [x] CSS class names describe WHERE, not WHAT
- [x] CHANGELOG.md not modified

https://claude.ai/code/session_01HHRwRAagZmbMef4jUygynd