### PR TITLE
Enable CI workflow to run on all branches

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -2,7 +2,7 @@ name: Build Refined PrUn ZIP
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '**' ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Modified the build-extension workflow to run on all branches instead of only the main branch. This allows the CI pipeline to execute and validate changes on feature branches and pull requests.

## Changes

- Updated `.github/workflows/build-extension.yml` to trigger on all branches (`branches: [ '**' ]`) instead of just `main`

## Standards Checklist

- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] N/A - Configuration change only
- [x] CHANGELOG.md not modified

## Test Plan

N/A - Configuration change. CI workflow will automatically execute on next push to any branch.

https://claude.ai/code/session_01DEx9jHjqphrWEDDBkcUjJQ