### PR TITLE
XIT BS: redesign Burn/Prod/Repair as single colored status cells

### DIFF
--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -124,24 +124,17 @@ const bases = computed<BaseEntry[] | undefined>(() => {
           <th v-if="showCmds" :class="[$style.narrowCol, $style.centered]">CMD</th>
           <th
             v-if="showBurn"
-            colspan="2"
-            :class="[$style.narrowCol, $style.sortable, $style.centered, $style.sectionBottom]"
+            :class="[$style.narrowCol, $style.sortable, $style.centered]"
             @click="setSort('burn')">
             Burn
             <span :class="isSorted('burn') ? $style.sortActive : $style.sortInactive">{{
               getSortIndicator('burn')
             }}</span>
           </th>
-          <th
-            v-if="showProd"
-            colspan="2"
-            :class="[$style.narrowCol, $style.centered, $style.sectionBottom]">
-            Prod
-          </th>
+          <th v-if="showProd" :class="[$style.narrowCol, $style.centered]">Prod</th>
           <th
             v-if="showRepair"
-            colspan="2"
-            :class="[$style.narrowCol, $style.sortable, $style.centered, $style.sectionBottom]"
+            :class="[$style.narrowCol, $style.sortable, $style.centered]"
             @click="setSort('repair')">
             Repair
             <span :class="isSorted('repair') ? $style.sortActive : $style.sortInactive">{{
@@ -205,9 +198,5 @@ const bases = computed<BaseEntry[] | undefined>(() => {
 
 .sortInactive {
   color: rgb(63, 162, 222);
-}
-
-.sectionBottom {
-  border-bottom: 1px solid #ffc856;
 }
 </style>

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -132,15 +132,15 @@ const warehouseStore = computed(() =>
         <span :class="$style.statusNum" @click="showBuffer(`XIT BURN ${naturalId}`)">{{
           daysText ?? '-'
         }}</span>
-        <span :class="$style.statusLabel" @click="showBuffer(`XIT BURNACT ${naturalId}`)">RES</span>
+        <PrunButton dark inline @click="showBuffer(`XIT BURNACT ${naturalId}`)">RES</PrunButton>
       </div>
     </td>
     <td v-if="showProd" :class="$style.statusCell">
-      <div
-        :class="[$style.statusContent, prodBgClass]"
-        @click="showBuffer(`XIT PROD ${naturalId}`)">
-        <span :class="$style.statusNum">{{ prodText ?? '-' }}</span>
-        <span :class="$style.statusLabel">PROD</span>
+      <div :class="[$style.statusContent, prodBgClass]">
+        <span :class="$style.statusNum" @click="showBuffer(`XIT PROD ${naturalId}`)">{{
+          prodText ?? '-'
+        }}</span>
+        <PrunButton dark inline @click="showBuffer(`XIT PROD ${naturalId}`)">PROD</PrunButton>
       </div>
     </td>
     <td v-if="showRepair" :class="$style.statusCell">
@@ -148,7 +148,7 @@ const warehouseStore = computed(() =>
         <span :class="$style.statusNum" @click="showBuffer(`XIT REP ${naturalId}`)">{{
           repairDaysText ?? '-'
         }}</span>
-        <span :class="$style.statusLabel" @click="showBuffer(`XIT REPAIRACT ${naturalId}`)">REP</span>
+        <PrunButton dark inline @click="showBuffer(`XIT REPAIRACT ${naturalId}`)">REP</PrunButton>
       </div>
     </td>
     <td v-if="showInv" :class="$style.invCell">
@@ -243,10 +243,6 @@ const warehouseStore = computed(() =>
   padding: 2px 4px;
 }
 
-.statusLabel {
-  padding: 2px 4px;
-  border-left: 1px solid rgba(0, 0, 0, 0.25);
-}
 
 .invCell {
   min-width: 60px;

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -232,9 +232,10 @@ const warehouseStore = computed(() =>
 }
 
 .statusContent {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   cursor: pointer;
+  vertical-align: middle;
 }
 
 .statusNum {

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -127,47 +127,29 @@ const warehouseStore = computed(() =>
         <PrunButton dark inline @click="showBuffer(`EXP ${siteId}`)">EXPERTS</PrunButton>
       </div>
     </td>
-    <td
-      v-if="showBurn"
-      :class="[$style.indicatorCell, $style.clickable, $style.sectionLeft, $style.sectionBottom]"
-      @click="showBuffer(`XIT BURN ${naturalId}`)">
-      <div :class="[$style.overlay, burnBgClass]" />
-      <span :class="$style.indicatorText">{{ daysText ?? '-' }}</span>
+    <td v-if="showBurn" :class="$style.statusCell">
+      <div :class="[$style.statusContent, burnBgClass]">
+        <span :class="$style.statusNum" @click="showBuffer(`XIT BURN ${naturalId}`)">{{
+          daysText ?? '-'
+        }}</span>
+        <span :class="$style.statusLabel" @click="showBuffer(`XIT BURNACT ${naturalId}`)">RES</span>
+      </div>
     </td>
-    <td
-      v-if="showBurn"
-      :class="[
-        $style.buttonCell,
-        $style.sectionBottom,
-        !showProd && !showRepair && $style.sectionRight,
-      ]">
-      <PrunButton dark inline @click="showBuffer(`XIT BURNACT ${naturalId}`)">RES</PrunButton>
+    <td v-if="showProd" :class="$style.statusCell">
+      <div
+        :class="[$style.statusContent, prodBgClass]"
+        @click="showBuffer(`XIT PROD ${naturalId}`)">
+        <span :class="$style.statusNum">{{ prodText ?? '-' }}</span>
+        <span :class="$style.statusLabel">PROD</span>
+      </div>
     </td>
-    <td
-      v-if="showProd"
-      :class="[$style.indicatorCell, $style.clickable, $style.sectionLeft, $style.sectionBottom]"
-      @click="showBuffer(`XIT PROD ${naturalId}`)">
-      <div :class="[$style.overlay, prodBgClass]" />
-      <span :class="$style.indicatorText">{{ prodText ?? '-' }}</span>
-    </td>
-    <td
-      v-if="showProd"
-      :class="[
-        $style.buttonCell,
-        $style.sectionBottom,
-        !showRepair && $style.sectionRight,
-      ]">
-      <PrunButton dark inline @click="showBuffer(`XIT PROD ${naturalId}`)">PROD</PrunButton>
-    </td>
-    <td
-      v-if="showRepair"
-      :class="[$style.indicatorCell, $style.clickable, $style.sectionLeft, $style.sectionBottom]"
-      @click="showBuffer(`XIT REP ${naturalId}`)">
-      <div :class="[$style.overlay, repairBgClass]" />
-      <span :class="$style.indicatorText">{{ repairDaysText ?? '-' }}</span>
-    </td>
-    <td v-if="showRepair" :class="[$style.buttonCell, $style.sectionBottom, $style.sectionRight]">
-      <PrunButton dark inline @click="showBuffer(`XIT REPAIRACT ${naturalId}`)">REP</PrunButton>
+    <td v-if="showRepair" :class="$style.statusCell">
+      <div :class="[$style.statusContent, repairBgClass]">
+        <span :class="$style.statusNum" @click="showBuffer(`XIT REP ${naturalId}`)">{{
+          repairDaysText ?? '-'
+        }}</span>
+        <span :class="$style.statusLabel" @click="showBuffer(`XIT REPAIRACT ${naturalId}`)">REP</span>
+      </div>
     </td>
     <td v-if="showInv" :class="$style.invCell">
       <InvBar
@@ -243,48 +225,27 @@ const warehouseStore = computed(() =>
   border-bottom: 1px solid #2b485a;
 }
 
-.indicatorCell {
-  position: relative;
+.statusCell {
   width: 0;
   white-space: nowrap;
-  padding: 2px 4px;
-  text-align: center;
+  padding: 2px 3px;
 }
 
-.overlay {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.indicatorText {
-  position: relative;
-  display: inline-block;
-  min-width: 3ch;
-}
-
-.buttonCell {
-  width: 0;
-  white-space: nowrap;
-  padding: 2px 4px;
-}
-
-.clickable {
+.statusContent {
+  display: flex;
+  align-items: center;
   cursor: pointer;
 }
 
-.sectionLeft {
-  border-left: 1px solid #ffc856;
+.statusNum {
+  min-width: 3ch;
+  text-align: center;
+  padding: 2px 4px;
 }
 
-.sectionRight {
-  border-right: 1px solid #ffc856;
-}
-
-.sectionBottom {
-  border-bottom: 1px solid #ffc856;
+.statusLabel {
+  padding: 2px 4px;
+  border-left: 1px solid rgba(0, 0, 0, 0.25);
 }
 
 .invCell {

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -228,20 +228,21 @@ const warehouseStore = computed(() =>
 .statusCell {
   width: 0;
   white-space: nowrap;
-  padding: 2px 3px;
+  padding: 2px;
 }
 
 .statusContent {
   display: inline-flex;
   align-items: center;
+  gap: 2px;
   cursor: pointer;
   vertical-align: middle;
+  padding: 2px 4px;
 }
 
 .statusNum {
   min-width: 3ch;
   text-align: center;
-  padding: 2px 4px;
 }
 
 


### PR DESCRIPTION
## Summary

- Merges the indicator + button cell pair for Burn, Prod, and Repair into a single cell each
- Status background color (red/yellow/green) is applied to an `inline-flex` inner container, sized to content
- Uniform 2px transparent gap (td padding) surrounds the colored box on all sides
- Uniform 4px colored padding inside the box on left and right of content
- RES/PROD/REP retain their `PrunButton dark inline` styling on top of the colored background
- Removes all yellow (`#ffc856`) section borders from both header and data cells
- Headers updated from `colspan="2"` to single columns

## Click behaviour

| Column | Number click | Button click |
|--------|-------------|--------------|
| Burn | `XIT BURN` (detail) | `XIT BURNACT` (resupply) |
| Prod | `XIT PROD` | `XIT PROD` |
| Repair | `XIT REP` (detail) | `XIT REPAIRACT` (repair) |

https://claude.ai/code/session_01UUtD4MQhDag8B8tm5nuio4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUtD4MQhDag8B8tm5nuio4)_