### PR TITLE
XIT BS: add planet filter to filter bar

### DIFF
--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -106,13 +106,15 @@ const bases = computed<BaseEntry[] | undefined>(() => {
 
 const filteredBases = computed(() => {
   const all = bases.value;
-  if (!all) return undefined;
+  if (!all) {
+    return undefined;
+  }
   const filter = planetFilter.value.trim().toUpperCase();
-  if (!filter) return all;
+  if (!filter) {
+    return all;
+  }
   return all.filter(
-    x =>
-      x.naturalId.toUpperCase().includes(filter) ||
-      x.planetName.toUpperCase().includes(filter),
+    x => x.naturalId.toUpperCase().includes(filter) || x.planetName.toUpperCase().includes(filter),
   );
 });
 </script>

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
 import RadioItem from '@src/components/forms/RadioItem.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import PrunButton from '@src/components/PrunButton.vue';
 import BaseRow from '@src/features/XIT/BS/BaseRow.vue';
+import fa from '@src/utils/font-awesome.module.css';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import {
@@ -26,6 +29,7 @@ const showProd = useTileState('showProd', true);
 const showRepair = useTileState('showRepair', true);
 const showInv = useTileState('showInv', true);
 const showWar = useTileState('showWar', true);
+const planetFilter = ref('');
 
 function setSort(key: SortKey) {
   if (sortKey.value === key) {
@@ -99,6 +103,18 @@ const bases = computed<BaseEntry[] | undefined>(() => {
 
   return entries;
 });
+
+const filteredBases = computed(() => {
+  const all = bases.value;
+  if (!all) return undefined;
+  const filter = planetFilter.value.trim().toUpperCase();
+  if (!filter) return all;
+  return all.filter(
+    x =>
+      x.naturalId.toUpperCase().includes(filter) ||
+      x.planetName.toUpperCase().includes(filter),
+  );
+});
 </script>
 
 <template>
@@ -111,6 +127,18 @@ const bases = computed<BaseEntry[] | undefined>(() => {
       <RadioItem v-model="showRepair" horizontal>Repair</RadioItem>
       <RadioItem v-model="showInv" horizontal>Inv</RadioItem>
       <RadioItem v-model="showWar" horizontal>War</RadioItem>
+      <div :class="$style.spacer" />
+      <div :class="$style.searchContainer">
+        Planet:&nbsp;
+        <TextInput v-model="planetFilter" />
+        <PrunButton
+          v-if="planetFilter"
+          dark
+          :class="[fa.solid, $style.clearButton]"
+          @click="planetFilter = ''">
+          {{ '' }}
+        </PrunButton>
+      </div>
     </div>
     <table :class="$style.table">
       <thead>
@@ -147,7 +175,7 @@ const bases = computed<BaseEntry[] | undefined>(() => {
       </thead>
       <tbody>
         <BaseRow
-          v-for="base in bases"
+          v-for="base in filteredBases"
           :key="base.naturalId"
           :site-id="base.siteId"
           :natural-id="base.naturalId"
@@ -198,5 +226,24 @@ const bases = computed<BaseEntry[] | undefined>(() => {
 
 .sortInactive {
   color: rgb(63, 162, 222);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.searchContainer {
+  display: flex;
+  align-items: center;
+}
+
+.clearButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 2px;
+  width: 18px;
+  height: 18px;
+  font-size: 11px;
 }
 </style>

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -237,6 +237,18 @@ const filteredBases = computed(() => {
   align-items: center;
 }
 
+.searchContainer input {
+  background-color: #42361d;
+  border-width: 0 0 1px;
+  border-bottom: 1px solid #8d6411;
+  color: #cccccc;
+  padding: 0 5px;
+
+  &:focus {
+    outline: none;
+  }
+}
+
 .clearButton {
   display: flex;
   justify-content: center;

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -259,7 +259,6 @@ const warehouseStore = computed(() =>
   text-align: center;
 }
 
-
 .invCell {
   min-width: 60px;
   padding: 2px;


### PR DESCRIPTION
## Summary

- Adds a `Planet:` text input to the right of the XIT BS filter bar (pushed right via a flex spacer, same pattern as BURN's copy button)
- Filters rows in real time as you type, matching case-insensitively against both the planet natural ID (e.g. `OT-580b`) and full name (e.g. `Promitor`)
- Shows a × clear button (Font Awesome, same style as cx-search-bar) when the field has text
- Input styled with the standard PrUn orange background (`#42361d` / `#8d6411` border), matching `inv-search` and the game's native input fields

## Test plan

- [ ] Open `XIT BS` and confirm the filter input appears at the top right of the filter bar
- [ ] Type a partial planet name — only matching rows should remain visible
- [ ] Type a partial natural ID — matching rows should appear
- [ ] Clear with the × button — all rows return
- [ ] Confirm the input background matches the orange of other PrUn inputs (e.g. REP age threshold)
- [ ] Confirm column toggles (Cmds, Burn, Prod, etc.) still work normally

https://claude.ai/code/session_016GfZijE8nR5jUJwB5kT5c4

---
_Generated by [Claude Code](https://claude.ai/code/session_016GfZijE8nR5jUJwB5kT5c4)_