### PR TITLE
XIT BS: tighten Repair column spacing

### DIFF
--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -166,7 +166,7 @@ const filteredBases = computed(() => {
             v-if="showRepair"
             :class="[$style.narrowCol, $style.sortable, $style.centered]"
             @click="setSort('repair')">
-            Repair
+            Rep
             <span :class="isSorted('repair') ? $style.sortActive : $style.sortInactive">{{
               getSortIndicator('repair')
             }}</span>

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -243,6 +243,7 @@ const warehouseStore = computed(() =>
   width: 0;
   white-space: nowrap;
   padding: 2px;
+  text-align: center;
 }
 
 .statusContent {


### PR DESCRIPTION
## Summary
- Center status cell content so any column slack is split evenly on both sides instead of pooling on the right.
- Shorten the Repair column header to "Rep" so it no longer forces the column wider than the body content (matches the REP button and the XIT REP command).
- Visibility toggle radio in the filter bar still reads "Repair" (descriptive label for the on/off control).

## Test plan
- [ ] Open XIT BS — Burn, Prod, and Rep columns visually consistent in width.
- [ ] Colored status cells sit centered in their td, with even gaps on both sides.
- [ ] Sorting still works on the Rep column (click header toggles asc/desc, indicator updates).
- [ ] Toggling the "Repair" radio in the filter bar shows/hides the Rep column.

https://claude.ai/code/session_01KSiBLMDDBbGQZVTmdRe65V

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSiBLMDDBbGQZVTmdRe65V)_