### PR TITLE
XIT BS: fix CMDS button hover — don't cover planet name, hide sibling cell contents

### DIFF
--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -208,10 +208,10 @@ const warehouseStore = computed(() =>
   display: none;
   position: absolute;
   top: 0;
-  left: -500px;
-  right: -500px;
+  left: 0;
+  right: -9999px;
   height: 100%;
-  background: black;
+  background: #222e31;
   z-index: 9;
 }
 

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -209,6 +209,7 @@ onMounted(() => {
 
 .cmdCell {
   position: relative;
+  z-index: 1;
   overflow: visible;
   white-space: nowrap;
   width: 0;

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -122,20 +122,10 @@ const warehouseStore = computed(() =>
     .getByAddressableId(warehouse.value?.warehouseId)
     ?.find(x => x.type === 'WAREHOUSE_STORE'),
 );
-
-const rowEl = ref<HTMLElement | null>(null);
-const overlayBg = ref('transparent');
-
-onMounted(() => {
-  const tileBody = rowEl.value?.closest(`.${C.TileFrame.body}`);
-  if (tileBody) {
-    overlayBg.value = getComputedStyle(tileBody).backgroundColor;
-  }
-});
 </script>
 
 <template>
-  <tr :class="$style.row" ref="rowEl">
+  <tr :class="$style.row">
     <td
       :class="$style.planetCell"
       @contextmenu.prevent="planetContextMenu.showMenu($event, naturalId)">
@@ -145,7 +135,6 @@ onMounted(() => {
     </td>
     <td v-if="showCmds" :class="$style.cmdCell">
       <PrunButton dark inline>CMDS&#x25B6;</PrunButton>
-      <div :class="$style.rowOverlay" :style="{ background: overlayBg }" />
       <div :class="$style.expandedButtons">
         <PrunButton dark inline @click="showBuffer(`BBL ${siteId}`)">BUILDINGS</PrunButton>
         <PrunButton dark inline @click="showBuffer(`BBC ${naturalId}`)">CONSTRUCT</PrunButton>
@@ -209,24 +198,9 @@ onMounted(() => {
 
 .cmdCell {
   position: relative;
-  z-index: 1;
   overflow: visible;
   white-space: nowrap;
   width: 0;
-}
-
-.rowOverlay {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: -9999px;
-  height: 100%;
-  z-index: 9;
-}
-
-.cmdCell:hover .rowOverlay {
-  display: block;
 }
 
 .expandedButtons {
@@ -245,6 +219,11 @@ onMounted(() => {
 
 .cmdCell:hover .expandedButtons {
   display: flex;
+}
+
+.row:has(.cmdCell:hover) .statusCell > *,
+.row:has(.cmdCell:hover) .invCell > * {
+  visibility: hidden;
 }
 
 .row {

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -122,10 +122,20 @@ const warehouseStore = computed(() =>
     .getByAddressableId(warehouse.value?.warehouseId)
     ?.find(x => x.type === 'WAREHOUSE_STORE'),
 );
+
+const rowEl = ref<HTMLElement | null>(null);
+const overlayBg = ref('transparent');
+
+onMounted(() => {
+  const tileBody = rowEl.value?.closest(`.${C.TileFrame.body}`);
+  if (tileBody) {
+    overlayBg.value = getComputedStyle(tileBody).backgroundColor;
+  }
+});
 </script>
 
 <template>
-  <tr :class="$style.row">
+  <tr :class="$style.row" ref="rowEl">
     <td
       :class="$style.planetCell"
       @contextmenu.prevent="planetContextMenu.showMenu($event, naturalId)">
@@ -135,7 +145,7 @@ const warehouseStore = computed(() =>
     </td>
     <td v-if="showCmds" :class="$style.cmdCell">
       <PrunButton dark inline>CMDS&#x25B6;</PrunButton>
-      <div :class="$style.rowOverlay" />
+      <div :class="$style.rowOverlay" :style="{ background: overlayBg }" />
       <div :class="$style.expandedButtons">
         <PrunButton dark inline @click="showBuffer(`BBL ${siteId}`)">BUILDINGS</PrunButton>
         <PrunButton dark inline @click="showBuffer(`BBC ${naturalId}`)">CONSTRUCT</PrunButton>
@@ -211,7 +221,6 @@ const warehouseStore = computed(() =>
   left: 0;
   right: -9999px;
   height: 100%;
-  background: #222e31;
   z-index: 9;
 }
 


### PR DESCRIPTION
## Summary

- On CMDS hover, the overlay no longer covers the planet name cell (was extending 500px to the left)
- Replaced the solid-color overlay div with a CSS `:has()` rule that sets `visibility: hidden` on the direct children of `statusCell` and `invCell` — cells become transparent (naturally showing the tile background) rather than requiring a hardcoded or dynamically-read color
- Removed all JS plumbing: `rowEl` ref, `overlayBg` ref, `onMounted` background-reading logic

## Test plan

- [ ] Open XIT BS
- [ ] Mouse over the CMDS button on any row — burn/prod/repair/inv/war contents should disappear, planet name should remain visible, expanded buttons should appear
- [ ] Mouse off — all cell contents should reappear normally
- [ ] Verify with all column toggles on (Burn, Prod, Repair, Inv, War)
- [ ] Verify with some columns toggled off

https://claude.ai/code/session_016F2xM3sMmoJnK1J1wQi1bX

---
_Generated by [Claude Code](https://claude.ai/code/session_016F2xM3sMmoJnK1J1wQi1bX)_