### PR TITLE
XIT PROD: fix PRODQ/PRODCO links using full UUID instead of short ID

### DIFF
--- a/src/features/XIT/PROD/ProductionRow.vue
+++ b/src/features/XIT/PROD/ProductionRow.vue
@@ -83,8 +83,8 @@ const tooltipText = computed(() => tooltipLines.value.join('\n'));
     <FracCell :numerator="activeOrders" :denominator="capacity" />
     <td>
       <div :class="$style.buttons">
-        <PrunButton dark inline @click="showBuffer(`PRODCO ${productionLine.id}`)">CO</PrunButton>
-        <PrunButton dark inline @click="showBuffer(`PRODQ ${productionLine.id}`)">Q</PrunButton>
+        <PrunButton dark inline @click="showBuffer(`PRODCO ${productionLine.id.substring(0, 8)}`)">CO</PrunButton>
+        <PrunButton dark inline @click="showBuffer(`PRODQ ${productionLine.id.substring(0, 8)}`)">Q</PrunButton>
       </div>
     </td>
   </tr>


### PR DESCRIPTION
## Summary

- `ProductionRow.vue` was calling `showBuffer(`PRODQ ${productionLine.id}`)` with the full UUID (e.g. `6b845e44048447d060c9fd5f8bf7dfd3`), but the game expects the 8-character short ID (e.g. `6b845e44`)
- This caused cancel-order buttons inside the opened PRODQ buffer to fail
- Same bug affected the CO button (`PRODCO`)
- Fix: append `.substring(0, 8)` to `productionLine.id` on both buttons, consistent with every other ID-based buffer link in the codebase

## Test plan

- [ ] Open XIT PROD, find a building row, click Q — verify it opens `PRODQ <8-char-id>`
- [ ] Inside the opened PRODQ buffer, cancel an existing order — verify cancellation succeeds
- [ ] Click CO on a building row — verify it opens `PRODCO <8-char-id>` correctly

https://claude.ai/code/session_013sPR5UNYSrnguUCXmAcNjW

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPR5UNYSrnguUCXmAcNjW)_