### PR TITLE
fix(inv-analysis-button): prevent after-resupply tooltip from overflowing buffer edge

### DIFF
--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -31,13 +31,6 @@ const COLUMN_AFTER_RESUPPLY_TOOLTIP =
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
 const projectedStore = computed(() => buildProjectedStore(analysis.siteId));
 
-// The after-resupply bar is the rightmost column. When column tooltips are
-// shown with 'top' position (panel context), center-above overflows the right
-// buffer edge. 'left' keeps the tooltip within the buffer.
-const afterResupplyTooltipPos = computed(() =>
-  showColumnTooltips && tooltipPosition === 'top' ? 'left' : (tooltipPosition ?? 'bottom'),
-);
-
 const stripeClass = computed(() => {
   if (analysis.needFillRatio === 0) {
     return undefined;
@@ -140,9 +133,9 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="$style.colBg"
+        :class="[$style.colBg, $style.rightAlignedTooltip]"
         :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
-        :data-tooltip-position="afterResupplyTooltipPos">
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
         <CargoBar :store="projectedStore" disable-mini-mode />
       </div>
       <CargoBar v-else :store="projectedStore" disable-mini-mode />
@@ -232,5 +225,16 @@ const supplyClass = computed(() => {
   display: block;
   position: relative;
   z-index: 1;
+}
+
+/* Right-aligns the tooltip box so it doesn't overflow the right buffer edge.
+   The game centers 'top' tooltips via left:50%+translateX(-50%); overriding
+   to right:0 anchors the box's right edge to the element's right edge. */
+.rightAlignedTooltip {
+  &::before {
+    left: auto;
+    right: 0;
+    transform: translateX(0);
+  }
 }
 </style>

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -23,12 +23,20 @@ const COLUMN_LIMIT_TOOLTIP =
   'Days until storage is full at the current net production rate — when a ship visit is forced.';
 const COLUMN_SUPPLY_TOOLTIP =
   'Total days of consumables the base could hold when storage is filled to its threshold after ship-out (80% when filling, 95% when draining). Colors match XIT BURN: red below your red threshold, yellow below your yellow threshold.';
-const COLUMN_CURRENT_FILL_TOOLTIP = "What's in base storage right now. Colored by material category.";
+const COLUMN_CURRENT_FILL_TOOLTIP =
+  "What's in base storage right now. Colored by material category.";
 const COLUMN_AFTER_RESUPPLY_TOOLTIP =
   'Projected storage if all produced goods were shipped out and all consumables delivered up to their XIT BURN Need amount. Red hatching shows overflow past capacity.';
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
 const projectedStore = computed(() => buildProjectedStore(analysis.siteId));
+
+// The after-resupply bar is the rightmost column. When column tooltips are
+// shown with 'top' position (panel context), center-above overflows the right
+// buffer edge. 'left' keeps the tooltip within the buffer.
+const afterResupplyTooltipPos = computed(() =>
+  showColumnTooltips && tooltipPosition === 'top' ? 'left' : (tooltipPosition ?? 'bottom'),
+);
 
 const stripeClass = computed(() => {
   if (analysis.needFillRatio === 0) {
@@ -90,7 +98,10 @@ const supplyClass = computed(() => {
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
-      <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <span
+        v-else
+        :data-tooltip="limitTooltip"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
@@ -105,7 +116,10 @@ const supplyClass = computed(() => {
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
-      <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <span
+        v-else
+        :data-tooltip="supplyTooltip"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>
@@ -128,7 +142,7 @@ const supplyClass = computed(() => {
         v-if="showColumnTooltips"
         :class="$style.colBg"
         :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
-        :data-tooltip-position="tooltipPosition ?? 'bottom'">
+        :data-tooltip-position="afterResupplyTooltipPos">
         <CargoBar :store="projectedStore" disable-mini-mode />
       </div>
       <CargoBar v-else :store="projectedStore" disable-mini-mode />

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -10,7 +10,9 @@ import StoSummaryPanel from './StoSummaryPanel.vue';
 
 async function onTileReady(tile: PrunTile) {
   const store = computed(() => getInvStore(tile.parameter));
-  const site = computed(() => (store.value ? sitesStore.getById(store.value.addressableId) : undefined));
+  const site = computed(() =>
+    store.value ? sitesStore.getById(store.value.addressableId) : undefined,
+  );
   const naturalId = computed(() =>
     site.value ? getEntityNaturalIdFromAddress(site.value.address) : undefined,
   );
@@ -20,7 +22,9 @@ async function onTileReady(tile: PrunTile) {
   let panelShown = false;
 
   createFragmentApp(() => {
-    if (!naturalId.value) return null;
+    if (!naturalId.value) {
+      return null;
+    }
     return (
       <button
         class={[C.Button.btn, C.Button.primary]}
@@ -38,7 +42,9 @@ async function onTileReady(tile: PrunTile) {
 
 function showPanel(tile: PrunTile, naturalId: string) {
   const storeContainer = _$(tile.anchor, C.StoreView.container) as HTMLElement | null;
-  if (!storeContainer) return;
+  if (!storeContainer) {
+    return;
+  }
 
   // Make anchor a flex column so the panel sits below the store view.
   tile.anchor.style.display = 'flex';
@@ -64,8 +70,10 @@ function showPanel(tile: PrunTile, naturalId: string) {
 
   // Grow a solo floating buffer so the panel doesn't cover existing content.
   if (tile.container.classList.contains(C.Window.body)) {
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     let prevPanelHeight = 0;
     ro = new ResizeObserver(() => {
       const panelHeight = panelWrapper.offsetHeight;
@@ -84,14 +92,18 @@ async function openAnalysis(tile: PrunTile, naturalId: string) {
 
   if (tile.container.classList.contains(C.Window.body)) {
     // Solo floating buffer: resize taller and split vertically.
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     setBufferSize(tile.id, w, h + 450);
 
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '–');
     await clickElement(splitButton);
 
-    if (!windowEl) return;
+    if (!windowEl) {
+      return;
+    }
 
     const node = await $(windowEl, C.Node.node);
     const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
@@ -110,7 +122,9 @@ async function openAnalysis(tile: PrunTile, naturalId: string) {
 
 async function setChildCommand(child: Element, command: string) {
   const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
-  if (!tileEl) return;
+  if (!tileEl) {
+    return;
+  }
 
   const id = getPrunId(tileEl)!;
   const message = UI_TILES_CHANGE_COMMAND(id, command);
@@ -125,4 +139,8 @@ function init() {
   tiles.observe('INV', onTileReady);
 }
 
-features.add(import.meta.url, init, 'INV: Adds an Analysis button that shows an XIT STO summary pane, expandable to a full companion buffer.');
+features.add(
+  import.meta.url,
+  init,
+  'INV: Adds an Analysis button that shows an XIT STO summary pane, expandable to a full companion buffer.',
+);


### PR DESCRIPTION
## Summary

- The after-resupply cargo bar is the rightmost column in the `StoSummaryPanel`. With `data-tooltip-position="top"`, the game centers the tooltip box above the element via `left: 50%; transform: translateX(-50%)`, which causes it to overflow the right buffer edge.
- Adds `.rightAlignedTooltip` CSS class to that column's `colBg` div, overriding to `left: auto; right: 0; transform: translateX(0)` so the tooltip's right edge anchors to the element's right edge and the box extends leftward into the buffer.

## Test plan

- [ ] Open an INV buffer for a planet where you have a base
- [ ] Click "Analysis - XIT STO" — panel should appear below the inventory
- [ ] Hover the after-resupply (rightmost) cargo bar — tooltip should appear to the left, within buffer bounds
- [ ] Hover the other columns (days till full, supply days, current fill) — tooltips should appear above as before
- [ ] Click the planet name to expand to full XIT STO companion buffer — should still work

https://claude.ai/code/session_01B5DzjQbBwvyFw9jMXo2VbV

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5DzjQbBwvyFw9jMXo2VbV)_