### PR TITLE
feat(inv-analysis-button): Add XIT STO summary panel to INV buffers

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -387,6 +387,93 @@ import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 showBuffer('CXM AI1.RAT');  // opens a buffer with the given command
 ```
 
+### Companion Buffers (Splitting)
+
+To split a tile and set a companion command, click the tile's split button then wait for the node and change the companion's command.
+
+Split button characters (found via `C.TileControls.control`):
+- `'–'` (en-dash) = vertical split (top / bottom)
+- `'|'` = horizontal split (left / right)
+
+**Important:** `tile.frame` may be destroyed after a split. Capture `windowEl` and read `tile.container` / `tile.id` *before* clicking.
+
+```ts
+import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+
+async function splitVertically(tile: PrunTile, companionCommand: string) {
+  // Capture window reference before the split destroys tile.frame.
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    // Solo floating buffer: make taller, then split.
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    setBufferSize(tile.id, w, h + 450);
+
+    const splitBtn = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '–');
+    await clickElement(splitBtn);
+
+    // MutationObserver waits for the Node to appear after the split.
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1]; // new tile is always the second child
+    if (companion) await setTileCommand(companion, companionCommand);
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    // Already in a split: reuse the sibling.
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) await setTileCommand(sibling, companionCommand);
+  }
+}
+
+async function setTileCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) return;
+  const id = getPrunId(tileEl)!;
+  if (!dispatchClientPrunMessage(UI_TILES_CHANGE_COMMAND(id, command))) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
+}
+```
+
+See also `src/features/XIT/ACT/runner/tile-allocator.ts` for the full horizontal-split companion pattern used by ACT.
+
+---
+
+## Context Controls
+
+All tiles have a `C.ContextControls.container` element. Add items to it via `$(tile.frame, C.ContextControls.container)`.
+
+For items that simply open a buffer, use the existing `ContextControlsItem` component:
+
+```ts
+import ContextControlsItem from '@src/components/ContextControlsItem.vue';
+
+const contextBar = await $(tile.frame, C.ContextControls.container);
+createFragmentApp(ContextControlsItem, { cmd: 'XIT BURN OT-580b' }).prependTo(contextBar);
+```
+
+For items with custom `onClick` behavior, use inline TSX with the same CSS classes:
+
+```tsx
+const contextBar = await $(tile.frame, C.ContextControls.container);
+createFragmentApp(() => (
+  <div
+    class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+    onClick={() => doSomething()}>
+    <span>
+      <span class={C.ContextControls.cmd}>Label</span>
+      {' - subtitle'}
+    </span>
+  </div>
+)).prependTo(contextBar);
+```
+
 ---
 
 ## CSS

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -31,13 +31,6 @@ const COLUMN_AFTER_RESUPPLY_TOOLTIP =
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
 const projectedStore = computed(() => buildProjectedStore(analysis.siteId));
 
-// The after-resupply bar is the rightmost column. When column tooltips are
-// shown with 'top' position (panel context), center-above overflows the right
-// buffer edge. 'left' keeps the tooltip within the buffer.
-const afterResupplyTooltipPos = computed(() =>
-  showColumnTooltips && tooltipPosition === 'top' ? 'left' : (tooltipPosition ?? 'bottom'),
-);
-
 const stripeClass = computed(() => {
   if (analysis.needFillRatio === 0) {
     return undefined;
@@ -140,9 +133,9 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="$style.colBg"
+        :class="[$style.colBg, $style.rightAlignedTooltip]"
         :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
-        :data-tooltip-position="afterResupplyTooltipPos">
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
         <CargoBar :store="projectedStore" disable-mini-mode />
       </div>
       <CargoBar v-else :store="projectedStore" disable-mini-mode />
@@ -232,5 +225,16 @@ const supplyClass = computed(() => {
   display: block;
   position: relative;
   z-index: 1;
+}
+
+/* Right-aligns the tooltip box so it doesn't overflow the right buffer edge.
+   The game centers 'top' tooltips via left:50%+translateX(-50%); overriding
+   to right:0 anchors the box's right edge to the element's right edge. */
+.rightAlignedTooltip {
+  &::before {
+    left: auto;
+    right: 0;
+    transform: translateX(0);
+  }
 }
 </style>

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -15,7 +15,13 @@ const { analysis } = defineProps<{
   onClick: () => void;
   tooltipPosition?: string;
   hideButtons?: boolean;
+  showColumnTooltips?: boolean;
 }>();
+
+const COLUMN_LIMIT_TOOLTIP =
+  'Days until storage is full at the current net production rate — when a ship visit is forced.';
+const COLUMN_SUPPLY_TOOLTIP =
+  'Total days of consumables the base could hold when storage is filled to its threshold after ship-out (80% when filling, 95% when draining). Colors match XIT BURN: red below your red threshold, yellow below your yellow threshold.';
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
 const projectedStore = computed(() => buildProjectedStore(analysis.siteId));
@@ -70,12 +76,20 @@ const supplyClass = computed(() => {
       </span>
       <span>{{ analysis.planetName }}</span>
     </td>
-    <td :class="$style.clickable" @click="onClick">
+    <td
+      :class="$style.clickable"
+      :data-tooltip="showColumnTooltips ? COLUMN_LIMIT_TOOLTIP : undefined"
+      :data-tooltip-position="showColumnTooltips ? (tooltipPosition ?? 'bottom') : undefined"
+      @click="onClick">
       <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
-    <td :class="[$style.clickable, $style.supplyCell]" @click="onClick">
+    <td
+      :class="[$style.clickable, $style.supplyCell]"
+      :data-tooltip="showColumnTooltips ? COLUMN_SUPPLY_TOOLTIP : undefined"
+      :data-tooltip-position="showColumnTooltips ? (tooltipPosition ?? 'bottom') : undefined"
+      @click="onClick">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
       <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -4,8 +4,6 @@ import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { userData } from '@src/store/user-data';
 import PrunButton from '@src/components/PrunButton.vue';
 import CargoBar from '@src/components/CargoBar.vue';
-import InlineFlex from '@src/components/InlineFlex.vue';
-import Tooltip, { TooltipPosition } from '@src/components/Tooltip.vue';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { fillRatioClass, formatDays, formatDaysCompact } from '@src/features/XIT/STO/utils';
 import { fixed01 } from '@src/utils/format';
@@ -15,9 +13,8 @@ const { analysis } = defineProps<{
   hasMinimize?: boolean;
   minimized?: boolean;
   onClick: () => void;
-  tooltipPosition?: TooltipPosition;
+  tooltipPosition?: string;
   hideButtons?: boolean;
-  showTooltipIcons?: boolean;
 }>();
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
@@ -74,21 +71,13 @@ const supplyClass = computed(() => {
       <span>{{ analysis.planetName }}</span>
     </td>
     <td :class="$style.clickable" @click="onClick">
-      <InlineFlex v-if="showTooltipIcons">
-        <span>{{ formatDays(analysis.daysUntilFull) }}</span>
-        <Tooltip :position="tooltipPosition ?? 'bottom'" :tooltip="limitTooltip" />
-      </InlineFlex>
-      <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
     <td :class="[$style.clickable, $style.supplyCell]" @click="onClick">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
-      <InlineFlex v-if="showTooltipIcons">
-        <span>{{ formatDaysCompact(analysis.daysOfSuppliesFit) }}</span>
-        <Tooltip :position="tooltipPosition ?? 'bottom'" :tooltip="supplyTooltip" />
-      </InlineFlex>
-      <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -13,6 +13,7 @@ const { analysis } = defineProps<{
   hasMinimize?: boolean;
   minimized?: boolean;
   onClick: () => void;
+  tooltipPosition?: string;
 }>();
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
@@ -69,13 +70,13 @@ const supplyClass = computed(() => {
       <span>{{ analysis.planetName }}</span>
     </td>
     <td :class="$style.clickable" @click="onClick">
-      <span :data-tooltip="limitTooltip" data-tooltip-position="bottom">
+      <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
     <td :class="[$style.clickable, $style.supplyCell]" @click="onClick">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
-      <span :data-tooltip="supplyTooltip" data-tooltip-position="bottom">
+      <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -23,12 +23,20 @@ const COLUMN_LIMIT_TOOLTIP =
   'Days until storage is full at the current net production rate — when a ship visit is forced.';
 const COLUMN_SUPPLY_TOOLTIP =
   'Total days of consumables the base could hold when storage is filled to its threshold after ship-out (80% when filling, 95% when draining). Colors match XIT BURN: red below your red threshold, yellow below your yellow threshold.';
-const COLUMN_CURRENT_FILL_TOOLTIP = "What's in base storage right now. Colored by material category.";
+const COLUMN_CURRENT_FILL_TOOLTIP =
+  "What's in base storage right now. Colored by material category.";
 const COLUMN_AFTER_RESUPPLY_TOOLTIP =
   'Projected storage if all produced goods were shipped out and all consumables delivered up to their XIT BURN Need amount. Red hatching shows overflow past capacity.';
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
 const projectedStore = computed(() => buildProjectedStore(analysis.siteId));
+
+// The after-resupply bar is the rightmost column. When column tooltips are
+// shown with 'top' position (panel context), center-above overflows the right
+// buffer edge. 'left' keeps the tooltip within the buffer.
+const afterResupplyTooltipPos = computed(() =>
+  showColumnTooltips && tooltipPosition === 'top' ? 'left' : (tooltipPosition ?? 'bottom'),
+);
 
 const stripeClass = computed(() => {
   if (analysis.needFillRatio === 0) {
@@ -90,7 +98,10 @@ const supplyClass = computed(() => {
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
-      <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <span
+        v-else
+        :data-tooltip="limitTooltip"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
@@ -105,7 +116,10 @@ const supplyClass = computed(() => {
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
-      <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <span
+        v-else
+        :data-tooltip="supplyTooltip"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>
@@ -128,7 +142,7 @@ const supplyClass = computed(() => {
         v-if="showColumnTooltips"
         :class="$style.colBg"
         :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
-        :data-tooltip-position="tooltipPosition ?? 'bottom'">
+        :data-tooltip-position="afterResupplyTooltipPos">
         <CargoBar :store="projectedStore" disable-mini-mode />
       </div>
       <CargoBar v-else :store="projectedStore" disable-mini-mode />

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -14,6 +14,7 @@ const { analysis } = defineProps<{
   minimized?: boolean;
   onClick: () => void;
   tooltipPosition?: string;
+  hideButtons?: boolean;
 }>();
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
@@ -86,7 +87,7 @@ const supplyClass = computed(() => {
     <td :class="[$style.clickable, $style.barCell]" @click="onClick">
       <CargoBar :store="projectedStore" disable-mini-mode />
     </td>
-    <td>
+    <td v-if="!hideButtons">
       <div :class="$style.buttons">
         <PrunButton dark inline @click="showBuffer(`BS ${analysis.naturalId}`)">BS</PrunButton>
         <PrunButton dark inline @click="showBuffer(`INV ${analysis.storeId.substring(0, 8)}`)">

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -81,23 +81,21 @@ const supplyClass = computed(() => {
       <span>{{ analysis.planetName }}</span>
     </td>
     <td
-      :class="[$style.clickable, $style.noWrap]"
+      :class="[!planetOnlyClick && $style.clickable, $style.noWrap]"
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
         :class="$style.colBg"
         :data-tooltip="COLUMN_LIMIT_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
-        <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
-          {{ formatDays(analysis.daysUntilFull) }}
-        </span>
+        {{ formatDays(analysis.daysUntilFull) }}
       </div>
       <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
     <td
-      :class="[$style.clickable, $style.supplyCell, $style.noWrap]"
+      :class="[!planetOnlyClick && $style.clickable, $style.supplyCell, $style.noWrap]"
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
       <div
@@ -105,16 +103,14 @@ const supplyClass = computed(() => {
         :class="$style.colBg"
         :data-tooltip="COLUMN_SUPPLY_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
-        <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
-          {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
-        </span>
+        {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </div>
       <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>
     <td
-      :class="[$style.clickable, $style.barCell]"
+      :class="[!planetOnlyClick && $style.clickable, $style.barCell]"
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
@@ -126,7 +122,7 @@ const supplyClass = computed(() => {
       <CargoBar v-else :store="currentStore" disable-mini-mode />
     </td>
     <td
-      :class="[$style.clickable, $style.barCell]"
+      :class="[!planetOnlyClick && $style.clickable, $style.barCell]"
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -4,6 +4,8 @@ import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { userData } from '@src/store/user-data';
 import PrunButton from '@src/components/PrunButton.vue';
 import CargoBar from '@src/components/CargoBar.vue';
+import InlineFlex from '@src/components/InlineFlex.vue';
+import Tooltip, { TooltipPosition } from '@src/components/Tooltip.vue';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { fillRatioClass, formatDays, formatDaysCompact } from '@src/features/XIT/STO/utils';
 import { fixed01 } from '@src/utils/format';
@@ -13,8 +15,9 @@ const { analysis } = defineProps<{
   hasMinimize?: boolean;
   minimized?: boolean;
   onClick: () => void;
-  tooltipPosition?: string;
+  tooltipPosition?: TooltipPosition;
   hideButtons?: boolean;
+  showTooltipIcons?: boolean;
 }>();
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
@@ -71,13 +74,21 @@ const supplyClass = computed(() => {
       <span>{{ analysis.planetName }}</span>
     </td>
     <td :class="$style.clickable" @click="onClick">
-      <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <InlineFlex v-if="showTooltipIcons">
+        <span>{{ formatDays(analysis.daysUntilFull) }}</span>
+        <Tooltip :position="tooltipPosition ?? 'bottom'" :tooltip="limitTooltip" />
+      </InlineFlex>
+      <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
     <td :class="[$style.clickable, $style.supplyCell]" @click="onClick">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
-      <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <InlineFlex v-if="showTooltipIcons">
+        <span>{{ formatDaysCompact(analysis.daysOfSuppliesFit) }}</span>
+        <Tooltip :position="tooltipPosition ?? 'bottom'" :tooltip="supplyTooltip" />
+      </InlineFlex>
+      <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -85,7 +85,7 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <span
         v-if="showColumnTooltips"
-        :class="C.Tooltip.container"
+        :class="[C.Tooltip.container, $style.tooltipSpan]"
         :data-tooltip="COLUMN_LIMIT_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
@@ -100,7 +100,7 @@ const supplyClass = computed(() => {
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
       <span
         v-if="showColumnTooltips"
-        :class="C.Tooltip.container"
+        :class="[C.Tooltip.container, $style.tooltipSpan]"
         :data-tooltip="COLUMN_SUPPLY_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
@@ -171,6 +171,13 @@ const supplyClass = computed(() => {
 
 .noWrap {
   white-space: nowrap;
+}
+
+/* Tooltip ::before inherits white-space from its element. When the parent td
+   has noWrap, the inherited nowrap prevents tooltip text from wrapping inside
+   the tooltip box. Reset it here so the tooltip renders correctly. */
+.tooltipSpan {
+  white-space: normal;
 }
 
 .minimize {

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -83,13 +83,13 @@ const supplyClass = computed(() => {
     <td
       :class="[!planetOnlyClick && $style.clickable, $style.noWrap]"
       v-on="planetOnlyClick ? {} : { click: onClick }">
-      <div
+      <span
         v-if="showColumnTooltips"
-        :class="[$style.colBg, C.Tooltip.container]"
+        :class="C.Tooltip.container"
         :data-tooltip="COLUMN_LIMIT_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
-      </div>
+      </span>
       <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
@@ -98,13 +98,13 @@ const supplyClass = computed(() => {
       :class="[!planetOnlyClick && $style.clickable, $style.supplyCell, $style.noWrap]"
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
-      <div
+      <span
         v-if="showColumnTooltips"
-        :class="[$style.colBg, C.Tooltip.container]"
+        :class="C.Tooltip.container"
         :data-tooltip="COLUMN_SUPPLY_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
-      </div>
+      </span>
       <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
@@ -114,7 +114,7 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="[$style.colBg, C.Tooltip.container]"
+        :class="$style.colBg"
         :data-tooltip="COLUMN_CURRENT_FILL_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         <CargoBar :store="currentStore" disable-mini-mode />
@@ -126,7 +126,7 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="[$style.colBg, C.Tooltip.container]"
+        :class="$style.colBg"
         :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         <CargoBar :store="projectedStore" disable-mini-mode />

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -85,7 +85,7 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="$style.colBg"
+        :class="[$style.colBg, C.Tooltip.container]"
         :data-tooltip="COLUMN_LIMIT_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
@@ -100,7 +100,7 @@ const supplyClass = computed(() => {
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
       <div
         v-if="showColumnTooltips"
-        :class="$style.colBg"
+        :class="[$style.colBg, C.Tooltip.container]"
         :data-tooltip="COLUMN_SUPPLY_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
@@ -114,7 +114,7 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="$style.colBg"
+        :class="[$style.colBg, C.Tooltip.container]"
         :data-tooltip="COLUMN_CURRENT_FILL_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         <CargoBar :store="currentStore" disable-mini-mode />
@@ -126,7 +126,7 @@ const supplyClass = computed(() => {
       v-on="planetOnlyClick ? {} : { click: onClick }">
       <div
         v-if="showColumnTooltips"
-        :class="$style.colBg"
+        :class="[$style.colBg, C.Tooltip.container]"
         :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
         :data-tooltip-position="tooltipPosition ?? 'bottom'">
         <CargoBar :store="projectedStore" disable-mini-mode />

--- a/src/features/XIT/STO/BaseHeader.vue
+++ b/src/features/XIT/STO/BaseHeader.vue
@@ -16,12 +16,16 @@ const { analysis } = defineProps<{
   tooltipPosition?: string;
   hideButtons?: boolean;
   showColumnTooltips?: boolean;
+  planetOnlyClick?: boolean;
 }>();
 
 const COLUMN_LIMIT_TOOLTIP =
   'Days until storage is full at the current net production rate — when a ship visit is forced.';
 const COLUMN_SUPPLY_TOOLTIP =
   'Total days of consumables the base could hold when storage is filled to its threshold after ship-out (80% when filling, 95% when draining). Colors match XIT BURN: red below your red threshold, yellow below your yellow threshold.';
+const COLUMN_CURRENT_FILL_TOOLTIP = "What's in base storage right now. Colored by material category.";
+const COLUMN_AFTER_RESUPPLY_TOOLTIP =
+  'Projected storage if all produced goods were shipped out and all consumables delivered up to their XIT BURN Need amount. Red hatching shows overflow past capacity.';
 
 const currentStore = computed(() => storagesStore.getById(analysis.storeId));
 const projectedStore = computed(() => buildProjectedStore(analysis.siteId));
@@ -77,29 +81,61 @@ const supplyClass = computed(() => {
       <span>{{ analysis.planetName }}</span>
     </td>
     <td
-      :class="$style.clickable"
-      :data-tooltip="showColumnTooltips ? COLUMN_LIMIT_TOOLTIP : undefined"
-      :data-tooltip-position="showColumnTooltips ? (tooltipPosition ?? 'bottom') : undefined"
-      @click="onClick">
-      <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      :class="[$style.clickable, $style.noWrap]"
+      v-on="planetOnlyClick ? {} : { click: onClick }">
+      <div
+        v-if="showColumnTooltips"
+        :class="$style.colBg"
+        :data-tooltip="COLUMN_LIMIT_TOOLTIP"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
+        <span :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+          {{ formatDays(analysis.daysUntilFull) }}
+        </span>
+      </div>
+      <span v-else :data-tooltip="limitTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDays(analysis.daysUntilFull) }}
       </span>
     </td>
     <td
-      :class="[$style.clickable, $style.supplyCell]"
-      :data-tooltip="showColumnTooltips ? COLUMN_SUPPLY_TOOLTIP : undefined"
-      :data-tooltip-position="showColumnTooltips ? (tooltipPosition ?? 'bottom') : undefined"
-      @click="onClick">
+      :class="[$style.clickable, $style.supplyCell, $style.noWrap]"
+      v-on="planetOnlyClick ? {} : { click: onClick }">
       <div v-if="supplyClass" :class="[$style.supplyBg, supplyClass]" />
-      <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+      <div
+        v-if="showColumnTooltips"
+        :class="$style.colBg"
+        :data-tooltip="COLUMN_SUPPLY_TOOLTIP"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
+        <span :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
+          {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
+        </span>
+      </div>
+      <span v-else :data-tooltip="supplyTooltip" :data-tooltip-position="tooltipPosition ?? 'bottom'">
         {{ formatDaysCompact(analysis.daysOfSuppliesFit) }}
       </span>
     </td>
-    <td :class="[$style.clickable, $style.barCell]" @click="onClick">
-      <CargoBar :store="currentStore" disable-mini-mode />
+    <td
+      :class="[$style.clickable, $style.barCell]"
+      v-on="planetOnlyClick ? {} : { click: onClick }">
+      <div
+        v-if="showColumnTooltips"
+        :class="$style.colBg"
+        :data-tooltip="COLUMN_CURRENT_FILL_TOOLTIP"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
+        <CargoBar :store="currentStore" disable-mini-mode />
+      </div>
+      <CargoBar v-else :store="currentStore" disable-mini-mode />
     </td>
-    <td :class="[$style.clickable, $style.barCell]" @click="onClick">
-      <CargoBar :store="projectedStore" disable-mini-mode />
+    <td
+      :class="[$style.clickable, $style.barCell]"
+      v-on="planetOnlyClick ? {} : { click: onClick }">
+      <div
+        v-if="showColumnTooltips"
+        :class="$style.colBg"
+        :data-tooltip="COLUMN_AFTER_RESUPPLY_TOOLTIP"
+        :data-tooltip-position="tooltipPosition ?? 'bottom'">
+        <CargoBar :store="projectedStore" disable-mini-mode />
+      </div>
+      <CargoBar v-else :store="projectedStore" disable-mini-mode />
     </td>
     <td v-if="!hideButtons">
       <div :class="$style.buttons">
@@ -137,6 +173,10 @@ const supplyClass = computed(() => {
   cursor: pointer;
 }
 
+.noWrap {
+  white-space: nowrap;
+}
+
 .minimize {
   display: inline-block;
   width: 20px;
@@ -168,5 +208,12 @@ const supplyClass = computed(() => {
   top: 0;
   width: 100%;
   height: 100%;
+}
+
+/* Fills the td so background hover area covers empty space around the value. */
+.colBg {
+  display: block;
+  position: relative;
+  z-index: 1;
 }
 </style>

--- a/src/features/basic/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button.tsx
@@ -1,0 +1,81 @@
+import { getInvStore } from '@src/core/store-id';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+
+async function onTileReady(tile: PrunTile) {
+  const store = computed(() => getInvStore(tile.parameter));
+  const site = computed(() => (store.value ? sitesStore.getById(store.value.addressableId) : undefined));
+  const naturalId = computed(() =>
+    site.value ? getEntityNaturalIdFromAddress(site.value.address) : undefined,
+  );
+
+  const contextBar = await $(tile.frame, C.ContextControls.container);
+
+  createFragmentApp(() => {
+    if (!naturalId.value) return null;
+    return (
+      <div
+        class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+        onClick={() => void openAnalysis(tile, naturalId.value!)}>
+        <span>
+          <span class={C.ContextControls.cmd}>Analysis</span>
+          {' - XIT STO'}
+        </span>
+      </div>
+    );
+  }).prependTo(contextBar);
+}
+
+async function openAnalysis(tile: PrunTile, naturalId: string) {
+  const command = `XIT STO ${naturalId}`;
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    // Solo floating buffer: resize taller and split vertically.
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    setBufferSize(tile.id, w, h + 450);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '–');
+    await clickElement(splitButton);
+
+    if (!windowEl) return;
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    // Already in a split: find the sibling and change its command.
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) return;
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
+}
+
+function init() {
+  tiles.observe('INV', onTileReady);
+}
+
+features.add(import.meta.url, init, 'INV: Adds an Analysis button to open XIT STO in a vertical companion pane.');

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -24,7 +24,8 @@ const ready = computed(() => !!sitesStore.fetched.value);
           :minimized="true"
           :on-click="onExpand"
           tooltip-position="top"
-          hide-buttons />
+          hide-buttons
+          show-tooltip-icons />
       </tbody>
     </table>
     <LoadingSpinner v-else-if="!ready" />

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -24,8 +24,7 @@ const ready = computed(() => !!sitesStore.fetched.value);
           :minimized="true"
           :on-click="onExpand"
           tooltip-position="top"
-          hide-buttons
-          show-tooltip-icons />
+          hide-buttons />
       </tbody>
     </table>
     <LoadingSpinner v-else-if="!ready" />

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -23,7 +23,8 @@ const ready = computed(() => !!sitesStore.fetched.value);
           has-minimize
           :minimized="true"
           :on-click="onExpand"
-          tooltip-position="top" />
+          tooltip-position="top"
+          hide-buttons />
       </tbody>
     </table>
     <LoadingSpinner v-else-if="!ready" />
@@ -35,10 +36,6 @@ const ready = computed(() => !!sitesStore.fetched.value);
 .panel {
   border-top: 1px solid #2b485a;
   flex-shrink: 0;
-}
-
-.panel :deep(td:last-child) {
-  display: none;
 }
 
 .empty {

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { getBaseStorageAnalysis } from '@src/core/storage-analysis';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import BaseHeader from '@src/features/XIT/STO/BaseHeader.vue';
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+
+const { naturalId, onExpand } = defineProps<{
+  naturalId: string;
+  onExpand: () => void;
+}>();
+
+const site = computed(() => sitesStore.getByPlanetNaturalIdOrName(naturalId));
+const analysis = computed(() => getBaseStorageAnalysis(site.value));
+const ready = computed(() => !!sitesStore.fetched.value);
+</script>
+
+<template>
+  <div :class="$style.panel">
+    <table v-if="analysis">
+      <tbody>
+        <BaseHeader :analysis="analysis" has-minimize :minimized="true" :on-click="onExpand" />
+      </tbody>
+    </table>
+    <LoadingSpinner v-else-if="!ready" />
+    <div v-else :class="$style.empty">No storage data for {{ naturalId }}</div>
+  </div>
+</template>
+
+<style module>
+.panel {
+  border-top: 1px solid #2b485a;
+  flex-shrink: 0;
+}
+
+.empty {
+  padding: 4px 8px;
+  font-size: 11px;
+  font-style: italic;
+  opacity: 0.7;
+}
+</style>

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -16,7 +16,7 @@ const ready = computed(() => !!sitesStore.fetched.value);
 
 <template>
   <div :class="$style.panel">
-    <table v-if="analysis">
+    <table v-if="analysis" :class="$style.table">
       <tbody>
         <BaseHeader
           :analysis="analysis"
@@ -25,7 +25,8 @@ const ready = computed(() => !!sitesStore.fetched.value);
           :on-click="onExpand"
           tooltip-position="top"
           hide-buttons
-          show-column-tooltips />
+          show-column-tooltips
+          planet-only-click />
       </tbody>
     </table>
     <LoadingSpinner v-else-if="!ready" />
@@ -37,6 +38,10 @@ const ready = computed(() => !!sitesStore.fetched.value);
 .panel {
   border-top: 1px solid #2b485a;
   flex-shrink: 0;
+}
+
+.table {
+  width: 100%;
 }
 
 .empty {

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -24,7 +24,8 @@ const ready = computed(() => !!sitesStore.fetched.value);
           :minimized="true"
           :on-click="onExpand"
           tooltip-position="top"
-          hide-buttons />
+          hide-buttons
+          show-column-tooltips />
       </tbody>
     </table>
     <LoadingSpinner v-else-if="!ready" />

--- a/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
+++ b/src/features/basic/inv-analysis-button/StoSummaryPanel.vue
@@ -18,7 +18,12 @@ const ready = computed(() => !!sitesStore.fetched.value);
   <div :class="$style.panel">
     <table v-if="analysis">
       <tbody>
-        <BaseHeader :analysis="analysis" has-minimize :minimized="true" :on-click="onExpand" />
+        <BaseHeader
+          :analysis="analysis"
+          has-minimize
+          :minimized="true"
+          :on-click="onExpand"
+          tooltip-position="top" />
       </tbody>
     </table>
     <LoadingSpinner v-else-if="!ready" />
@@ -30,6 +35,10 @@ const ready = computed(() => !!sitesStore.fetched.value);
 .panel {
   border-top: 1px solid #2b485a;
   flex-shrink: 0;
+}
+
+.panel :deep(td:last-child) {
+  display: none;
 }
 
 .empty {

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -48,6 +48,7 @@ function showPanel(tile: PrunTile, naturalId: string) {
   tile.anchor.style.flexDirection = 'column';
   storeContainer.style.flex = '1';
   storeContainer.style.minHeight = '0';
+  storeContainer.style.overflow = 'hidden';
 
   const panelWrapper = document.createElement('div');
   panelWrapper.style.flexShrink = '0';

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -54,13 +54,31 @@ function showPanel(tile: PrunTile, naturalId: string) {
   panelWrapper.style.flexShrink = '0';
   tile.anchor.appendChild(panelWrapper);
 
+  let ro: ResizeObserver | undefined;
+
   createFragmentApp(StoSummaryPanel, {
     naturalId,
     onExpand: () => {
+      ro?.disconnect();
       panelWrapper.remove();
       void openAnalysis(tile, naturalId);
     },
   }).appendTo(panelWrapper);
+
+  // Grow a solo floating buffer so the panel doesn't cover existing content.
+  if (tile.container.classList.contains(C.Window.body)) {
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    let prevPanelHeight = 0;
+    ro = new ResizeObserver(() => {
+      const panelHeight = panelWrapper.offsetHeight;
+      if (panelHeight !== prevPanelHeight) {
+        prevPanelHeight = panelHeight;
+        setBufferSize(tile.id, w, h + panelHeight);
+      }
+    });
+    ro.observe(panelWrapper);
+  }
 }
 
 async function openAnalysis(tile: PrunTile, naturalId: string) {

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -10,7 +10,9 @@ import StoSummaryPanel from './StoSummaryPanel.vue';
 
 async function onTileReady(tile: PrunTile) {
   const store = computed(() => getInvStore(tile.parameter));
-  const site = computed(() => (store.value ? sitesStore.getById(store.value.addressableId) : undefined));
+  const site = computed(() =>
+    store.value ? sitesStore.getById(store.value.addressableId) : undefined,
+  );
   const naturalId = computed(() =>
     site.value ? getEntityNaturalIdFromAddress(site.value.address) : undefined,
   );
@@ -20,7 +22,9 @@ async function onTileReady(tile: PrunTile) {
   let panelShown = false;
 
   createFragmentApp(() => {
-    if (!naturalId.value) return null;
+    if (!naturalId.value) {
+      return null;
+    }
     return (
       <button
         class={[C.Button.btn, C.Button.primary]}
@@ -38,7 +42,9 @@ async function onTileReady(tile: PrunTile) {
 
 function showPanel(tile: PrunTile, naturalId: string) {
   const storeContainer = _$(tile.anchor, C.StoreView.container) as HTMLElement | null;
-  if (!storeContainer) return;
+  if (!storeContainer) {
+    return;
+  }
 
   // Make anchor a flex column so the panel sits below the store view.
   tile.anchor.style.display = 'flex';
@@ -64,8 +70,10 @@ function showPanel(tile: PrunTile, naturalId: string) {
 
   // Grow a solo floating buffer so the panel doesn't cover existing content.
   if (tile.container.classList.contains(C.Window.body)) {
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     let prevPanelHeight = 0;
     ro = new ResizeObserver(() => {
       const panelHeight = panelWrapper.offsetHeight;
@@ -84,14 +92,18 @@ async function openAnalysis(tile: PrunTile, naturalId: string) {
 
   if (tile.container.classList.contains(C.Window.body)) {
     // Solo floating buffer: resize taller and split vertically.
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     setBufferSize(tile.id, w, h + 450);
 
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '–');
     await clickElement(splitButton);
 
-    if (!windowEl) return;
+    if (!windowEl) {
+      return;
+    }
 
     const node = await $(windowEl, C.Node.node);
     const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
@@ -110,7 +122,9 @@ async function openAnalysis(tile: PrunTile, naturalId: string) {
 
 async function setChildCommand(child: Element, command: string) {
   const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
-  if (!tileEl) return;
+  if (!tileEl) {
+    return;
+  }
 
   const id = getPrunId(tileEl)!;
   const message = UI_TILES_CHANGE_COMMAND(id, command);
@@ -125,4 +139,8 @@ function init() {
   tiles.observe('INV', onTileReady);
 }
 
-features.add(import.meta.url, init, 'INV: Adds an Analysis button that shows an XIT STO summary pane, expandable to a full companion buffer.');
+features.add(
+  import.meta.url,
+  init,
+  'INV: Adds an Analysis button that shows an XIT STO summary pane, expandable to a full companion buffer.',
+);

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -22,19 +22,16 @@ async function onTileReady(tile: PrunTile) {
   createFragmentApp(() => {
     if (!naturalId.value) return null;
     return (
-      <div
-        class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+      <button
+        class={[C.Button.btn, C.Button.primary]}
         onClick={() => {
           if (!panelShown) {
             showPanel(tile, naturalId.value!);
             panelShown = true;
           }
         }}>
-        <span>
-          <span class={C.ContextControls.cmd}>Analysis</span>
-          {' - XIT STO'}
-        </span>
-      </div>
+        Analysis - XIT STO
+      </button>
     );
   }).prependTo(contextBar);
 }

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -48,7 +48,6 @@ function showPanel(tile: PrunTile, naturalId: string) {
   tile.anchor.style.flexDirection = 'column';
   storeContainer.style.flex = '1';
   storeContainer.style.minHeight = '0';
-  storeContainer.style.overflowY = 'auto';
 
   const panelWrapper = document.createElement('div');
   panelWrapper.style.flexShrink = '0';

--- a/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
+++ b/src/features/basic/inv-analysis-button/inv-analysis-button.tsx
@@ -6,6 +6,7 @@ import { clickElement, changeInputValue } from '@src/util';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
 import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+import StoSummaryPanel from './StoSummaryPanel.vue';
 
 async function onTileReady(tile: PrunTile) {
   const store = computed(() => getInvStore(tile.parameter));
@@ -16,12 +17,19 @@ async function onTileReady(tile: PrunTile) {
 
   const contextBar = await $(tile.frame, C.ContextControls.container);
 
+  let panelShown = false;
+
   createFragmentApp(() => {
     if (!naturalId.value) return null;
     return (
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
-        onClick={() => void openAnalysis(tile, naturalId.value!)}>
+        onClick={() => {
+          if (!panelShown) {
+            showPanel(tile, naturalId.value!);
+            panelShown = true;
+          }
+        }}>
         <span>
           <span class={C.ContextControls.cmd}>Analysis</span>
           {' - XIT STO'}
@@ -29,6 +37,30 @@ async function onTileReady(tile: PrunTile) {
       </div>
     );
   }).prependTo(contextBar);
+}
+
+function showPanel(tile: PrunTile, naturalId: string) {
+  const storeContainer = _$(tile.anchor, C.StoreView.container) as HTMLElement | null;
+  if (!storeContainer) return;
+
+  // Make anchor a flex column so the panel sits below the store view.
+  tile.anchor.style.display = 'flex';
+  tile.anchor.style.flexDirection = 'column';
+  storeContainer.style.flex = '1';
+  storeContainer.style.minHeight = '0';
+  storeContainer.style.overflowY = 'auto';
+
+  const panelWrapper = document.createElement('div');
+  panelWrapper.style.flexShrink = '0';
+  tile.anchor.appendChild(panelWrapper);
+
+  createFragmentApp(StoSummaryPanel, {
+    naturalId,
+    onExpand: () => {
+      panelWrapper.remove();
+      void openAnalysis(tile, naturalId);
+    },
+  }).appendTo(panelWrapper);
 }
 
 async function openAnalysis(tile: PrunTile, naturalId: string) {
@@ -78,4 +110,4 @@ function init() {
   tiles.observe('INV', onTileReady);
 }
 
-features.add(import.meta.url, init, 'INV: Adds an Analysis button to open XIT STO in a vertical companion pane.');
+features.add(import.meta.url, init, 'INV: Adds an Analysis button that shows an XIT STO summary pane, expandable to a full companion buffer.');


### PR DESCRIPTION
## Summary

- Adds an **"Analysis - XIT STO"** button to the context bar of any INV buffer that belongs to a planet base
- Clicking the button appends a compact XIT STO summary row below the inventory, showing days-till-full, supply days, current fill bar, and after-resupply bar — all with column-description tooltips on hover
- Only the planet-name cell is clickable; clicking expands to a full `XIT STO <planet>` companion buffer (vertical split for floating buffers, sibling reuse for already-split tiles)
- Solo floating buffers grow in height automatically to accommodate the panel via `ResizeObserver` so no inventory content is hidden
- Tooltip text wraps correctly inside the tooltip box; after-resupply (rightmost) tooltip is right-anchored so it doesn't overflow the buffer edge

## Test plan

- [ ] Open an INV buffer for a planet where you have a base — "Analysis - XIT STO" button appears in context bar
- [ ] Open an INV buffer for a ship or warehouse (no planet base) — button does not appear
- [ ] Click the button — compact summary panel appears below the inventory; buffer grows taller if floating
- [ ] Hover each column — tooltips appear with column descriptions; text wraps correctly
- [ ] Hover the after-resupply (rightmost) bar — tooltip extends leftward, stays within buffer bounds
- [ ] Click the planet name in the summary row — full XIT STO companion buffer opens
- [ ] Repeat expand from a floating buffer, a docked tile, and an already-split tile

https://claude.ai/code/session_01UL8d78qt5eKsdCXHTMLtpw