### PR TITLE
Disable automatic deploy to local runner on push

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -17,8 +17,7 @@
 name: Deploy to Local Runner
 
 on:
-  push:
-    branches: ['**']
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Change the workflow trigger from automatic push to manual workflow_dispatch. This allows the workflow to be triggered manually from GitHub UI while preventing it from running on every push.

https://claude.ai/code/session_013ZxY19pavSdmPFHgRBhcZU

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
