### PR TITLE
Fix artifact download path in release-firefox workflow

### DIFF
--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
+          name: artifact
           path: dist
       - name: Sign with Mozilla
         run: npx web-ext@8 sign --source-dir dist --channel=unlisted


### PR DESCRIPTION
Without name: artifact, download-artifact@v4 creates a subdirectory per artifact, landing files at dist/artifact/ instead of dist/.

https://claude.ai/code/session_01TZu6aSzc3R4dtja88NboGT

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
