### PR TITLE
Fix data_collection_permissions and bump Firefox min version

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,9 +7,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{c35c3edc-0acc-4531-b01c-35b6bede69fb}",
-      "strict_min_version": "109.0",
+      "strict_min_version": "140.0",
       "update_url": "https://storage.googleapis.com/oog-fork-gcs-bucket/updates.json",
       "data_collection_permissions": {
+        "required": ["none"],
         "optional": ["searchTerms", "personallyIdentifyingInfo"]
       }
     }


### PR DESCRIPTION
Add required: ["none"] — AMO validation requires the field to be present even when there is no required data collection.

Bump strict_min_version 109.0 -> 140.0 to match when data_collection_permissions was introduced, silencing the two KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION warnings.

https://claude.ai/code/session_01TZu6aSzc3R4dtja88NboGT

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
