### PR TITLE
Auto-stamp version as date.run_number on each Firefox release

### DIFF
--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -21,6 +21,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - name: Stamp version
+        run: |
+          version="$(date -u +'%Y.%-m.%-d').${{ github.run_number }}"
+          npx dot-json@1 "$DIRECTORY/manifest.json" version "$version"
       - uses: actions/upload-artifact@v4
         with:
           path: ${{ env.DIRECTORY }}


### PR DESCRIPTION
Prevents AMO version conflict errors when the workflow is run more than once. Produces versions like 2026.5.8.3.

https://claude.ai/code/session_01TZu6aSzc3R4dtja88NboGT

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
