### PR TITLE
Standardize Filter Bar Labels

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -63,6 +63,19 @@ if (!tile.parameter) {
 // Just use tile.parameter directly
 ```
 
+## XIT Filter Bars
+
+XIT panels with filter toggles use `C.ComExOrdersPanel.filter` as the container and `RadioItem` with `horizontal` prop for each toggle. Labels must be ALL CAPS:
+
+```html
+<div :class="C.ComExOrdersPanel.filter">
+  <RadioItem v-model="showFoo" horizontal>FOO</RadioItem>
+  <RadioItem v-model="showBar" horizontal>BAR</RadioItem>
+</div>
+```
+
+---
+
 ## Adding an XIT Command
 
 XIT commands are custom in-game panels opened via the `XIT` buffer. Register in a `.ts` file:

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -123,12 +123,12 @@ const filteredBases = computed(() => {
   <LoadingSpinner v-if="bases === undefined" />
   <template v-else>
     <div :class="C.ComExOrdersPanel.filter">
-      <RadioItem v-model="showCmds" horizontal>Cmds</RadioItem>
-      <RadioItem v-model="showBurn" horizontal>Burn</RadioItem>
-      <RadioItem v-model="showProd" horizontal>Prod</RadioItem>
-      <RadioItem v-model="showRepair" horizontal>Repair</RadioItem>
-      <RadioItem v-model="showInv" horizontal>Inv</RadioItem>
-      <RadioItem v-model="showWar" horizontal>War</RadioItem>
+      <RadioItem v-model="showCmds" horizontal>CMDS</RadioItem>
+      <RadioItem v-model="showBurn" horizontal>BURN</RadioItem>
+      <RadioItem v-model="showProd" horizontal>PROD</RadioItem>
+      <RadioItem v-model="showRepair" horizontal>REPAIR</RadioItem>
+      <RadioItem v-model="showInv" horizontal>INV</RadioItem>
+      <RadioItem v-model="showWar" horizontal>WAR</RadioItem>
       <div :class="$style.spacer" />
       <div :class="$style.searchContainer">
         Planet:&nbsp;


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
