### PR TITLE
feat: CXPO quick price setting (OOG, default off)

### DIFF
--- a/src/features/XIT/PROD/ProductionRow.vue
+++ b/src/features/XIT/PROD/ProductionRow.vue
@@ -83,8 +83,12 @@ const tooltipText = computed(() => tooltipLines.value.join('\n'));
     <FracCell :numerator="activeOrders" :denominator="capacity" />
     <td>
       <div :class="$style.buttons">
-        <PrunButton dark inline @click="showBuffer(`PRODCO ${productionLine.id.substring(0, 8)}`)">CO</PrunButton>
-        <PrunButton dark inline @click="showBuffer(`PRODQ ${productionLine.id.substring(0, 8)}`)">Q</PrunButton>
+        <PrunButton dark inline @click="showBuffer(`PRODCO ${productionLine.id.substring(0, 8)}`)"
+          >CO</PrunButton
+        >
+        <PrunButton dark inline @click="showBuffer(`PRODQ ${productionLine.id.substring(0, 8)}`)"
+          >Q</PrunButton
+        >
       </div>
     </td>
   </tr>

--- a/src/features/basic/cxpo-order-book/OrderBook.vue
+++ b/src/features/basic/cxpo-order-book/OrderBook.vue
@@ -15,15 +15,21 @@ const { ticker, onOrderClick } = defineProps<{
 const orderBook = computed(() => cxobStore.getByTicker(ticker));
 
 const getSigFigIncrement = (num: number, n: number = 3): number => {
-  if (num === 0) return 0;
+  if (num === 0) {
+    return 0;
+  }
   const exponent = Math.floor(Math.log10(Math.abs(num)));
   return Math.pow(10, exponent - (n - 1));
 };
 
 const undercutOffer = computed(() => {
-  if (!quickPriceEnabled.value) return null;
+  if (!quickPriceEnabled.value) {
+    return null;
+  }
   const ask = orderBook.value?.ask?.price.amount;
-  if (ask === undefined) return null;
+  if (ask === undefined) {
+    return null;
+  }
   return {
     id: 'undrcut',
     limit: { amount: ask - getSigFigIncrement(ask) },
@@ -33,9 +39,13 @@ const undercutOffer = computed(() => {
 });
 
 const outbidRequest = computed(() => {
-  if (!quickPriceEnabled.value) return null;
+  if (!quickPriceEnabled.value) {
+    return null;
+  }
   const bid = orderBook.value?.bid?.price.amount;
-  if (bid === undefined) return null;
+  if (bid === undefined) {
+    return null;
+  }
   return {
     id: 'outbid',
     limit: { amount: bid + getSigFigIncrement(bid) },

--- a/src/features/basic/cxpo-order-book/OrderBook.vue
+++ b/src/features/basic/cxpo-order-book/OrderBook.vue
@@ -5,6 +5,7 @@ import { fixed2 } from '@src/utils/format';
 import { isEmpty } from 'ts-extras';
 import { OrderHoverData } from '@src/features/basic/cxpo-order-book/order-hover-data';
 import { isFiniteOrder } from '@src/core/orders';
+import { quickPriceEnabled } from './quick-price';
 
 const { ticker, onOrderClick } = defineProps<{
   ticker?: string;
@@ -13,8 +14,51 @@ const { ticker, onOrderClick } = defineProps<{
 
 const orderBook = computed(() => cxobStore.getByTicker(ticker));
 
-const offers = computed(() => orderBook.value?.sellingOrders.toReversed() ?? []);
-const requests = computed(() => orderBook.value?.buyingOrders ?? []);
+const getSigFigIncrement = (num: number, n: number = 3): number => {
+  if (num === 0) return 0;
+  const exponent = Math.floor(Math.log10(Math.abs(num)));
+  return Math.pow(10, exponent - (n - 1));
+};
+
+const undercutOffer = computed(() => {
+  if (!quickPriceEnabled.value) return null;
+  const ask = orderBook.value?.ask?.price.amount;
+  if (ask === undefined) return null;
+  return {
+    id: 'undrcut',
+    limit: { amount: ask - getSigFigIncrement(ask) },
+    amount: 0,
+    trader: { id: 'ghost' },
+  } as PrunApi.CXBrokerOrder;
+});
+
+const outbidRequest = computed(() => {
+  if (!quickPriceEnabled.value) return null;
+  const bid = orderBook.value?.bid?.price.amount;
+  if (bid === undefined) return null;
+  return {
+    id: 'outbid',
+    limit: { amount: bid + getSigFigIncrement(bid) },
+    amount: 0,
+    trader: { id: 'ghost' },
+  } as PrunApi.CXBrokerOrder;
+});
+
+const offers = computed(() => {
+  const list = [...(orderBook.value?.sellingOrders.toReversed() ?? [])];
+  if (undercutOffer.value) {
+    list.push(undercutOffer.value);
+  }
+  return list;
+});
+
+const requests = computed(() => {
+  const list = [...(orderBook.value?.buyingOrders ?? [])];
+  if (outbidRequest.value) {
+    list.unshift(outbidRequest.value);
+  }
+  return list;
+});
 const spread = computed(() => {
   const ask = orderBook.value?.ask?.price.amount;
   const bid = orderBook.value?.bid?.price.amount;
@@ -47,6 +91,10 @@ function onClick(data: OrderHoverData) {
   }
 
   const order = data.order;
+  if (order.trader.id === 'ghost') {
+    onOrderClick(order.limit.amount);
+    return;
+  }
   if (!data.cumulative) {
     onOrderClick(order.limit.amount);
     return;
@@ -118,6 +166,7 @@ function getCumulativeOrders(targetOrder: PrunApi.CXBrokerOrder) {
             v-for="order in offers"
             :key="order.id"
             :order="order"
+            :class="{ [$style.ghost]: order.trader.id === 'ghost' }"
             :highlight-amount="isAmountHighlighted(order)"
             :highlight-price="isPriceHighlighted(order)"
             :on-hover="onHover"
@@ -141,6 +190,7 @@ function getCumulativeOrders(targetOrder: PrunApi.CXBrokerOrder) {
             :key="order.id"
             request
             :order="order"
+            :class="{ [$style.ghost]: order.trader.id === 'ghost' }"
             :highlight-amount="isAmountHighlighted(order)"
             :highlight-price="isPriceHighlighted(order)"
             :on-hover="onHover"
@@ -163,5 +213,10 @@ function getCumulativeOrders(targetOrder: PrunApi.CXBrokerOrder) {
 
 .spread {
   text-align: center;
+}
+
+.ghost {
+  opacity: 0.5;
+  font-style: italic;
 }
 </style>

--- a/src/features/basic/cxpo-order-book/OrderRow.vue
+++ b/src/features/basic/cxpo-order-book/OrderRow.vue
@@ -19,7 +19,13 @@ const $style = useCssModule();
 const isOwnOrder = computed(
   () => (order.amount ?? 0) > 0 && order.trader.id === companyStore.value?.id,
 );
-const amount = computed(() => ((order.amount ?? 0) > 0 ? fixed0(order.amount!) : '∞'));
+const amount = computed(() => {
+  const qty = order.amount ?? 0;
+  if (qty <= 0) {
+    return order.trader.id === 'ghost' ? order.id : '∞';
+  }
+  return fixed0(order.amount!);
+});
 const amountClass = computed(() => ({
   [$style.valueHighlight]: highlightAmount,
   [link.link]: isOwnOrder.value,

--- a/src/features/basic/cxpo-order-book/quick-price.ts
+++ b/src/features/basic/cxpo-order-book/quick-price.ts
@@ -1,0 +1,5 @@
+export const quickPriceEnabled = ref(false);
+
+export function setQuickPriceEnabled(value: boolean) {
+  quickPriceEnabled.value = value;
+}

--- a/src/features/basic/oog-cxpo-quick-price.ts
+++ b/src/features/basic/oog-cxpo-quick-price.ts
@@ -4,4 +4,8 @@ function init() {
   setQuickPriceEnabled(true);
 }
 
-features.add(import.meta.url, init, 'CXPO: Shows ghost price rows to quickly undercut/outbid in the order book.');
+features.add(
+  import.meta.url,
+  init,
+  'CXPO: Shows ghost price rows to quickly undercut/outbid in the order book.',
+);

--- a/src/features/basic/oog-cxpo-quick-price.ts
+++ b/src/features/basic/oog-cxpo-quick-price.ts
@@ -1,0 +1,7 @@
+import { setQuickPriceEnabled } from './cxpo-order-book/quick-price';
+
+function init() {
+  setQuickPriceEnabled(true);
+}
+
+features.add(import.meta.url, init, 'CXPO: Shows ghost price rows to quickly undercut/outbid in the order book.');

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -5,7 +5,7 @@ export const initialUserData = deepFreeze({
   tileState: {} as Record<string, UserData.TileState | undefined>,
   settings: {
     mode: undefined as 'BASIC' | 'FULL' | undefined,
-    disabled: ['oog-burn-inflight-inventory'] as string[],
+    disabled: ['oog-burn-inflight-inventory', 'oog-cxpo-quick-price'] as string[],
     time: 'DEFAULT' as UserData.TimeFormat,
     defaultChartType: 'SMOOTH' as UserData.ExchangeChartType,
     currency: {


### PR DESCRIPTION
## Summary

- Ports the "quick price setting system" from [agm-114/refined-prun@8db5624](https://github.com/agm-114/refined-prun/commit/8db5624c086f7c21acd63399da2133946e6ad8eb) as an opt-in OOG feature
- Adds two **ghost rows** to the CXPO order book: one undercuts the current ask, one outbids the current bid, each offset by one significant-figure increment (e.g. ask at 123.45 → suggests 123.44)
- Clicking a ghost row pre-fills that price in the order form
- Ghost rows are styled at 50% opacity + italic; their amount cell shows `undrcut` / `outbid` instead of a quantity
- Feature is **default off** (`oog-cxpo-quick-price`) following the existing OOG pattern — users opt in via `XIT SET`

## Changed files

| File | Change |
|---|---|
| `src/features/basic/cxpo-order-book/quick-price.ts` | New — shared `quickPriceEnabled` ref + setter |
| `src/features/basic/oog-cxpo-quick-price.ts` | New — feature registration, sets flag on init |
| `src/features/basic/cxpo-order-book/OrderBook.vue` | `getSigFigIncrement` helper; ghost computeds; extended `offers`/`requests`; ghost early-exit in `onClick`; ghost CSS class + rule |
| `src/features/basic/cxpo-order-book/OrderRow.vue` | `amount` computed shows `order.id` for ghost orders instead of ∞ |
| `src/store/user-data.ts` | `oog-cxpo-quick-price` added to default `disabled` array |

## Test plan

- [ ] With feature off (default): order book shows no ghost rows, existing click behaviour unchanged
- [ ] Enable `oog-cxpo-quick-price` in `XIT SET`, reload
- [ ] Open `CXPO` for any traded material with both asks and bids
- [ ] Ghost undercut row appears just below the lowest ask, styled faint/italic, amount shows `undrcut`
- [ ] Ghost outbid row appears just above the highest bid, styled faint/italic, amount shows `outbid`
- [ ] Clicking the price cell of a ghost row pre-fills the price input with the suggested price
- [ ] Clicking the amount cell of a ghost row also pre-fills only the price (no quantity)
- [ ] Cumulative highlight on real orders still works correctly
- [ ] Own-order CXO link on real orders still works correctly

https://claude.ai/code/session_01Mkb5dkrfkeuU8WZcsRyQPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkb5dkrfkeuU8WZcsRyQPJ)_