### PR TITLE
fix: guard enhanceSegmentVisibility against empty segments

### DIFF
--- a/src/features/XIT/BS/InvBar.vue
+++ b/src/features/XIT/BS/InvBar.vue
@@ -118,6 +118,10 @@ const invBar = computed(() => {
 });
 
 function enhanceSegmentVisibility(segments: Segment[], loadRatio: number) {
+  if (segments.length === 0) {
+    return;
+  }
+
   const lowContrastCategories = new Set(['elements', 'metals', 'shipments', 'unit prefabs']);
   const isAlmostFull = loadRatio > 0.98;
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When a storage is empty, `maxRatio` is `0`, so `isMiniMode` evaluates to `false` (requires `> 0`)
- This caused `enhanceSegmentVisibility` to be called with an empty `segments` array
- Accessing `segments[-1].borderClasses` threw, corrupting the `invBar` computed and cascading into a second error when the template accessed `invBar.value.miniMode`
- Fix: early return at the top of `enhanceSegmentVisibility` when `segments.length === 0`

## Test plan

- [ ] Open a BS tile for a ship/base with an empty inventory — no console errors
- [ ] Open a BS tile for a ship/base with items — bar renders correctly
- [ ] Verify mini mode still works for lightly loaded stores

https://claude.ai/code/session_0182NjgSLWxCrSDatD5uJ8eD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0182NjgSLWxCrSDatD5uJ8eD)_