### PR TITLE
FLT/XIT FLT: update ship condition color thresholds

### DIFF
--- a/src/features/XIT/FLT/FLT.vue
+++ b/src/features/XIT/FLT/FLT.vue
@@ -13,6 +13,7 @@ import RadioItem from '@src/components/forms/RadioItem.vue';
 import FleetStatusCell from './FleetStatusCell.vue';
 import CargoBar from './CargoBar.vue';
 import { fixed0 } from '@src/utils/format';
+import coloredValue from '@src/infrastructure/prun-ui/css/colored-value.module.css';
 
 type SortKey = 'name' | 'cargo' | 'status' | 'fuel';
 type SortDirection = 'asc' | 'desc';
@@ -136,6 +137,7 @@ const rawRows = computed(() => {
       warningFuelRatio,
       statusSortValue,
       conditionText: `${Math.round(condition)}%`,
+      conditionClass: getConditionClass(condition),
       cargoSizeText: getCargoSizeText(inventory),
       isFtlCapable,
       inFlight,
@@ -504,6 +506,16 @@ function clearFilters() {
   fuelAlertFilter.value = 'any';
 }
 
+function getConditionClass(condition: number) {
+  if (Math.floor(condition) <= 79) {
+    return C.ColoredValue.negative;
+  }
+  if (Math.floor(condition) <= 82) {
+    return coloredValue.warning;
+  }
+  return C.ColoredValue.positive;
+}
+
 function getShipClass(ship: PrunApi.Ship) {
   const name = ship.name?.toUpperCase() ?? '';
   const nameMatch =
@@ -668,7 +680,7 @@ function getCargoState(cargoRatio: number) {
             <span :class="C.Link.link" @click="showBuffer(`SFC ${x.ship.registration}`)">
               {{ x.ship.name || x.ship.registration }}
             </span>
-            <span :class="C.ColoredValue.positive">&nbsp;{{ x.conditionText }}</span>
+            <span :class="x.conditionClass">&nbsp;{{ x.conditionText }}</span>
           </td>
 
           <td :class="[$style.bodyCell, $style.cargoCell]">

--- a/src/features/basic/flt-ship-condition/ShipCondition.vue
+++ b/src/features/basic/flt-ship-condition/ShipCondition.vue
@@ -13,7 +13,7 @@ const labelClass = computed(() => {
   if (condition.value <= 0.79) {
     return C.ColoredValue.negative;
   }
-  if (condition.value <= 0.81) {
+  if (condition.value <= 0.82) {
     return coloredValue.warning;
   }
   return C.ColoredValue.positive;


### PR DESCRIPTION
## Summary

- Raises the yellow warning threshold in regular FLT from 81% to 82%
- Fixes XIT FLT where condition was always shown green — now applies the same color thresholds as regular FLT

## Color thresholds (both FLT and XIT FLT)

| Condition | Color |
|-----------|-------|
| > 82% | green |
| ≤ 82% | yellow |
| ≤ 79% | red |

## Test plan

- [ ] Open FLT with a ship at >82% condition — should be green
- [ ] Open FLT with a ship at 80–82% condition — should be yellow
- [ ] Open FLT with a ship at ≤79% condition — should be red
- [ ] Open XIT FLT and verify the same color behavior applies

https://claude.ai/code/session_01C5w5ULR5gWjGFiJgouNr4P

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5w5ULR5gWjGFiJgouNr4P)_