### PR TITLE
Add screen folders to the tab bar

### DIFF
--- a/src/features/basic/screen-tab-bar/FldrButton.vue
+++ b/src/features/basic/screen-tab-bar/FldrButton.vue
@@ -82,7 +82,7 @@ watchEffect(() => {
   <Teleport to="body">
     <div
       v-if="showDropdown && userData.tabs.folders.length > 0"
-      :class="$style.dropdown"
+      :class="[$style.dropdown, C.fonts.fontRegular, C.type.typeRegular]"
       :style="dropdownStyle"
       @mouseenter="onDropdownEnter"
       @mouseleave="onDropdownLeave">

--- a/src/features/basic/screen-tab-bar/FldrButton.vue
+++ b/src/features/basic/screen-tab-bar/FldrButton.vue
@@ -25,7 +25,9 @@ function scheduleHide() {
 
 function onTabEnter() {
   clearHide();
-  if (userData.tabs.folders.length > 0) showDropdown.value = true;
+  if (userData.tabs.folders.length > 0) {
+    showDropdown.value = true;
+  }
 }
 
 function onTabLeave() {
@@ -46,21 +48,29 @@ function onClick() {
 
 function deleteFolder(folderId: string) {
   const folder = userData.tabs.folders.find(f => f.id === folderId);
-  if (!folder) return;
+  if (!folder) {
+    return;
+  }
   for (const screenId of folder.screenIds) {
     userData.tabs.order.push(screenId);
   }
   removeArrayElement(userData.tabs.folders, folder);
   removeArrayElement(userData.tabs.order, folderId);
-  if (userData.tabs.folders.length === 0) showDropdown.value = false;
+  if (userData.tabs.folders.length === 0) {
+    showDropdown.value = false;
+  }
 }
 
 const dropdownStyle = ref<Record<string, string>>({});
 
 watchEffect(() => {
-  if (!showDropdown.value) return;
+  if (!showDropdown.value) {
+    return;
+  }
   const rect = tabEl.value?.getBoundingClientRect();
-  if (!rect) return;
+  if (!rect) {
+    return;
+  }
   dropdownStyle.value = {
     top: `${rect.bottom}px`,
     left: `${rect.left}px`,
@@ -94,7 +104,7 @@ watchEffect(() => {
         <div
           :class="[C.ScreenControls.delete, C.type.typeSmall, $style.delBtn]"
           @click.prevent="deleteFolder(folder.id)">
-          DEL
+          del
         </div>
       </div>
     </div>

--- a/src/features/basic/screen-tab-bar/FldrButton.vue
+++ b/src/features/basic/screen-tab-bar/FldrButton.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { userData } from '@src/store/user-data';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import removeArrayElement from '@src/utils/remove-array-element';
+
+defineOptions({ inheritAttrs: false });
+
+const tabEl = useTemplateRef<HTMLElement>('tab');
+const showDropdown = ref(false);
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearHide() {
+  if (hideTimer !== null) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+}
+
+function scheduleHide() {
+  hideTimer = setTimeout(() => {
+    showDropdown.value = false;
+    hideTimer = null;
+  }, 150);
+}
+
+function onTabEnter() {
+  clearHide();
+  if (userData.tabs.folders.length > 0) showDropdown.value = true;
+}
+
+function onTabLeave() {
+  scheduleHide();
+}
+
+function onDropdownEnter() {
+  clearHide();
+}
+
+function onDropdownLeave() {
+  scheduleHide();
+}
+
+function onClick() {
+  void showBuffer('XIT FLDR');
+}
+
+function deleteFolder(folderId: string) {
+  const folder = userData.tabs.folders.find(f => f.id === folderId);
+  if (!folder) return;
+  for (const screenId of folder.screenIds) {
+    userData.tabs.order.push(screenId);
+  }
+  removeArrayElement(userData.tabs.folders, folder);
+  removeArrayElement(userData.tabs.order, folderId);
+  if (userData.tabs.folders.length === 0) showDropdown.value = false;
+}
+
+const dropdownStyle = ref<Record<string, string>>({});
+
+watchEffect(() => {
+  if (!showDropdown.value) return;
+  const rect = tabEl.value?.getBoundingClientRect();
+  if (!rect) return;
+  dropdownStyle.value = {
+    top: `${rect.bottom}px`,
+    left: `${rect.left}px`,
+  };
+});
+</script>
+
+<template>
+  <div
+    ref="tab"
+    v-bind="$attrs"
+    :class="[C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular, C.HeadItem.link]"
+    @mouseenter="onTabEnter"
+    @mouseleave="onTabLeave"
+    @click="onClick">
+    <span :class="C.HeadItem.label">FLDR</span>
+    <div :class="[C.HeadItem.indicator, C.HeadItem.indicatorPrimary]" />
+  </div>
+  <Teleport to="body">
+    <div
+      v-if="showDropdown && userData.tabs.folders.length > 0"
+      :class="$style.dropdown"
+      :style="dropdownStyle"
+      @mouseenter="onDropdownEnter"
+      @mouseleave="onDropdownLeave">
+      <div
+        v-for="folder in userData.tabs.folders"
+        :key="folder.id"
+        :class="C.ScreenControls.screen">
+        <span :class="[C.ScreenControls.name, $style.folderName]">{{ folder.name }}</span>
+        <div
+          :class="[C.ScreenControls.delete, C.type.typeSmall, $style.delBtn]"
+          @click.prevent="deleteFolder(folder.id)">
+          DEL
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style module>
+.dropdown {
+  position: fixed;
+  z-index: 9999;
+  background: #181818;
+  border: 1px solid #333;
+  min-width: 120px;
+}
+
+.folderName {
+  color: #7fa8e0;
+}
+
+.delBtn {
+  width: 26px;
+  text-align: center;
+}
+</style>

--- a/src/features/basic/screen-tab-bar/FolderCreator.vue
+++ b/src/features/basic/screen-tab-bar/FolderCreator.vue
@@ -5,8 +5,11 @@ import TextInput from '@src/components/forms/TextInput.vue';
 import Commands from '@src/components/forms/Commands.vue';
 import { userData } from '@src/store/user-data';
 import { createId } from '@src/store/create-id';
+import { useTile } from '@src/hooks/use-tile';
 
+const tile = useTile();
 const name = ref('');
+const showSuccess = ref(false);
 
 onMounted(() => {
   name.value = `FLDR ${userData.tabs.folders.length + 1}`;
@@ -19,6 +22,11 @@ function onCreate() {
   userData.tabs.folders.push({ id, name: trimmed.toUpperCase(), screenIds: [] });
   userData.tabs.order.push(id);
   name.value = `FLDR ${userData.tabs.folders.length + 1}`;
+  showSuccess.value = true;
+}
+
+function dismissSuccess() {
+  showSuccess.value = false;
 }
 </script>
 
@@ -31,4 +39,17 @@ function onCreate() {
       <PrunButton primary type="submit">CREATE</PrunButton>
     </Commands>
   </form>
+  <Teleport :to="tile.frame">
+    <div
+      v-if="showSuccess"
+      :class="[C.ActionFeedback.overlay, C.ActionFeedback.success]"
+      @click="dismissSuccess">
+      <div :class="[C.ActionFeedback.message, C.fonts.fontRegular, C.type.typeLarger]">
+        Action succeeded!
+        <span :class="[C.ActionFeedback.text, C.fonts.fontRegular, C.type.typeRegular]"
+          >(click to dismiss)</span
+        >
+      </div>
+    </div>
+  </Teleport>
 </template>

--- a/src/features/basic/screen-tab-bar/FolderCreator.vue
+++ b/src/features/basic/screen-tab-bar/FolderCreator.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { userData } from '@src/store/user-data';
+import { createId } from '@src/store/create-id';
+
+const name = ref('');
+
+onMounted(() => {
+  name.value = `FLDR ${userData.tabs.folders.length + 1}`;
+});
+
+function onCreate() {
+  const trimmed = name.value.trim();
+  if (!trimmed) return;
+  const id = createId();
+  userData.tabs.folders.push({ id, name: trimmed.toUpperCase(), screenIds: [] });
+  userData.tabs.order.push(id);
+  name.value = `FLDR ${userData.tabs.folders.length + 1}`;
+}
+</script>
+
+<template>
+  <form @submit.prevent="onCreate">
+    <Active label="Folder Name">
+      <TextInput v-model="name" :focus-on-mount="true" />
+    </Active>
+    <Commands>
+      <PrunButton primary type="submit" @click="onCreate">CREATE</PrunButton>
+    </Commands>
+  </form>
+</template>

--- a/src/features/basic/screen-tab-bar/FolderCreator.vue
+++ b/src/features/basic/screen-tab-bar/FolderCreator.vue
@@ -28,7 +28,7 @@ function onCreate() {
       <TextInput v-model="name" :focus-on-mount="true" />
     </Active>
     <Commands>
-      <PrunButton primary type="submit" @click="onCreate">CREATE</PrunButton>
+      <PrunButton primary type="submit">CREATE</PrunButton>
     </Commands>
   </form>
 </template>

--- a/src/features/basic/screen-tab-bar/FolderCreator.vue
+++ b/src/features/basic/screen-tab-bar/FolderCreator.vue
@@ -17,7 +17,9 @@ onMounted(() => {
 
 function onCreate() {
   const trimmed = name.value.trim();
-  if (!trimmed) return;
+  if (!trimmed) {
+    return;
+  }
   const id = createId();
   userData.tabs.folders.push({ id, name: trimmed.toUpperCase(), screenIds: [] });
   userData.tabs.order.push(id);

--- a/src/features/basic/screen-tab-bar/FolderTab.vue
+++ b/src/features/basic/screen-tab-bar/FolderTab.vue
@@ -71,9 +71,13 @@ function removeScreen(screenId: string) {
 const dropdownStyle = ref<Record<string, string>>({});
 
 watchEffect(() => {
-  if (!showDropdown.value) return;
+  if (!showDropdown.value) {
+    return;
+  }
   const rect = tabEl.value?.getBoundingClientRect();
-  if (!rect) return;
+  if (!rect) {
+    return;
+  }
   dropdownStyle.value = {
     top: `${rect.bottom}px`,
     left: `${rect.left}px`,
@@ -105,10 +109,7 @@ function getScreen(id: string) {
       :style="dropdownStyle"
       @mouseenter="onDropdownEnter"
       @mouseleave="onDropdownLeave">
-      <div
-        v-for="screenId in folder.screenIds"
-        :key="screenId"
-        :class="C.ScreenControls.screen">
+      <div v-for="screenId in folder.screenIds" :key="screenId" :class="C.ScreenControls.screen">
         <a
           :href="`#screen=${screenId}`"
           :class="[C.ScreenControls.name, screenId === currentScreenId && $style.currentScreen]">
@@ -117,7 +118,7 @@ function getScreen(id: string) {
         <div
           :class="[C.ScreenControls.delete, C.type.typeSmall, $style.rmvBtn]"
           @click.prevent="removeScreen(screenId)">
-          RMV
+          rmv
         </div>
       </div>
     </div>

--- a/src/features/basic/screen-tab-bar/FolderTab.vue
+++ b/src/features/basic/screen-tab-bar/FolderTab.vue
@@ -101,7 +101,7 @@ function getScreen(id: string) {
   <Teleport to="body">
     <div
       v-if="showDropdown && folder.screenIds.length > 0"
-      :class="$style.dropdown"
+      :class="[$style.dropdown, C.fonts.fontRegular, C.type.typeRegular]"
       :style="dropdownStyle"
       @mouseenter="onDropdownEnter"
       @mouseleave="onDropdownLeave">

--- a/src/features/basic/screen-tab-bar/FolderTab.vue
+++ b/src/features/basic/screen-tab-bar/FolderTab.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { screensStore } from '@src/infrastructure/prun-api/data/screens';
+import { userData } from '@src/store/user-data';
+import removeArrayElement from '@src/utils/remove-array-element';
+
+const { folder } = defineProps<{
+  folder: UserData.TabFolder;
+}>();
+
+const currentScreenId = computed(() => screensStore.current.value?.id);
+const isActive = computed(
+  () => currentScreenId.value !== undefined && folder.screenIds.includes(currentScreenId.value),
+);
+
+const indicatorClasses = computed(() => ({
+  [C.HeadItem.indicator]: true,
+  [C.HeadItem.indicatorPrimary]: true,
+  [C.HeadItem.indicatorPrimaryActive]: isActive.value,
+  [C.effects.shadowPrimary]: isActive.value,
+}));
+
+const tabEl = useTemplateRef<HTMLElement>('tab');
+const showDropdown = ref(false);
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearHide() {
+  if (hideTimer !== null) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+}
+
+function scheduleHide() {
+  hideTimer = setTimeout(() => {
+    showDropdown.value = false;
+    hideTimer = null;
+  }, 150);
+}
+
+function onTabEnter() {
+  clearHide();
+  showDropdown.value = true;
+}
+
+function onTabLeave() {
+  scheduleHide();
+}
+
+function onDropdownEnter() {
+  clearHide();
+}
+
+function onDropdownLeave() {
+  scheduleHide();
+}
+
+function rename() {
+  const name = window.prompt('Folder name:', folder.name);
+  if (name !== null && name.trim() !== '') {
+    folder.name = name.trim().toUpperCase();
+  }
+}
+
+function removeScreen(screenId: string) {
+  removeArrayElement(folder.screenIds, screenId);
+  userData.tabs.order.push(screenId);
+}
+
+function deleteFolder() {
+  for (const screenId of folder.screenIds.slice()) {
+    userData.tabs.order.push(screenId);
+  }
+  removeArrayElement(userData.tabs.order, folder.id);
+  removeArrayElement(userData.tabs.folders, folder);
+  showDropdown.value = false;
+}
+
+const dropdownStyle = ref<Record<string, string>>({});
+
+watchEffect(() => {
+  if (!showDropdown.value) return;
+  const rect = tabEl.value?.getBoundingClientRect();
+  if (!rect) return;
+  dropdownStyle.value = {
+    top: `${rect.bottom}px`,
+    left: `${rect.left}px`,
+  };
+});
+
+function getScreen(id: string) {
+  return screensStore.getById(id);
+}
+</script>
+
+<template>
+  <div
+    ref="tab"
+    :class="$style.folderTab"
+    @mouseenter="onTabEnter"
+    @mouseleave="onTabLeave"
+    @dblclick.prevent="rename">
+    <div :class="[C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular]">
+      <span :class="[C.HeadItem.label, C.links.textLink]">{{ folder.name }}</span>
+      <div :class="indicatorClasses" />
+    </div>
+  </div>
+  <Teleport to="body">
+    <div
+      v-if="showDropdown"
+      :class="$style.dropdown"
+      :style="dropdownStyle"
+      @mouseenter="onDropdownEnter"
+      @mouseleave="onDropdownLeave">
+      <a
+        v-for="screenId in folder.screenIds"
+        :key="screenId"
+        :href="`#screen=${screenId}`"
+        :class="[$style.dropdownItem, screenId === currentScreenId && $style.dropdownItemActive]">
+        <span :class="$style.screenName">{{ getScreen(screenId)?.name ?? screenId }}</span>
+        <span :class="$style.removeBtn" @click.prevent="removeScreen(screenId)">×</span>
+      </a>
+      <div :class="$style.deleteFolder" @click="deleteFolder">delete folder</div>
+    </div>
+  </Teleport>
+</template>
+
+<style module>
+.folderTab {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.dropdown {
+  position: fixed;
+  z-index: 9999;
+  background: #181818;
+  border: 1px solid #333;
+  min-width: 100px;
+}
+
+.dropdownItem {
+  display: flex;
+  align-items: center;
+  padding: 3px 8px;
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    background: #2a2a2a;
+  }
+}
+
+.dropdownItemActive .screenName {
+  color: #7fa8e0;
+}
+
+.screenName {
+  flex: 1;
+}
+
+.removeBtn {
+  margin-left: 8px;
+  cursor: pointer;
+  color: #666;
+
+  &:hover {
+    color: #e55;
+  }
+}
+
+.deleteFolder {
+  padding: 3px 8px;
+  color: #666;
+  cursor: pointer;
+  border-top: 1px solid #333;
+
+  &:hover {
+    color: #e55;
+  }
+}
+</style>

--- a/src/features/basic/screen-tab-bar/FolderTab.vue
+++ b/src/features/basic/screen-tab-bar/FolderTab.vue
@@ -68,15 +68,6 @@ function removeScreen(screenId: string) {
   userData.tabs.order.push(screenId);
 }
 
-function deleteFolder() {
-  for (const screenId of folder.screenIds.slice()) {
-    userData.tabs.order.push(screenId);
-  }
-  removeArrayElement(userData.tabs.order, folder.id);
-  removeArrayElement(userData.tabs.folders, folder);
-  showDropdown.value = false;
-}
-
 const dropdownStyle = ref<Record<string, string>>({});
 
 watchEffect(() => {
@@ -103,26 +94,32 @@ function getScreen(id: string) {
     @mouseleave="onTabLeave"
     @dblclick.prevent="rename">
     <div :class="[C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular]">
-      <span :class="[C.HeadItem.label, C.links.textLink]">{{ folder.name }}</span>
+      <span :class="[C.HeadItem.label, $style.folderLabel]">{{ folder.name }}</span>
       <div :class="indicatorClasses" />
     </div>
   </div>
   <Teleport to="body">
     <div
-      v-if="showDropdown"
+      v-if="showDropdown && folder.screenIds.length > 0"
       :class="$style.dropdown"
       :style="dropdownStyle"
       @mouseenter="onDropdownEnter"
       @mouseleave="onDropdownLeave">
-      <a
+      <div
         v-for="screenId in folder.screenIds"
         :key="screenId"
-        :href="`#screen=${screenId}`"
-        :class="[$style.dropdownItem, screenId === currentScreenId && $style.dropdownItemActive]">
-        <span :class="$style.screenName">{{ getScreen(screenId)?.name ?? screenId }}</span>
-        <span :class="$style.removeBtn" @click.prevent="removeScreen(screenId)">×</span>
-      </a>
-      <div :class="$style.deleteFolder" @click="deleteFolder">delete folder</div>
+        :class="C.ScreenControls.screen">
+        <a
+          :href="`#screen=${screenId}`"
+          :class="[C.ScreenControls.name, screenId === currentScreenId && $style.currentScreen]">
+          {{ getScreen(screenId)?.name ?? screenId }}
+        </a>
+        <div
+          :class="[C.ScreenControls.delete, C.type.typeSmall, $style.rmvBtn]"
+          @click.prevent="removeScreen(screenId)">
+          RMV
+        </div>
+      </div>
     </div>
   </Teleport>
 </template>
@@ -133,52 +130,28 @@ function getScreen(id: string) {
   cursor: pointer;
 }
 
+.folderLabel {
+  color: #7fa8e0;
+
+  &:hover {
+    color: #7fa8e0;
+  }
+}
+
 .dropdown {
   position: fixed;
   z-index: 9999;
   background: #181818;
   border: 1px solid #333;
-  min-width: 100px;
+  min-width: 120px;
 }
 
-.dropdownItem {
-  display: flex;
-  align-items: center;
-  padding: 3px 8px;
-  text-decoration: none;
-  color: inherit;
-
-  &:hover {
-    background: #2a2a2a;
-  }
-}
-
-.dropdownItemActive .screenName {
+.currentScreen {
   color: #7fa8e0;
 }
 
-.screenName {
-  flex: 1;
-}
-
-.removeBtn {
-  margin-left: 8px;
-  cursor: pointer;
-  color: #666;
-
-  &:hover {
-    color: #e55;
-  }
-}
-
-.deleteFolder {
-  padding: 3px 8px;
-  color: #666;
-  cursor: pointer;
-  border-top: 1px solid #333;
-
-  &:hover {
-    color: #e55;
-  }
+.rmvBtn {
+  width: 26px;
+  text-align: center;
 }
 </style>

--- a/src/features/basic/screen-tab-bar/FolderTab.vue
+++ b/src/features/basic/screen-tab-bar/FolderTab.vue
@@ -3,6 +3,8 @@ import { screensStore } from '@src/infrastructure/prun-api/data/screens';
 import { userData } from '@src/store/user-data';
 import removeArrayElement from '@src/utils/remove-array-element';
 
+defineOptions({ inheritAttrs: false });
+
 const { folder } = defineProps<{
   folder: UserData.TabFolder;
 }>();
@@ -95,6 +97,7 @@ function getScreen(id: string) {
 <template>
   <div
     ref="tab"
+    v-bind="$attrs"
     :class="$style.folderTab"
     @mouseenter="onTabEnter"
     @mouseleave="onTabLeave"

--- a/src/features/basic/screen-tab-bar/TabBar.vue
+++ b/src/features/basic/screen-tab-bar/TabBar.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import HeadItem from './HeadItem.vue';
+import FolderTab from './FolderTab.vue';
 import { screensStore } from '@src/infrastructure/prun-api/data/screens';
 import { userData } from '@src/store/user-data';
 import { vDraggable } from 'vue-draggable-plus';
 import { syncState } from '@src/features/basic/screen-tab-bar/sync';
 import { useTemplateRef } from 'vue';
+import removeArrayElement from '@src/utils/remove-array-element';
 
 watchEffect(syncState);
 
@@ -13,6 +15,14 @@ const current = computed(() => screensStore.current.value);
 function getScreen(id: string) {
   return screensStore.getById(id);
 }
+
+const folderMap = computed(() => {
+  const map = new Map<string, UserData.TabFolder>();
+  for (const folder of userData.tabs.folders) {
+    map.set(folder.id, folder);
+  }
+  return map;
+});
 
 const container = useTemplateRef('container');
 
@@ -37,7 +47,6 @@ onMounted(() => {
     'wheel',
     e => {
       e.preventDefault();
-      // Use dominant axis: deltaX for horizontal gestures, deltaY for vertical-to-horizontal mapping.
       const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
       target = Math.max(0, Math.min(target + delta, el.scrollWidth - el.clientWidth));
       if (!animating) {
@@ -48,17 +57,64 @@ onMounted(() => {
     { passive: false },
   );
 });
+
+const pendingFolderDrop = ref<string | null>(null);
+let activeDragId: string | null = null;
+
+function onDragStart(evt: { item: Element }) {
+  activeDragId = (evt.item as HTMLElement).dataset.itemId ?? null;
+}
+
+function onDragMove(evt: { dragged: Element; related: Element }) {
+  const relatedId = (evt.related as HTMLElement).dataset.itemId;
+  const draggedId = (evt.dragged as HTMLElement).dataset.itemId;
+  if (relatedId && draggedId && folderMap.value.has(relatedId) && !folderMap.value.has(draggedId)) {
+    pendingFolderDrop.value = relatedId;
+    return false;
+  }
+  pendingFolderDrop.value = null;
+  return true;
+}
+
+function onDragEnd() {
+  if (pendingFolderDrop.value && activeDragId && !folderMap.value.has(activeDragId)) {
+    const folder = userData.tabs.folders.find(f => f.id === pendingFolderDrop.value);
+    if (folder) {
+      removeArrayElement(userData.tabs.order, activeDragId);
+      folder.screenIds.push(activeDragId);
+    }
+  }
+  pendingFolderDrop.value = null;
+  activeDragId = null;
+}
+
+const draggableOptions = {
+  animation: 150,
+  onStart: onDragStart,
+  onMove: onDragMove,
+  onEnd: onDragEnd,
+};
 </script>
 
 <template>
   <div :class="$style.spacer" />
   <div
     ref="container"
-    v-draggable="[userData.tabs.order, { animation: 150 }]"
+    v-draggable="[userData.tabs.order, draggableOptions]"
     :class="$style.container">
     <template v-for="id in userData.tabs.order" :key="id">
-      <a v-show="!userData.tabs.hidden.includes(id)" :href="`#screen=${id}`" :class="$style.item">
-        <HeadItem :label="getScreen(id).name" :active="current === getScreen(id)" />
+      <FolderTab
+        v-if="folderMap.get(id)"
+        :folder="folderMap.get(id)!"
+        :data-item-id="id"
+        :class="pendingFolderDrop === id ? $style.folderHovered : undefined" />
+      <a
+        v-else
+        v-show="!userData.tabs.hidden.includes(id)"
+        :href="`#screen=${id}`"
+        :class="$style.item"
+        :data-item-id="id">
+        <HeadItem :label="getScreen(id)?.name ?? ''" :active="current === getScreen(id)" />
       </a>
     </template>
   </div>
@@ -82,5 +138,10 @@ onMounted(() => {
   > .item {
     flex-shrink: 0;
   }
+}
+
+.folderHovered {
+  outline: 1px solid #7fa8e0;
+  outline-offset: -1px;
 }
 </style>

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -70,17 +70,21 @@ function extractScreenId(url?: string) {
 
 function addFolder() {
   const n = userData.tabs.folders.length + 1;
+  const name = window.prompt('Folder name:', `FLDR ${n}`);
+  if (name === null || name.trim() === '') return;
   const id = `fldr-${Math.random().toString(36).slice(2, 9)}`;
-  userData.tabs.folders.push({ id, name: `FLDR ${n}`, screenIds: [] });
+  userData.tabs.folders.push({ id, name: name.trim().toUpperCase(), screenIds: [] });
   userData.tabs.order.push(id);
 }
 
 function onContainerReady(container: HTMLElement) {
   createFragmentApp(TabBar).appendTo(container);
+  let fldrInserted = false;
   subscribe($$(container, C.HeadItem.label), label => {
-    if (label.textContent !== 'FULL') return;
+    if (fldrInserted || label.textContent !== 'FULL') return;
     const fullItem = label.closest(`.${C.HeadItem.container}`) as HTMLElement | null;
-    if (!fullItem || fullItem.parentElement !== container) return;
+    if (!fullItem) return;
+    fldrInserted = true;
     createFragmentApp(() => (
       <div
         class={[C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular, C.HeadItem.link]}

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -1,11 +1,11 @@
 import $style from './screen-tab-bar.module.css';
 import TabBar from './TabBar.vue';
 import FolderCreator from './FolderCreator.vue';
+import FldrButton from './FldrButton.vue';
 import { userData } from '@src/store/user-data';
 import removeArrayElement from '@src/utils/remove-array-element';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { syncState } from '@src/features/basic/screen-tab-bar/sync';
-import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
 function onListReady(list: HTMLElement) {
   subscribe($$(list, C.ScreenControls.screen), onScreenItemReady);
@@ -70,10 +70,6 @@ function extractScreenId(url?: string) {
   return url?.match(/screen=([\w-]+)/)?.[1] ?? undefined;
 }
 
-function addFolder() {
-  void showBuffer('XIT FLDR');
-}
-
 function onContainerReady(container: HTMLElement) {
   createFragmentApp(TabBar).appendTo(container);
   let fldrInserted = false;
@@ -82,14 +78,7 @@ function onContainerReady(container: HTMLElement) {
     const fullItem = label.closest(`.${C.HeadItem.container}`) as HTMLElement | null;
     if (!fullItem) return;
     fldrInserted = true;
-    createFragmentApp(() => (
-      <div
-        class={[C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular, C.HeadItem.link]}
-        onClick={addFolder}>
-        <span class={C.HeadItem.label}>FLDR</span>
-        <div class={[C.HeadItem.indicator, C.HeadItem.indicatorPrimary]} />
-      </div>
-    )).before(fullItem);
+    createFragmentApp(FldrButton).before(fullItem);
   });
 }
 

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -1,9 +1,11 @@
 import $style from './screen-tab-bar.module.css';
 import TabBar from './TabBar.vue';
+import FolderCreator from './FolderCreator.vue';
 import { userData } from '@src/store/user-data';
 import removeArrayElement from '@src/utils/remove-array-element';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { syncState } from '@src/features/basic/screen-tab-bar/sync';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
 function onListReady(list: HTMLElement) {
   subscribe($$(list, C.ScreenControls.screen), onScreenItemReady);
@@ -69,12 +71,7 @@ function extractScreenId(url?: string) {
 }
 
 function addFolder() {
-  const n = userData.tabs.folders.length + 1;
-  const name = window.prompt('Folder name:', `FLDR ${n}`);
-  if (name === null || name.trim() === '') return;
-  const id = `fldr-${Math.random().toString(36).slice(2, 9)}`;
-  userData.tabs.folders.push({ id, name: name.trim().toUpperCase(), screenIds: [] });
-  userData.tabs.order.push(id);
+  void showBuffer('XIT FLDR');
 }
 
 function onContainerReady(container: HTMLElement) {
@@ -101,6 +98,13 @@ function init() {
   subscribe($$(document, C.ScreenControls.screens), onListReady);
   applyCssRule(`.${C.Head.contextAndScreens}`, $style.contextAndScreens);
   applyCssRule(`.${C.ScreenControls.container}`, $style.screenControls);
+  xit.add({
+    command: 'FLDR',
+    name: 'NEW FOLDER',
+    description: 'Create a new screen folder.',
+    component: () => FolderCreator,
+    bufferSize: [300, 110],
+  });
 }
 
 features.add(import.meta.url, init, 'Adds a tab bar for user screens.');

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -74,9 +74,13 @@ function onContainerReady(container: HTMLElement) {
   createFragmentApp(TabBar).appendTo(container);
   let fldrInserted = false;
   subscribe($$(container, C.HeadItem.label), label => {
-    if (fldrInserted || label.textContent !== 'FULL') return;
+    if (fldrInserted || label.textContent !== 'FULL') {
+      return;
+    }
     const fullItem = label.closest(`.${C.HeadItem.container}`) as HTMLElement | null;
-    if (!fullItem) return;
+    if (!fullItem) {
+      return;
+    }
     fldrInserted = true;
     createFragmentApp(FldrButton).before(fullItem);
   });

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -92,7 +92,7 @@ function init() {
     name: 'NEW FOLDER',
     description: 'Create a new screen folder.',
     component: () => FolderCreator,
-    bufferSize: [300, 110],
+    bufferSize: [450, 110],
   });
 }
 

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -68,10 +68,32 @@ function extractScreenId(url?: string) {
   return url?.match(/screen=([\w-]+)/)?.[1] ?? undefined;
 }
 
-function init() {
-  subscribe($$(document, C.ScreenControls.container), container => {
-    createFragmentApp(TabBar).appendTo(container);
+function addFolder() {
+  const n = userData.tabs.folders.length + 1;
+  const id = `fldr-${Math.random().toString(36).slice(2, 9)}`;
+  userData.tabs.folders.push({ id, name: `FLDR ${n}`, screenIds: [] });
+  userData.tabs.order.push(id);
+}
+
+function onContainerReady(container: HTMLElement) {
+  createFragmentApp(TabBar).appendTo(container);
+  subscribe($$(container, C.HeadItem.label), label => {
+    if (label.textContent !== 'FULL') return;
+    const fullItem = label.closest(`.${C.HeadItem.container}`) as HTMLElement | null;
+    if (!fullItem || fullItem.parentElement !== container) return;
+    createFragmentApp(() => (
+      <div
+        class={[C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular, C.HeadItem.link]}
+        onClick={addFolder}>
+        <span class={C.HeadItem.label}>FLDR</span>
+        <div class={[C.HeadItem.indicator, C.HeadItem.indicatorPrimary]} />
+      </div>
+    )).before(fullItem);
   });
+}
+
+function init() {
+  subscribe($$(document, C.ScreenControls.container), onContainerReady);
   subscribe($$(document, C.ScreenControls.screens), onListReady);
   applyCssRule(`.${C.Head.contextAndScreens}`, $style.contextAndScreens);
   applyCssRule(`.${C.ScreenControls.container}`, $style.screenControls);

--- a/src/features/basic/screen-tab-bar/sync.ts
+++ b/src/features/basic/screen-tab-bar/sync.ts
@@ -7,23 +7,42 @@ export function syncState() {
   if (!sorted) {
     return;
   }
-  const order = userData.tabs.order;
-  const hidden = userData.tabs.hidden;
-  const tracked = new Set<string>([...order, ...hidden]);
+  const { order, hidden, folders } = userData.tabs;
+  const existingScreenIds = new Set<string>(sorted.map(x => x.id));
+  const folderIds = new Set<string>(folders.map(f => f.id));
+  const screensInFolders = new Set<string>(folders.flatMap(f => f.screenIds));
+
+  const trackedScreenIds = new Set<string>([...hidden, ...screensInFolders]);
+  for (const id of order) {
+    if (!folderIds.has(id)) {
+      trackedScreenIds.add(id);
+    }
+  }
+
   for (const tab of sorted) {
-    if (!tracked.has(tab.id)) {
+    if (!trackedScreenIds.has(tab.id)) {
       order.push(tab.id);
     }
   }
-  const existing = new Set<string>(sorted.map(x => x.id));
-  for (const id of order) {
-    if (!existing.has(id)) {
-      removeArrayElement(order, id);
+
+  for (let i = order.length - 1; i >= 0; i--) {
+    const id = order[i];
+    if (!folderIds.has(id) && !existingScreenIds.has(id)) {
+      order.splice(i, 1);
     }
   }
-  for (const id of hidden) {
-    if (!existing.has(id)) {
+
+  for (const id of hidden.slice()) {
+    if (!existingScreenIds.has(id)) {
       removeArrayElement(hidden, id);
+    }
+  }
+
+  for (const folder of folders) {
+    for (let i = folder.screenIds.length - 1; i >= 0; i--) {
+      if (!existingScreenIds.has(folder.screenIds[i])) {
+        folder.screenIds.splice(i, 1);
+      }
     }
   }
 }

--- a/src/store/user-data-migrations.ts
+++ b/src/store/user-data-migrations.ts
@@ -17,6 +17,12 @@ function isCheckpoint(entry: MigrationEntry): entry is Checkpoint {
 // The date is for reference only, and it does not affect migration order.
 const migrations: MigrationEntry[] = [
   [
+    '10.05.2026 Add tab folders',
+    userData => {
+      userData.tabs.folders = [];
+    },
+  ],
+  [
     '25.04.2026 Add per-planet repair overrides',
     userData => {
       userData.settings.repair.planetOverrides = {};

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -71,6 +71,7 @@ export const initialUserData = deepFreeze({
     order: [] as string[],
     hidden: [] as string[],
     locked: [] as string[],
+    folders: [] as UserData.TabFolder[],
   },
   commandLists: [] as UserData.CommandList[],
   linkedBuffersPresets: [] as UserData.LinkedBuffersPreset[],

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -155,4 +155,10 @@ declare namespace UserData {
     width: number;
     height: number;
   }
+
+  interface TabFolder {
+    id: string;
+    name: string;
+    screenIds: string[];
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a **FLDR** button to the tab bar header (between ADD and FULL) that opens an `XIT FLDR` buffer for creating named screen folders
- Folders appear as **blue tabs** in the tab bar; hovering reveals a dropdown listing their screens with `rmv` buttons to move screens back to the main bar
- **Drag a screen tab onto a folder tab** to add it to that folder
- Hovering the **FLDR button** shows a dropdown of all folders with `del` buttons for deletion
- Creating a folder shows a native-styled **Action succeeded!** overlay (click to dismiss)

## Implementation notes

- `UserData.TabFolder` added to user data types; migration `10.05.2026 Add tab folders` handles existing saves
- `sync.ts` updated to track folder IDs in `order` and clean up stale screen IDs from folders
- `FolderTab.vue`: multi-root fragment — uses `defineOptions({ inheritAttrs: false })` + `v-bind="$attrs"` so Sortable.js `data-item-id` attributes reach the DOM correctly
- `FldrButton.vue`: same multi-root pattern; hover dropdown for folder deletion
- `FolderCreator.vue`: XIT buffer component; success overlay uses `useTile()` + `<Teleport>` into `tile.frame` with game's `C.ActionFeedback` CSS classes
- Dropdowns use `C.fonts.fontRegular` + `C.type.typeRegular` explicitly (Teleport to body escapes parent font inheritance)

https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD)_