### PR TITLE
Add screen folders to the tab bar

### DIFF
--- a/src/features/basic/screen-tab-bar/sync.ts
+++ b/src/features/basic/screen-tab-bar/sync.ts
@@ -32,6 +32,12 @@ export function syncState() {
     }
   }
 
+  for (let i = order.length - 1; i >= 0; i--) {
+    if (screensInFolders.has(order[i])) {
+      order.splice(i, 1);
+    }
+  }
+
   for (const id of hidden.slice()) {
     if (!existingScreenIds.has(id)) {
       removeArrayElement(hidden, id);


### PR DESCRIPTION
## Summary

- Adds a **FLDR** button to the tab bar header (between ADD and FULL) that opens an `XIT FLDR` buffer for creating named screen folders
- Folders appear as **blue tabs** in the tab bar; hovering reveals a dropdown listing their screens with `rmv` buttons to move screens back to the main bar
- **Drag a screen tab onto a folder tab** to add it to that folder
- Hovering the **FLDR button** shows a dropdown of all folders with `del` buttons for deletion
- Creating a folder shows a native-styled **Action succeeded!** overlay (click to dismiss)

## Implementation notes

- `UserData.TabFolder` added to user data types; migration `10.05.2026 Add tab folders` handles existing saves
- `sync.ts` updated to track folder IDs in `order`, clean up stale screen IDs from folders, and evict from `order` any screen already assigned to a folder (fixes intermittent drag race with vue-draggable-plus)
- `FolderTab.vue`: multi-root fragment — uses `defineOptions({ inheritAttrs: false })` + `v-bind="$attrs"` so Sortable.js `data-item-id` attributes reach the DOM correctly
- `FldrButton.vue`: same multi-root pattern; hover dropdown for folder deletion
- `FolderCreator.vue`: XIT buffer component; success overlay uses `useTile()` + `<Teleport>` into `tile.frame` with game's `C.ActionFeedback` CSS classes
- Dropdowns use `C.fonts.fontRegular` + `C.type.typeRegular` explicitly (Teleport to body escapes parent font inheritance)

https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD)_