### PR TITLE
Allow screen folders to be disabled independently

### DIFF
--- a/src/features/basic/screen-tab-bar/screen-tab-bar-folders.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar-folders.tsx
@@ -1,0 +1,30 @@
+import FolderCreator from './FolderCreator.vue';
+import FldrButton from './FldrButton.vue';
+
+function onContainerReady(container: HTMLElement) {
+  let fldrInserted = false;
+  subscribe($$(container, C.HeadItem.label), label => {
+    if (fldrInserted || label.textContent !== 'FULL') {
+      return;
+    }
+    const fullItem = label.closest(`.${C.HeadItem.container}`) as HTMLElement | null;
+    if (!fullItem) {
+      return;
+    }
+    fldrInserted = true;
+    createFragmentApp(FldrButton).before(fullItem);
+  });
+}
+
+function init() {
+  subscribe($$(document, C.ScreenControls.container), onContainerReady);
+  xit.add({
+    command: 'FLDR',
+    name: 'NEW FOLDER',
+    description: 'Create a new screen folder.',
+    component: () => FolderCreator,
+    bufferSize: [450, 110],
+  });
+}
+
+features.add(import.meta.url, init, 'Adds folder management to the screen tab bar.');

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -1,7 +1,5 @@
 import $style from './screen-tab-bar.module.css';
 import TabBar from './TabBar.vue';
-import FolderCreator from './FolderCreator.vue';
-import FldrButton from './FldrButton.vue';
 import { userData } from '@src/store/user-data';
 import removeArrayElement from '@src/utils/remove-array-element';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
@@ -72,18 +70,6 @@ function extractScreenId(url?: string) {
 
 function onContainerReady(container: HTMLElement) {
   createFragmentApp(TabBar).appendTo(container);
-  let fldrInserted = false;
-  subscribe($$(container, C.HeadItem.label), label => {
-    if (fldrInserted || label.textContent !== 'FULL') {
-      return;
-    }
-    const fullItem = label.closest(`.${C.HeadItem.container}`) as HTMLElement | null;
-    if (!fullItem) {
-      return;
-    }
-    fldrInserted = true;
-    createFragmentApp(FldrButton).before(fullItem);
-  });
 }
 
 function init() {
@@ -91,13 +77,6 @@ function init() {
   subscribe($$(document, C.ScreenControls.screens), onListReady);
   applyCssRule(`.${C.Head.contextAndScreens}`, $style.contextAndScreens);
   applyCssRule(`.${C.ScreenControls.container}`, $style.screenControls);
-  xit.add({
-    command: 'FLDR',
-    name: 'NEW FOLDER',
-    description: 'Create a new screen folder.',
-    component: () => FolderCreator,
-    bufferSize: [450, 110],
-  });
 }
 
 features.add(import.meta.url, init, 'Adds a tab bar for user screens.');


### PR DESCRIPTION
## Summary

Splits the folder UI out of `screen-tab-bar` into its own feature (`screen-tab-bar-folders`) so users can disable folder management without disabling the tab bar itself.

- `screen-tab-bar` — tab bar, screen sorting, hide/show buttons (unchanged behaviour)
- `screen-tab-bar-folders` *(new)* — FLDR button + `XIT FLDR` buffer; add to `userData.settings.disabled` to disable

Disabling `screen-tab-bar-folders` hides the FLDR button and prevents creating new folders. Existing folders remain as tabs until the user removes them via the FLDR dropdown before disabling.

https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD)_