### PR TITLE
Claude/rename lb edit button mv ts q

### DIFF
--- a/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue
+++ b/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue
@@ -336,7 +336,7 @@ function onCreateClick() {
       </tbody>
     </table>
     <ActionBar>
-      <PrunButton primary @click="openEditor">ADD CMD</PrunButton>
+      <PrunButton primary @click="openEditor">EDIT CMDS</PrunButton>
       <PrunButton primary @click="saveLayout">SAVE LAYOUT</PrunButton>
     </ActionBar>
   </div>

--- a/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue
+++ b/src/features/XIT/LINKEDBUFFERS/LINKEDBUFFERS.vue
@@ -336,8 +336,8 @@ function onCreateClick() {
       </tbody>
     </table>
     <ActionBar>
+      <PrunButton primary @click="openEditor">ADD CMD</PrunButton>
       <PrunButton primary @click="saveLayout">SAVE LAYOUT</PrunButton>
-      <PrunButton primary @click="openEditor">EDIT</PrunButton>
     </ActionBar>
   </div>
 </template>


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
