### PR TITLE
Fix screen folder bugs: hide from native list, re-add reliability, tab persistence

### DIFF
--- a/src/features/basic/screen-tab-bar/FldrButton.vue
+++ b/src/features/basic/screen-tab-bar/FldrButton.vue
@@ -103,7 +103,7 @@ watchEffect(() => {
         <span :class="[C.ScreenControls.name, $style.folderName]">{{ folder.name }}</span>
         <div
           :class="[C.ScreenControls.delete, C.type.typeSmall, $style.delBtn]"
-          @click.prevent="deleteFolder(folder.id)">
+          @click.stop.prevent="deleteFolder(folder.id)">
           del
         </div>
       </div>

--- a/src/features/basic/screen-tab-bar/FolderTab.vue
+++ b/src/features/basic/screen-tab-bar/FolderTab.vue
@@ -117,7 +117,7 @@ function getScreen(id: string) {
         </a>
         <div
           :class="[C.ScreenControls.delete, C.type.typeSmall, $style.rmvBtn]"
-          @click.prevent="removeScreen(screenId)">
+          @click.stop.prevent="removeScreen(screenId)">
           rmv
         </div>
       </div>

--- a/src/features/basic/screen-tab-bar/TabBar.vue
+++ b/src/features/basic/screen-tab-bar/TabBar.vue
@@ -76,9 +76,25 @@ function onDragMove(evt: { dragged: Element; related: Element }) {
   return true;
 }
 
-function onDragEnd() {
-  if (pendingFolderDrop.value && activeDragId && !folderMap.value.has(activeDragId)) {
-    const folder = userData.tabs.folders.find(f => f.id === pendingFolderDrop.value);
+function onDragEnd(evt: { originalEvent?: Event }) {
+  let targetFolderId = pendingFolderDrop.value;
+
+  // Prefer actual cursor position at drop time over the last onMove state,
+  // because onMove clears pendingFolderDrop when Sortable repositions the
+  // dragged element right after the folder on the same tick as the drop.
+  if (!targetFolderId && evt.originalEvent && 'clientX' in evt.originalEvent) {
+    const { clientX, clientY } = evt.originalEvent as MouseEvent;
+    for (const el of document.elementsFromPoint(clientX, clientY)) {
+      const itemId = (el as HTMLElement).dataset?.itemId;
+      if (itemId && folderMap.value.has(itemId)) {
+        targetFolderId = itemId;
+        break;
+      }
+    }
+  }
+
+  if (targetFolderId && activeDragId && !folderMap.value.has(activeDragId)) {
+    const folder = userData.tabs.folders.find(f => f.id === targetFolderId);
     if (folder) {
       removeArrayElement(userData.tabs.order, activeDragId);
       folder.screenIds.push(activeDragId);

--- a/src/features/basic/screen-tab-bar/TabBar.vue
+++ b/src/features/basic/screen-tab-bar/TabBar.vue
@@ -95,9 +95,14 @@ function onDragEnd(evt: { originalEvent?: Event }) {
 
   if (targetFolderId && activeDragId && !folderMap.value.has(activeDragId)) {
     const folder = userData.tabs.folders.find(f => f.id === targetFolderId);
+    const screenId = activeDragId;
     if (folder) {
-      removeArrayElement(userData.tabs.order, activeDragId);
-      folder.screenIds.push(activeDragId);
+      folder.screenIds.push(screenId);
+      // Defer removal until after vue-draggable-plus's own model update (nextTick)
+      // so it doesn't re-insert the screen after we remove it.
+      nextTick(() => {
+        removeArrayElement(userData.tabs.order, screenId);
+      });
     }
   }
   pendingFolderDrop.value = null;

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -38,6 +38,11 @@ async function onScreenItemReady(item: HTMLElement) {
   }
   const copy = await $(item, C.ScreenControls.copy);
   const hidden = computed(() => userData.tabs.hidden.includes(id));
+  const inFolder = computed(() => userData.tabs.folders.some(f => f.screenIds.includes(id)));
+
+  watchEffectWhileNodeAlive(item, () => {
+    item.style.display = inFolder.value ? 'none' : '';
+  });
 
   watchEffectWhileNodeAlive(name, () => {
     if (hidden.value) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Hide folder screens from native SCRNS list**: Screens added to folders were still appearing in the game's native screen list. Fixed by adding a reactive `watchEffect` per screen item that sets `display: none` while the screen is in any folder.
- **Fix RMV/DEL button propagation**: The game has a document-level click listener on the `ScreenControls.delete` CSS class; clicking RMV/DEL was triggering it and deleting screens. Fixed by adding `.stop` to the click modifier (`@click.stop.prevent`).
- **Fix folder re-add reliability**: After removing a screen from a folder and dragging it back, the drop sometimes failed. `onMove` clears `pendingFolderDrop` when Sortable repositions the dragged element adjacent to the folder on the same tick as the drop. Fixed by using `document.elementsFromPoint` on the actual cursor position in `onEnd` as a fallback.
- **Fix screen tab persisting after drag-to-folder**: After a successful drag-to-folder, the screen tab remained visible until reload. vue-draggable-plus re-inserts the dragged item into the order array via its own `nextTick` callback after `onEnd` fires. Fixed by deferring our `removeArrayElement` to `nextTick` so it always runs after the library's update. `syncState`'s eviction loop serves as a final backstop.

## Test plan

- [ ] Drag a screen tab onto a folder tab — screen should disappear from tab bar immediately and appear in folder dropdown
- [ ] RMV a screen from a folder dropdown — screen should reappear in tab bar, not disappear entirely
- [ ] Re-add a removed screen back to a folder by dragging — should work reliably every time
- [ ] Open native SCRNS list — folder screens should not appear there
- [ ] DEL a folder — its screens should return to the tab bar, not disappear

https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQZXgSK8ARPHcLeMEBzveD)_