### PR TITLE
PLI: Show COGC program type in Chamber of Global Commerce row

### DIFF
--- a/src/features/basic/pli-cogc-label.ts
+++ b/src/features/basic/pli-cogc-label.ts
@@ -1,0 +1,35 @@
+import { planetsStore } from '@src/infrastructure/prun-api/data/planets';
+
+function formatCogcLabel(programType?: string | null) {
+  if (!programType) {
+    return 'COGC (Inactive)';
+  }
+  for (const prefix of ['ADVERTISING_', 'WORKFORCE_']) {
+    if (programType.startsWith(prefix)) {
+      const suffix = programType.slice(prefix.length);
+      return `COGC (${suffix.charAt(0) + suffix.slice(1).toLowerCase()})`;
+    }
+  }
+  return `COGC (${programType.charAt(0) + programType.slice(1).toLowerCase()})`;
+}
+
+function onTileReady(tile: PrunTile) {
+  subscribe($$(tile.anchor, C.PlanetaryProjectsList.row), row => {
+    const link = _$(row, C.Link.link);
+    if (!link || link.textContent !== 'Chamber of Global Commerce') {
+      return;
+    }
+    const programType = planetsStore.find(tile.parameter)?.cogcProgramType;
+    link.textContent = formatCogcLabel(programType);
+  });
+}
+
+function init() {
+  tiles.observe('PLI', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'PLI: Replaces "Chamber of Global Commerce" row label with "COGC ({program type})".',
+);

--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -5,6 +5,7 @@ import { createMapGetter } from '@src/infrastructure/prun-api/data/create-map-ge
 interface Planet {
   naturalId: string;
   name: string;
+  cogcProgramType?: string | null;
 }
 
 const store = createEntityStore<Planet>({
@@ -17,6 +18,12 @@ onApiMessage({
   FIO_PLANET_DATA(data: { planets: Planet[] }) {
     store.setAll(data.planets);
     store.setFetched();
+  },
+  DATA_DATA(data: { body: { naturalId: string; cogcProgramType?: string | null }; path: string[] }) {
+    if (data.path[0] !== 'planets' || data.path.length !== 2) {
+      return;
+    }
+    store.updateOne({ naturalId: data.body.naturalId, cogcProgramType: data.body.cogcProgramType });
   },
 });
 

--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -23,7 +23,10 @@ onApiMessage({
     if (data.path[0] !== 'planets' || data.path.length !== 2) {
       return;
     }
-    store.updateOne({ naturalId: data.body.naturalId, cogcProgramType: data.body.cogcProgramType });
+    const existing = state.getById(data.body.naturalId);
+    if (existing) {
+      store.updateOne({ ...existing, cogcProgramType: data.body.cogcProgramType });
+    }
   },
 });
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Captures `cogcProgramType` from the game's `DATA_DATA` WebSocket message when a PLI tab is opened, storing it on the planet entity in `planetsStore`
- Adds `pli-cogc-label` feature that replaces the "Chamber of Global Commerce" row label in PLI with a shorter, more informative format:
  - `ADVERTISING_ELECTRONICS` → `COGC (Electronics)`
  - `WORKFORCE_PIONEERS` → `COGC (Pioneers)`
  - `null` (no active program) → `COGC (Inactive)`

## Test plan

- [ ] Open a PLI tab for a planet with an active CoGC industry program — row should show e.g. `COGC (Electronics)`
- [ ] Open a PLI tab for a planet with an active CoGC workforce program — row should show e.g. `COGC (Pioneers)`
- [ ] Open a PLI tab for a planet with no active CoGC program — row should show `COGC (Inactive)`
- [ ] Toggling off `pli-cogc-label` in feature settings restores the original label

https://claude.ai/code/session_01WxzUEJrU7qyThSEyyKxgZU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxzUEJrU7qyThSEyyKxgZU)_