### PR TITLE
fix(burnact): account for cross-demand in workforce/production filters

### DIFF
--- a/src/features/XIT/ACT/material-groups/resupply/bill.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/bill.ts
@@ -31,8 +31,8 @@ export function computeResupplyBill(
 
   const filter = materialFilter ?? (data.consumablesOnly ? 'Workforce' : 'All');
   const planetBurn = calculatePlanetBurn(
-    filter === 'Workforce' ? undefined : production,
-    filter === 'Production' ? undefined : workforce,
+    production,
+    workforce,
     (data.useBaseInv ?? true) ? stores : undefined,
   );
 
@@ -43,6 +43,15 @@ export function computeResupplyBill(
       continue;
     }
     const matBurn = planetBurn[ticker];
+    // For filtered modes, only include materials with primary demand type.
+    // Still use full dailyAmount so cross-demand (e.g. a workforce consumable
+    // that is also a production input) is fully accounted for.
+    if (filter === 'Workforce' && matBurn.workforce === 0) {
+      continue;
+    }
+    if (filter === 'Production' && matBurn.input === 0) {
+      continue;
+    }
     if (matBurn.dailyAmount >= 0) {
       continue;
     }


### PR DESCRIPTION
## Summary

- When the **Workforce** filter is selected, materials that are also production inputs now have their full demand counted (not just workforce consumption). For example, if `DW` is needed by workers *and* used as a recipe input, both demands are included in the resupply bill.
- The same fix applies in reverse for the **Production** filter: if a production input is also a workforce consumable, the workforce demand is added too.
- **All** filter behavior is unchanged.

## Root cause

`bill.ts` previously passed `undefined` for production when filter was `'Workforce'` (and `undefined` for workforce when filter was `'Production'`), which zeroed out cross-demand entirely inside `calculatePlanetBurn`. The fix always passes both datasets, then gates *inclusion* on whether the material has the primary demand type (`workforce > 0` for Workforce, `input > 0` for Production). The `dailyAmount` naturally captures the combined demand.

## Scope

Affects `computeResupplyBill` in `bill.ts`, which is the shared codepath for both XIT ACT resupply material groups and BURNACT.

## Test plan

- [ ] Planet where a material (e.g. `DW`) is both a workforce consumable and a production input: Workforce filter bill should now include the production portion of its demand
- [ ] Same scenario with Production filter: workforce portion of demand included
- [ ] Planet with no cross-demand materials: Workforce and Production filter bills unchanged
- [ ] All filter: no change in behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_015ByWJTzdMJ976mjGCkxNJb)_