### PR TITLE
CONTD: bulk commodity row insertion

### DIFF
--- a/src/features/basic/contd-bulk-add-commodity.module.css
+++ b/src/features/basic/contd-bulk-add-commodity.module.css
@@ -1,0 +1,5 @@
+.countInput {
+  width: 48px;
+  margin-right: 4px;
+  text-align: center;
+}

--- a/src/features/basic/contd-bulk-add-commodity.tsx
+++ b/src/features/basic/contd-bulk-add-commodity.tsx
@@ -24,12 +24,19 @@ function onTileReady(tile: PrunTile) {
     countInput.className = $style.countInput;
     addBtn.before(countInput);
 
+    let running = false;
     addBtn.addEventListener('click', async () => {
-      const n = Math.max(1, parseInt(countInput.value, 10) || 1);
-      for (let i = 1; i < n; i++) {
-        const expected = _$$(tile.anchor, C.TemplateSelection.group).length + 1;
-        await waitForGroups(tile.anchor, expected);
-        await clickElement(findAddButton(tile.anchor));
+      if (running) return;
+      running = true;
+      try {
+        const n = Math.max(1, parseInt(countInput.value, 10) || 1);
+        for (let i = 1; i < n; i++) {
+          const expected = _$$(tile.anchor, C.TemplateSelection.group).length + 1;
+          await waitForGroups(tile.anchor, expected);
+          await clickElement(findAddButton(tile.anchor));
+        }
+      } finally {
+        running = false;
       }
     });
   });

--- a/src/features/basic/contd-bulk-add-commodity.tsx
+++ b/src/features/basic/contd-bulk-add-commodity.tsx
@@ -1,0 +1,52 @@
+import { clickElement } from '@src/util';
+import { sleep } from '@src/utils/sleep';
+import $style from './contd-bulk-add-commodity.module.css';
+
+function findAddButton(anchor: Element) {
+  return _$$(anchor, 'button').find(btn => {
+    const t = btn.textContent?.trim().toLowerCase();
+    return t === 'add commodity' || t === 'add shipment';
+  }) as HTMLElement | undefined;
+}
+
+function onTileReady(tile: PrunTile) {
+  subscribe($$(tile.anchor, C.TemplateSelection.buttons), async buttons => {
+    const addBtn = (await $(buttons, 'button')) as HTMLElement;
+
+    const countInput = document.createElement('input');
+    countInput.type = 'number';
+    countInput.min = '1';
+    countInput.value = '1';
+    countInput.className = $style.countInput;
+    addBtn.before(countInput);
+
+    addBtn.addEventListener('click', async () => {
+      const n = Math.max(1, parseInt(countInput.value, 10) || 1);
+      for (let i = 1; i < n; i++) {
+        const expected = _$$(tile.anchor, C.TemplateSelection.group).length + 1;
+        await waitForGroups(tile.anchor, expected);
+        await clickElement(findAddButton(tile.anchor));
+      }
+    });
+  });
+}
+
+async function waitForGroups(anchor: Element, expected: number, timeout = 2000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (_$$(anchor, C.TemplateSelection.group).length >= expected) {
+      return;
+    }
+    await sleep(50);
+  }
+}
+
+function init() {
+  tiles.observe('CONTD', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'CONTD: Adds a count input beside the add commodity/shipment button to add multiple rows at once.',
+);

--- a/src/features/basic/contd-bulk-add-commodity.tsx
+++ b/src/features/basic/contd-bulk-add-commodity.tsx
@@ -26,10 +26,13 @@ function onTileReady(tile: PrunTile) {
 
     let running = false;
     addBtn.addEventListener('click', async () => {
-      if (running) return;
+      if (running) {
+        return;
+      }
       running = true;
       try {
-        const n = Math.max(1, parseInt(countInput.value, 10) || 1);
+        const parsed = parseInt(countInput.value, 10);
+        const n = Math.max(1, isNaN(parsed) ? 1 : parsed);
         for (let i = 1; i < n; i++) {
           const expected = _$$(tile.anchor, C.TemplateSelection.group).length + 1;
           await waitForGroups(tile.anchor, expected);

--- a/src/features/basic/contd-bulk-add-commodity.tsx
+++ b/src/features/basic/contd-bulk-add-commodity.tsx
@@ -10,8 +10,12 @@ function findAddButton(anchor: Element) {
 }
 
 function onTileReady(tile: PrunTile) {
-  subscribe($$(tile.anchor, C.TemplateSelection.buttons), async buttons => {
-    const addBtn = (await $(buttons, 'button')) as HTMLElement;
+  subscribe($$(tile.anchor, 'button'), btn => {
+    const t = (btn as HTMLButtonElement).textContent?.trim().toLowerCase();
+    if (t !== 'add commodity' && t !== 'add shipment') {
+      return;
+    }
+    const addBtn = btn as HTMLElement;
 
     const countInput = document.createElement('input');
     countInput.type = 'number';


### PR DESCRIPTION
## Summary

- Adds a count input (default 1) to the left of the add commodity/shipment button in the CONTD template selection table
- Clicking the button adds N rows sequentially, waiting for each to render before clicking again
- Works for both "add commodity" and "add shipment" button variants

## Test plan

- [ ] Open a `CONTD <name>` buffer and click "Select Template"
- [ ] Confirm the number input appears to the left of the add commodity/shipment button, defaulting to 1
- [ ] Set count to 1 — clicking add commodity adds exactly 1 row (existing behavior unchanged)
- [ ] Set count to N — clicking add commodity adds exactly N rows
- [ ] Confirm no extra rows are added (re-entrancy guard working)

https://claude.ai/code/session_01QAHD1fdVaDVEartzhtxT1h

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAHD1fdVaDVEartzhtxT1h)_