### PR TITLE
fix: resolve prettier linting warnings in 3 files

### DIFF
--- a/src/features/XIT/NOBUY/NOBUY.vue
+++ b/src/features/XIT/NOBUY/NOBUY.vue
@@ -47,13 +47,8 @@ function onInputKeydown(ev: KeyboardEvent) {
 
 <template>
   <SectionHeader>No-Buy List</SectionHeader>
-  <Passive v-if="userData.settings.noBuy.length === 0" label="Materials">
-    None
-  </Passive>
-  <Passive
-    v-for="ticker in userData.settings.noBuy"
-    :key="ticker"
-    :label="ticker">
+  <Passive v-if="userData.settings.noBuy.length === 0" label="Materials"> None </Passive>
+  <Passive v-for="ticker in userData.settings.noBuy" :key="ticker" :label="ticker">
     <PrunButton danger @click="remove(ticker)">x</PrunButton>
   </Passive>
   <SectionHeader>Add Materials</SectionHeader>

--- a/src/features/basic/pli-warehouse-open-button.tsx
+++ b/src/features/basic/pli-warehouse-open-button.tsx
@@ -23,7 +23,11 @@ function onTileReady(tile: PrunTile) {
         return null;
       }
       return (
-        <PrunButton primary inline style={{ marginLeft: '4px' }} onClick={() => showBuffer(`INV ${ws.id.substring(0, 8)}`)}>
+        <PrunButton
+          primary
+          inline
+          style={{ marginLeft: '4px' }}
+          onClick={() => showBuffer(`INV ${ws.id.substring(0, 8)}`)}>
           OPEN
         </PrunButton>
       );

--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -19,7 +19,10 @@ onApiMessage({
     store.setAll(data.planets);
     store.setFetched();
   },
-  DATA_DATA(data: { body: { naturalId: string; cogcProgramType?: string | null }; path: string[] }) {
+  DATA_DATA(data: {
+    body: { naturalId: string; cogcProgramType?: string | null };
+    path: string[];
+  }) {
     if (data.path[0] !== 'planets' || data.path.length !== 2) {
       return;
     }


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
