### PR TITLE
Claude/cherry pick upstream commits c89 ix

### DIFF
--- a/src/components/forms/Commands.vue
+++ b/src/components/forms/Commands.vue
@@ -4,7 +4,7 @@ const { label = 'CMD' } = defineProps<{ label?: string }>();
 
 <template>
   <div :class="[C.FormComponent.containerCommand, C.forms.cmd, C.forms.formComponent]">
-    <label :class="[C.FormComponent.label, C.fonts.fontRegular, C.type.typeRegular]">
+    <label>
       <span>{{ label }}</span>
     </label>
     <div :class="[C.FormComponent.input, C.forms.input]">

--- a/src/features/XIT/BURN/BURN.vue
+++ b/src/features/XIT/BURN/BURN.vue
@@ -244,6 +244,7 @@ function copyBurnTable() {
       <RadioItem
         v-model="prod"
         horizontal
+        :class="$style.radioItemWithTooltip"
         data-tooltip="Toggle production I/O. When off, only workforce consumption is shown."
         data-tooltip-position="bottom">
         PROD
@@ -251,6 +252,7 @@ function copyBurnTable() {
       <RadioItem
         v-model="wf"
         horizontal
+        :class="$style.radioItemWithTooltip"
         data-tooltip="Toggle workforce consumption. When off, burn rates exclude workforce needs."
         data-tooltip-position="bottom">
         WF
@@ -326,5 +328,9 @@ function copyBurnTable() {
   font-size: 12px;
   padding-left: 18px;
   font-weight: bold;
+}
+
+.radioItemWithTooltip {
+  padding: 0;
 }
 </style>

--- a/src/features/advanced/minimize-headers/MinimizeRow.vue
+++ b/src/features/advanced/minimize-headers/MinimizeRow.vue
@@ -9,9 +9,9 @@ const symbol = computed(() => (isMinimized ? '+' : '-'));
 
 <template>
   <div :class="[C.FormComponent.containerPassive, C.forms.passive, C.forms.formComponent]">
-    <label :class="[C.FormComponent.label, C.fonts.fontRegular, C.type.typeRegular]"
-      >Minimize</label
-    >
+    <label>
+      <span>Minimize</span>
+    </label>
     <div :class="[C.FormComponent.input, C.forms.input]">
       <div>
         <div :class="$style.minimize" @click="onClick">{{ symbol }}</div>

--- a/src/features/advanced/minimize-headers/minimize-headers.ts
+++ b/src/features/advanced/minimize-headers/minimize-headers.ts
@@ -2,6 +2,7 @@ import MinimizeRow from './MinimizeRow.vue';
 import { streamHtmlCollection } from '@src/utils/stream-html-collection';
 import { computedTileState } from '@src/store/user-data-tiles';
 import { getTileState } from './tile-state';
+import { PrunI18N } from '@src/infrastructure/prun-ui/i18n';
 
 function onTileReady(tile: PrunTile) {
   const isMinimized = computedTileState(getTileState(tile), 'minimizeHeader', true);
@@ -25,18 +26,26 @@ function onTileReady(tile: PrunTile) {
 
 function setHeaders(tile: PrunTile, isMinimized: boolean) {
   for (const header of _$$(tile.anchor, C.FormComponent.containerPassive)) {
-    const label = _$(header, C.FormComponent.label);
+    const label = _$(header, 'label');
     if (label?.textContent === 'Minimize') {
       continue;
     }
-    if (label?.textContent === 'Termination request') {
+    if (matchesLocalization(label, 'Contract.termination', 'Termination request')) {
       const value = _$(header, C.FormComponent.input);
       if (value?.textContent !== '--') {
         continue;
       }
     }
+    if (matchesLocalization(label, 'Contribution.stores', 'Inventory')) {
+      continue;
+    }
     header.style.display = isMinimized ? 'none' : 'flex';
   }
+}
+
+function matchesLocalization(element: Element | undefined, key: string, defaultValue: string) {
+  const text = PrunI18N[key]?.[0]?.value ?? defaultValue;
+  return element?.textContent === text;
 }
 
 function init() {

--- a/src/features/basic/cxpo-order-book/cxpo-order-book.ts
+++ b/src/features/basic/cxpo-order-book/cxpo-order-book.ts
@@ -12,7 +12,7 @@ function onTileReady(tile: PrunTile) {
     const formParent = form.parentElement!;
     formParent.style.display = 'flex';
     form.style.flex = '1';
-    for (const label of _$$(form, C.FormComponent.label)) {
+    for (const label of _$$(form, 'label')) {
       (label as HTMLLabelElement).style.minWidth = '120px';
     }
     for (const span of _$$(form, C.Tooltip.container)) {

--- a/src/features/basic/mtra-auto-focus-amount.ts
+++ b/src/features/basic/mtra-auto-focus-amount.ts
@@ -4,8 +4,12 @@ function onTileReady(tile: PrunTile) {
   }
   subscribe($$(tile.anchor, 'input'), input => {
     if (input.type === 'text') {
-      input.focus();
-      input.select();
+      // Use setTimeout because something is messing with focus
+      // immediately after input element creation.
+      setTimeout(() => {
+        input.focus();
+        input.select();
+      });
     }
   });
 }

--- a/src/infrastructure/prun-ui/utils/delete-exchange-order.ts
+++ b/src/infrastructure/prun-ui/utils/delete-exchange-order.ts
@@ -11,17 +11,27 @@ import { fxosStore } from '@src/infrastructure/prun-api/data/fxos';
 import { refAnimationFrame } from '@src/utils/reactive-dom';
 
 export async function deleteExchangeOrderFromClick(
-  event: Event,
+  event: MouseEvent,
   orderId: string,
   screenCommand: 'CXOS' | 'FXOS',
 ) {
   event.preventDefault();
   event.stopPropagation();
+
+  if (event.shiftKey) {
+    return await deleteExchangeOrder(event.target as Element, orderId, screenCommand, true);
+  }
+
   return await new Promise<boolean>(resolve => {
     showConfirmationOverlay(
       event,
       async () => {
-        const success = await deleteExchangeOrder(event.target as Element, orderId, screenCommand);
+        const success = await deleteExchangeOrder(
+          event.target as Element,
+          orderId,
+          screenCommand,
+          false,
+        );
         resolve(success);
       },
       { message: 'Delete this order?', confirmLabel: 'Delete' },
@@ -33,6 +43,7 @@ export async function deleteExchangeOrder(
   target: Element,
   orderId: string,
   screenCommand: 'CXOS' | 'FXOS',
+  autoClose: boolean,
 ) {
   orderId = orderId.toLowerCase();
   const dismissProgress = showManualProgressOverlay(target);
@@ -70,27 +81,18 @@ export async function deleteExchangeOrder(
   onNodeDisconnected(outcome, () => {
     shouldClose.value = true;
   });
-  return outcome.classList.contains(C.ActionFeedback.success);
+  const isSuccess = outcome.classList.contains(C.ActionFeedback.success);
+  if (autoClose) {
+    await clickElement(outcome);
+  }
+  return isSuccess;
 }
 
-function awaitActionOutcome(window: Element) {
-  return new Promise<Element>(resolve => {
-    const findOutcome = () =>
-      _$(window, C.ActionFeedback.error) ?? _$(window, C.ActionFeedback.success);
-    const existing = findOutcome();
-    if (existing) {
-      resolve(existing);
-      return;
-    }
-    const observer = new MutationObserver(() => {
-      const outcome = findOutcome();
-      if (outcome) {
-        observer.disconnect();
-        resolve(outcome);
-      }
-    });
-    observer.observe(window, { childList: true, subtree: true });
-  });
+async function awaitActionOutcome(window: Element) {
+  return await Promise.race([
+    $(window, C.ActionFeedback.error),
+    $(window, C.ActionFeedback.success),
+  ]);
 }
 
 function showManualProgressOverlay(target: Element) {


### PR DESCRIPTION
Applies 5 bug-fix commits from refined-prun/refined-prun main branch. CHANGELOG.md changes were intentionally excluded.

Changes:

XIT BURN — Remove extra padding on PROD and WF filter buttons (BURN.vue)
CX order deletion — Skip the confirmation overlay when holding Shift while deleting exchange orders (delete-exchange-order.ts, cxpo-order-book.ts)
minimize-headers — Fix inventory selector getting incorrectly minimized inside POPID tiles (MinimizeRow.vue, minimize-headers.ts)
FormComponent — Fix label styling (Commands.vue)
mtra-auto-focus-amount — Fix the amount input field failing to focus automatically on MTRA open (mtra-auto-focus-amount.ts)
