### PR TITLE
Add pre-push hook to run eslint before pushing

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm lint


### PR DESCRIPTION
## Summary
Adds a pre-push git hook via husky that automatically runs eslint before any push to the remote repository. This prevents code with linting errors from being pushed.

## How it works
- Hook runs `pnpm lint` before push
- If eslint fails, the push is blocked
- Works transparently for all developers without manual invocation

---
_Generated by [Claude Code](https://claude.ai/code/session_014VA7JE8212ueNwAWz9VT63)_