### PR TITLE
Change material group "no planet" log from ERROR to WARNING

### DIFF
--- a/src/features/XIT/ACT/runner/step-generator.ts
+++ b/src/features/XIT/ACT/runner/step-generator.ts
@@ -100,7 +100,7 @@ export class StepGenerator {
     }
     const planet = group.planet;
     if (!planet) {
-      this.log.warning(`Material group [${name}] has no planet configured`);
+      this.log.warning(`Material group [${name}] has no planet configured; auto SFC will not run`);
       return undefined;
     }
     if (planet === configurableValue) {

--- a/src/features/XIT/ACT/runner/step-generator.ts
+++ b/src/features/XIT/ACT/runner/step-generator.ts
@@ -100,7 +100,7 @@ export class StepGenerator {
     }
     const planet = group.planet;
     if (!planet) {
-      this.log.error(`Material group [${name}] has no planet configured`);
+      this.log.warning(`Material group [${name}] has no planet configured`);
       return undefined;
     }
     if (planet === configurableValue) {


### PR DESCRIPTION
## Summary

- Changed `this.log.error(...)` to `this.log.warning(...)` for the "no planet configured" case in `step-generator.ts`
- Updated the message to: `Material group [${name}] has no planet configured; auto SFC will not run`

This is a non-fatal condition that doesn't need to surface as an error — a warning is more appropriate since the runner simply skips the group rather than failing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2irgVj8j6ceEdMTziw1zz)_