### PR TITLE
Shift-click inventory/warehouse buttons to open in companion buffer

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -458,6 +458,8 @@ async function setTileCommand(child: Element, command: string) {
 
 See also `src/features/XIT/ACT/runner/tile-allocator.ts` for the full horizontal-split companion pattern used by ACT.
 
+> **Note:** `openCompanionBuffer` + `setChildCommand` (horizontal variant of the above) is duplicated across `inv-analysis-button.tsx`, `shpi-base-inv-button.tsx`, and `shpi-warehouse-button.tsx`. Consider extracting to a shared utility in `buffers.ts` if a fourth caller appears.
+
 ---
 
 ## Context Controls

--- a/src/features/basic/bs-warehouse-button.tsx
+++ b/src/features/basic/bs-warehouse-button.tsx
@@ -39,8 +39,10 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
   const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
 
   if (tile.container.classList.contains(C.Window.body)) {
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     setBufferSize(tile.id, w + 450, h);
 
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');

--- a/src/features/basic/bs-warehouse-button.tsx
+++ b/src/features/basic/bs-warehouse-button.tsx
@@ -1,19 +1,27 @@
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import PrunButton from '@src/components/PrunButton.vue';
-import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { setBufferSize, showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { increaseDefaultBufferSize } from '@src/infrastructure/prun-ui/buffer-sizes';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
 
 function onTileReady(tile: PrunTile) {
-  // Only process BS tiles with parameter
   if (!tile.parameter) {
     return;
   }
 
-  const onClick = () => {
+  const onClick = (e: MouseEvent) => {
     const warehouse = warehousesStore.getByEntityNaturalId(tile.parameter);
     const storageId = storagesStore.getById(warehouse?.storeId)?.id?.substring(0, 8);
-    void showBuffer(storageId ? `INV ${storageId}` : `WAR ${tile.parameter}`);
+    const cmd = storageId ? `INV ${storageId}` : `WAR ${tile.parameter}`;
+    if (e.shiftKey) {
+      void openCompanionBuffer(tile, cmd);
+    } else {
+      void showBuffer(cmd);
+    }
   };
 
   subscribe($$(tile.anchor, C.ActionBar.container), container => {
@@ -25,6 +33,50 @@ function onTileReady(tile: PrunTile) {
       </div>
     )).appendTo(container);
   });
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) {
+      return;
+    }
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) {
+    return;
+  }
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
 }
 
 function init() {

--- a/src/features/basic/inv-warehouse-button.tsx
+++ b/src/features/basic/inv-warehouse-button.tsx
@@ -1,9 +1,13 @@
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { setBufferSize, showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { getInvStore } from '@src/core/store-id';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
 
 async function onTileReady(tile: PrunTile) {
   if (!tile.parameter) {
@@ -22,11 +26,16 @@ async function onTileReady(tile: PrunTile) {
 
   const contextBar = await $(tile.frame, C.ContextControls.container);
 
-  const onClick = () => {
+  const onClick = (e: MouseEvent) => {
     const id = naturalId.value;
     const warehouse = warehousesStore.getByEntityNaturalId(id);
     const storageId = storagesStore.getById(warehouse?.storeId)?.id?.substring(0, 8);
-    void showBuffer(storageId ? `INV ${storageId}` : `WAR ${id}`);
+    const cmd = storageId ? `INV ${storageId}` : `WAR ${id}`;
+    if (e.shiftKey) {
+      void openCompanionBuffer(tile, cmd);
+    } else {
+      void showBuffer(cmd);
+    }
   };
 
   // Insert after the analysis button (first child, prepended by inv-analysis-button)
@@ -52,6 +61,50 @@ async function onTileReady(tile: PrunTile) {
     app.after(anchorNode);
   } else {
     app.prependTo(contextBar);
+  }
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) {
+      return;
+    }
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) {
+    return;
+  }
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
   }
 }
 

--- a/src/features/basic/inv-warehouse-button.tsx
+++ b/src/features/basic/inv-warehouse-button.tsx
@@ -68,8 +68,10 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
   const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
 
   if (tile.container.classList.contains(C.Window.body)) {
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     setBufferSize(tile.id, w + 450, h);
 
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');

--- a/src/features/basic/shpi-base-inv-button.tsx
+++ b/src/features/basic/shpi-base-inv-button.tsx
@@ -1,11 +1,15 @@
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { setBufferSize, showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import {
   getLocationLineFromAddress,
   isPlanetLine,
 } from '@src/infrastructure/prun-api/data/addresses';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
 
 async function onTileReady(tile: PrunTile) {
   const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
@@ -42,13 +46,64 @@ async function onTileReady(tile: PrunTile) {
     return (
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
-        onClick={() => showBuffer(`INV ${store.id.substring(0, 8)}`)}>
+        onClick={(e: MouseEvent) => {
+          const cmd = `INV ${store.id.substring(0, 8)}`;
+          if (e.shiftKey) {
+            void openCompanionBuffer(tile, cmd);
+          } else {
+            showBuffer(cmd);
+          }
+        }}>
         <span>
           <span class={C.ContextControls.cmd}>INV {id}</span>
         </span>
       </div>
     );
   }).prependTo(contextBar);
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) {
+      return;
+    }
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) {
+    return;
+  }
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
 }
 
 function init() {

--- a/src/features/basic/shpi-base-inv-button.tsx
+++ b/src/features/basic/shpi-base-inv-button.tsx
@@ -66,8 +66,10 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
   const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
 
   if (tile.container.classList.contains(C.Window.body)) {
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     setBufferSize(tile.id, w + 450, h);
 
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');

--- a/src/features/basic/shpi-warehouse-button.tsx
+++ b/src/features/basic/shpi-warehouse-button.tsx
@@ -1,11 +1,15 @@
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { setBufferSize, showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import {
   getLocationLineFromAddress,
   isPlanetLine,
 } from '@src/infrastructure/prun-api/data/addresses';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
 
 async function onTileReady(tile: PrunTile) {
   const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
@@ -42,13 +46,64 @@ async function onTileReady(tile: PrunTile) {
     return (
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
-        onClick={() => showBuffer(`INV ${ws.id.substring(0, 8)}`)}>
+        onClick={(e: MouseEvent) => {
+          const cmd = `INV ${ws.id.substring(0, 8)}`;
+          if (e.shiftKey) {
+            void openCompanionBuffer(tile, cmd);
+          } else {
+            showBuffer(cmd);
+          }
+        }}>
         <span>
           <span class={C.ContextControls.cmd}>WAR {id}</span>
         </span>
       </div>
     );
   }).prependTo(contextBar);
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const w = parseInt(tile.container.style.width, 10) || 600;
+    const h = parseInt(tile.container.style.height, 10) || 400;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) {
+      return;
+    }
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) {
+    return;
+  }
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
 }
 
 function init() {

--- a/src/features/basic/shpi-warehouse-button.tsx
+++ b/src/features/basic/shpi-warehouse-button.tsx
@@ -66,8 +66,10 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
   const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
 
   if (tile.container.classList.contains(C.Window.body)) {
-    const w = parseInt(tile.container.style.width, 10) || 600;
-    const h = parseInt(tile.container.style.height, 10) || 400;
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
     setBufferSize(tile.id, w + 450, h);
 
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');


### PR DESCRIPTION
## Summary

Adds shift-click support to inventory/warehouse context buttons that previously only opened a new floating buffer on normal click. Shift-clicking now opens the target inventory as a horizontal companion buffer (splitting the current tile), consistent with the XIT ACT companion buffer pattern.

Affected buttons:

- **SHPI → INV (base inv)** — shift-click opens the landed ship's base inventory as a companion buffer (`shpi-base-inv-button.tsx`)
- **SHPI → WAR (warehouse)** — shift-click opens the landed ship's planetary warehouse as a companion buffer (`shpi-warehouse-button.tsx`)
- **INV → WAR** — shift-click opens the warehouse inventory as a companion buffer from a base inventory tile (`inv-warehouse-button.tsx`)
- **BS → WAREHOUSE** — shift-click opens the planet's warehouse inventory as a companion buffer from the base screen (`bs-warehouse-button.tsx`)

Normal (non-shift) clicks are unchanged.

## Behaviour

- **Solo floating buffer:** tile is widened by 450 px and split horizontally (`|`); the companion command is set in the new right-hand tile.
- **Already in a split:** the sibling tile is reused and its command is replaced.
- **Docked tile:** no split occurs (same limitation as other companion-buffer features).

## Test plan

- [ ] Open a SHPI for a ship landed on a planet where you have a base. Normal-click INV → opens floating buffer. Shift-click INV → splits SHPI tile and shows base inventory on the right.
- [ ] Same ship, planet has a warehouse. Shift-click WAR → splits and shows warehouse inventory.
- [ ] Open an INV tile for a base inventory. Shift-click WAR → splits and shows warehouse inventory.
- [ ] Open a BS tile for a planet with a warehouse. Shift-click WAREHOUSE → splits and shows warehouse inventory.
- [ ] Repeat each case with the tile already in a split — confirm the sibling tile is reused instead of creating a new split.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3Jdf1zUSQUE7HkhAattqC)_