### PR TITLE
Fix XIT FLT ship condition color threshold rounding

### DIFF
--- a/src/features/XIT/FLT/FLT.vue
+++ b/src/features/XIT/FLT/FLT.vue
@@ -507,10 +507,10 @@ function clearFilters() {
 }
 
 function getConditionClass(condition: number) {
-  if (Math.floor(condition) <= 79) {
+  if (Math.round(condition) <= 79) {
     return C.ColoredValue.negative;
   }
-  if (Math.floor(condition) <= 82) {
+  if (Math.round(condition) <= 82) {
     return coloredValue.warning;
   }
   return C.ColoredValue.positive;


### PR DESCRIPTION
## Summary

Fixed a rounding mismatch in ship condition color determination that caused conditions like 82.5% to display as "83%" but show yellow instead of green.

## Problem

In the XIT FLT panel, the displayed condition percentage and the color threshold logic used different rounding methods:
- Display: `Math.round(condition)` → shows "83%"
- Color: `Math.floor(condition)` → checks at 82, showing yellow

Result: Ships at ~82.5% condition displayed "83%" but incorrectly showed the yellow warning color.

## Solution

Changed `getConditionClass()` to use `Math.round()` consistently with the display logic.

Color thresholds now properly align:
- Red (negative): ≤79%
- Yellow (warning): 80-82%
- Green (positive): ≥83%

## Test Plan

- Open XIT FLT panel
- Check ships with condition near 82-83% boundary
- Verify displayed percentage matches the color shown
- Confirm ships at 83%+ show green, 80-82% show yellow, <80% show red

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9L2HgWnk54CubmVPD6ymG)_