### PR TITLE
Add CX Buy Only option to MTRA configure destination dropdown

### DIFF
--- a/src/features/XIT/ACT/actions/mtra/Configure.vue
+++ b/src/features/XIT/ACT/actions/mtra/Configure.vue
@@ -2,11 +2,12 @@
 import Active from '@src/components/forms/Active.vue';
 import Passive from '@src/components/forms/Passive.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
-import { Config } from '@src/features/XIT/ACT/actions/mtra/config';
+import { Config, CX_BUY_ONLY_DEST } from '@src/features/XIT/ACT/actions/mtra/config';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import {
   atSameLocation,
   deserializeStorage,
+  isCXWarehouse,
   serializeStorage,
   storageSort,
 } from '@src/features/XIT/ACT/actions/utils';
@@ -45,8 +46,18 @@ const destinationStorages = computed(() => {
   return storages.sort(storageSort);
 });
 
+const originIsCXWarehouse = computed(() => {
+  const originRef = data.origin !== configurableValue ? data.origin : config.origin;
+  const origin = deserializeStorage(originRef);
+  return origin ? isCXWarehouse(origin) : false;
+});
+
 const destinationOptions = computed(() => {
-  return getOptions(destinationStorages.value);
+  const options = getOptions(destinationStorages.value);
+  if (originIsCXWarehouse.value) {
+    options.push({ label: CX_BUY_ONLY_DEST, value: CX_BUY_ONLY_DEST });
+  }
+  return options;
 });
 
 if (
@@ -73,7 +84,7 @@ watchEffect(() => {
   }
 
   if (data.dest === configurableValue) {
-    if (config.destination) {
+    if (config.destination && config.destination !== CX_BUY_ONLY_DEST) {
       const destination = deserializeStorage(config.destination);
       if (!destination || !destinationStorages.value.includes(destination)) {
         config.destination = undefined;

--- a/src/features/XIT/ACT/actions/mtra/config.ts
+++ b/src/features/XIT/ACT/actions/mtra/config.ts
@@ -2,3 +2,5 @@ export interface Config {
   origin?: string;
   destination?: string;
 }
+
+export const CX_BUY_ONLY_DEST = 'CX Buy Only';

--- a/src/features/XIT/ACT/actions/mtra/mtra.ts
+++ b/src/features/XIT/ACT/actions/mtra/mtra.ts
@@ -4,7 +4,7 @@ import Configure from '@src/features/XIT/ACT/actions/mtra/Configure.vue';
 import { MTRA_TRANSFER } from '@src/features/XIT/ACT/action-steps/MTRA_TRANSFER';
 import { OPEN_SFC } from '@src/features/XIT/ACT/action-steps/OPEN_SFC';
 import { atSameLocation, deserializeStorage } from '@src/features/XIT/ACT/actions/utils';
-import { Config } from '@src/features/XIT/ACT/actions/mtra/config';
+import { Config, CX_BUY_ONLY_DEST } from '@src/features/XIT/ACT/actions/mtra/config';
 import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
 
 act.addAction<Config>({
@@ -23,6 +23,9 @@ act.addAction<Config>({
       action.dest == configurableValue
         ? (config?.destination ?? 'configured location')
         : action.dest;
+    if (dest === CX_BUY_ONLY_DEST) {
+      return `CX Buy only [${action.group}] from ${origin} (no transfer)`;
+    }
     return `Transfer group [${action.group}] from ${origin} to ${dest}`;
   },
   editComponent: Edit,
@@ -55,6 +58,9 @@ act.addAction<Config>({
     assert(origin, 'Invalid origin');
 
     const serializedDest = data.dest === configurableValue ? config?.destination : data.dest;
+    if (serializedDest === CX_BUY_ONLY_DEST) {
+      return;
+    }
     const dest = deserializeStorage(serializedDest);
     assert(dest, 'Invalid destination');
 


### PR DESCRIPTION
## Summary

- When the MTRA action's **From** location is a CX station warehouse (Antares, Hortus, Benten, Moria), a **CX Buy Only** option appears at the bottom of the **To:** dropdown in the MTRA configure section
- The option is visible even when the To: dropdown otherwise shows "No locations available" (e.g. no ship docked at the station)
- Selecting it skips MTRA step generation entirely — only the CX Buy stages of the action package run

## How it works

`Configure.vue` computes `originIsCXWarehouse` by resolving the selected/fixed origin storage and checking whether it is a station warehouse (using the existing `isCXWarehouse` utility). When true, "CX Buy Only" is appended to the destination options list.

The watchEffect that auto-resets an invalid destination selection is guarded to leave the "CX Buy Only" sentinel value untouched (previously it would call `deserializeStorage` on it, get `undefined`, and clear the selection).

In `mtra.ts`, `generateSteps` returns early with no emitted steps when the resolved destination equals the sentinel. The action description is also updated to reflect the no-transfer mode.

## Test plan

- [ ] Open `XIT BURNACT <planet>` or `XIT REPAIRACT <planet>` for a planet supplied from a CX station warehouse
- [ ] In the Configure section, set **From** to a CX station warehouse (e.g. "Antares Warehouse")
- [ ] Confirm **CX Buy Only** appears at the bottom of the **To:** dropdown
- [ ] Confirm it appears even when To: would otherwise show "No locations available"
- [ ] Select **CX Buy Only**, apply config, and run Preview — verify only CX Buy steps appear in the log (no MTRA transfer steps)
- [ ] Execute and confirm only CX Buy orders are placed; no MTRA transfer runs
- [ ] Confirm normal MTRA (non-CX-warehouse origin) still works as before and does not show the CX Buy Only option

https://claude.ai/code/session_01KgbPhEoRQsag5N6nMs6Zz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgbPhEoRQsag5N6nMs6Zz4)_