### PR TITLE
Speed up deploy-local by skipping redundant setup actions

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -27,18 +27,11 @@ jobs:
         with:
           lfs: true
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: 'pnpm'
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build extension
-        run: pnpm build
+        run: pnpm run build:fast
 
       - name: Restart Edge with new build
         shell: powershell

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "compile": "tsc --noEmit",
     "build": "pnpm run clean && pnpm run compile && vite build",
+    "build:fast": "pnpm run clean && vite build",
     "build:firefox": "bash scripts/build-firefox.sh",
     "sign:firefox": "web-ext sign --source-dir dist --channel=unlisted",
     "clean": "rimraf dist",


### PR DESCRIPTION
Drop pnpm/action-setup and actions/setup-node from the local runner
workflow — Node and pnpm are already installed on the self-hosted
machine, and the pnpm cache step was round-tripping to GitHub's servers
instead of using the local store.

Add build:fast script that skips tsc type-checking for local deploys;
tsc still runs in the normal CI build-extension workflow.

https://claude.ai/code/session_01BmueLemQ4xS8kbGsqahUn1