### PR TITLE
Restore pnpm/action-setup for PATH wiring on self-hosted runner

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           lfs: true
 
+      - uses: pnpm/action-setup@v4
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Without it pnpm is not on the runner's PATH since the Task Scheduler process doesn't inherit the user environment. Keep actions/setup-node removed — that was the expensive step.

https://claude.ai/code/session_01BmueLemQ4xS8kbGsqahUn1

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
