### PR TITLE
fix(burn): PROD/WF buttons hide rows instead of zeroing rates

### DIFF
--- a/src/features/XIT/BURN/BURN.vue
+++ b/src/features/XIT/BURN/BURN.vue
@@ -97,12 +97,7 @@ function filterBurn(burn: BurnValues): BurnValues {
     if (!(hasProd && prod.value) && !(hasWf && wf.value)) {
       continue;
     }
-    const input = prod.value ? mat.input : 0;
-    const output = prod.value ? mat.output : 0;
-    const workforce = wf.value ? mat.workforce : 0;
-    const dailyAmount = output - input - workforce;
-    const daysLeft = dailyAmount >= 0 ? 1000 : Math.floor(-mat.inventory / dailyAmount);
-    filtered[ticker] = { ...mat, input, output, workforce, dailyAmount, daysLeft };
+    filtered[ticker] = mat;
   }
   return filtered;
 }
@@ -245,7 +240,7 @@ function copyBurnTable() {
         v-model="prod"
         horizontal
         :class="$style.radioItemWithTooltip"
-        data-tooltip="Toggle production I/O. When off, only workforce consumption is shown."
+        data-tooltip="Toggle materials with production consumption. When off, hides materials only used in production."
         data-tooltip-position="bottom">
         PROD
       </RadioItem>
@@ -253,7 +248,7 @@ function copyBurnTable() {
         v-model="wf"
         horizontal
         :class="$style.radioItemWithTooltip"
-        data-tooltip="Toggle workforce consumption. When off, burn rates exclude workforce needs."
+        data-tooltip="Toggle materials with workforce consumption. When off, hides materials only consumed by workforce."
         data-tooltip-position="bottom">
         WF
       </RadioItem>


### PR DESCRIPTION
## Summary

Port of upstream fix: [refined-prun/refined-prun@a54e1fb](https://github.com/refined-prun/refined-prun/commit/a54e1fb12a40a4383974e82c1f3cbe17e1082dc9)

The PROD and WF toggle buttons on the burn screen were zeroing out `input`, `output`, and `workforce` values before recalculating `dailyAmount`. This meant that when PROD was toggled off, any material consumed by both workers and factories would show only the workforce portion of its burn rate — understating demand. Same problem in reverse when WF was toggled off.

The fix: toggles now only control **row visibility**. A material row is hidden if it has no demand of the toggled type. Rows that do pass the filter always display their real, unmodified rates.

## What changed

- `filterBurn()` in `BURN.vue`: removed the 5 lines that recalculated `input`/`output`/`workforce`/`dailyAmount`/`daysLeft` based on toggle state; replaced with a single `filtered[ticker] = mat`
- Updated PROD and WF button tooltips to accurately describe the new behaviour

## Relationship to PR #77

PR #77 fixes the same class of bug in `bill.ts` (the resupply bill calculator). This PR fixes it in the burn screen display. Same root cause, different locations.

## Test plan

- [ ] Base with a material consumed by both workers and a factory recipe: toggling PROD off should hide pure-production materials but show the cross-demand material with its **full** burn rate (not just the workforce portion)
- [ ] Same in reverse: toggling WF off should show cross-demand materials with full rates
- [ ] Pure workforce materials hidden when WF is off; pure production materials hidden when PROD is off

---
_Generated by [Claude Code](https://claude.ai/code/session_015ByWJTzdMJ976mjGCkxNJb)_