### PR TITLE
Cherry-pick upstream commits: ELEC sort fix, delete-order optimization, profiling guide

### DIFF
--- a/guides/how-to-record-profile-session.md
+++ b/guides/how-to-record-profile-session.md
@@ -1,0 +1,23 @@
+## Recording a Performance profile session (Chrome)
+1. Press F12
+2. Open Performance tab
+3. Press big dot
+4. Record for the time required
+5. Export the profile session
+
+![](https://i.imgur.com/BPTnpFP.png)
+
+## How to record a Memory profile session (Chrome):
+1. Press F12
+2. Open Memory tab
+3. Select "Heap snapshot"
+4. Press Take snapshot
+5. Press Save to export snapshot
+6. Go back to Profiles
+7. Select "Allocation instrumentation on timeline", tick "Record allocation stacks"
+8. Record for 10 seconds
+9. Press big red dot to stop the recording
+10. Press Save to export snapshot
+11. Attach both snapshots to report
+
+![](https://i.imgur.com/VFXvYFK.png)

--- a/src/features/XIT/ELEC/ELEC.vue
+++ b/src/features/XIT/ELEC/ELEC.vue
@@ -117,11 +117,11 @@ function compareRows(a: ElectionRow, b: ElectionRow) {
     return groupDiff;
   }
   if (
-    a.electionStart !== undefined &&
-    b.electionStart !== undefined &&
-    a.electionStart !== b.electionStart
+    a.electionEnd !== undefined &&
+    b.electionEnd !== undefined &&
+    a.electionEnd !== b.electionEnd
   ) {
-    return a.electionStart - b.electionStart;
+    return a.electionEnd - b.electionEnd;
   }
   const planetDiff = a.planetNaturalId.localeCompare(b.planetNaturalId);
   return planetDiff !== 0 ? planetDiff : a.type.localeCompare(b.type);

--- a/src/infrastructure/prun-ui/utils/delete-exchange-order.ts
+++ b/src/infrastructure/prun-ui/utils/delete-exchange-order.ts
@@ -57,8 +57,7 @@ export async function deleteExchangeOrder(
   });
 
   const isCX = screenCommand === 'CXOS';
-  // FXOS doesn't support 9999 D:
-  const window = await showBuffer(isCX ? `CXOS 9999` : screenCommand, {
+  const window = await showBuffer(screenCommand, {
     autoClose: true,
     closeWhen: shouldClose,
     force: true,


### PR DESCRIPTION
## Summary

- `XIT ELEC`: Fix election sorting to use end date instead of start date
- `delete-exchange-order`: Remove `CXOS 9999` workaround, pass `screenCommand` directly
- Add `guides/how-to-record-profile-session.md` (Chrome perf/memory profiling steps)

## Upstream commits

- `3375fbe` — XIT ELEC: Sort elections by election date end ascending
- `04ca1ea` — Optimize deleting own orders from non-CXOS places
- `ab07f6c` — Add how-to-record-profile-session.md

Skipped: `a54e1fb` (already merged as #89), `610e2c8` (CHANGELOG grammar only).

---
_Generated by [Claude Code](https://claude.ai/code/session_015kgpMZmLRMKoAarciLdMEG)_