### PR TITLE
Fix resupply bill to use optimal workforce efficiency (toggleable)

### DIFF
--- a/src/core/burn.ts
+++ b/src/core/burn.ts
@@ -113,10 +113,59 @@ export function getPlanetBurn(siteOrId?: PrunApi.Site | string | null) {
   return burnBySiteId.value?.get(site.siteId)?.value;
 }
 
+function getOptimalEfficiencyRatio(
+  line: PrunApi.ProductionLine,
+  workforces: PrunApi.Workforce[] | undefined,
+): number {
+  if (!workforces || workforces.length === 0 || line.workforces.length === 0) {
+    return 1;
+  }
+
+  const currentEfficiency = line.efficiency;
+  if (currentEfficiency === 0) {
+    return 1;
+  }
+
+  let optimalWorkforceComponent = 1;
+  let workforceCount = 0;
+
+  for (const lineWorkforce of line.workforces) {
+    const tierData = workforces.find(w => w.level === lineWorkforce.level);
+    if (!tierData) {
+      continue;
+    }
+
+    const currentTierEfficiency = lineWorkforce.efficiency;
+    const satisfaction = tierData.satisfaction;
+
+    if (satisfaction > 0 && currentTierEfficiency > 0) {
+      const optimalTierEfficiency = currentTierEfficiency / satisfaction;
+      optimalWorkforceComponent *= optimalTierEfficiency;
+      workforceCount++;
+    }
+  }
+
+  if (workforceCount === 0) {
+    return 1;
+  }
+
+  optimalWorkforceComponent = Math.pow(optimalWorkforceComponent, 1 / workforceCount);
+
+  const listedFactorsProduct = line.efficiencyFactors.reduce(
+    (acc, factor) => acc * (1 + factor.value),
+    1,
+  );
+
+  const optimalEfficiency = listedFactorsProduct * optimalWorkforceComponent;
+
+  return currentEfficiency / optimalEfficiency;
+}
+
 export function calculatePlanetBurn(
   production: PrunApi.ProductionLine[] | undefined,
   workforces: PrunApi.Workforce[] | undefined,
   storage: PrunApi.Store[] | undefined,
+  useOptimalEfficiency: boolean = false,
 ) {
   const burnValues: BurnValues = {};
 
@@ -140,6 +189,11 @@ export function calculatePlanetBurn(
       let totalDuration = sumBy(burnOrders, x => x.duration?.millis ?? Infinity);
       // Convert to days
       totalDuration /= 86400000;
+
+      if (useOptimalEfficiency) {
+        const efficiencyRatio = getOptimalEfficiencyRatio(line, workforces);
+        totalDuration *= efficiencyRatio;
+      }
 
       for (const order of burnOrders) {
         for (const mat of order.outputs) {

--- a/src/features/XIT/ACT/material-groups/resupply/bill.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/bill.ts
@@ -34,6 +34,7 @@ export function computeResupplyBill(
     production,
     workforce,
     (data.useBaseInv ?? true) ? stores : undefined,
+    true,
   );
 
   const exclusions = data.exclusions ?? [];

--- a/src/features/XIT/ACT/material-groups/resupply/bill.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/bill.ts
@@ -3,6 +3,7 @@ import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { workforcesStore } from '@src/infrastructure/prun-api/data/workforces';
 import { productionStore } from '@src/infrastructure/prun-api/data/production';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { resupplyOptimalEfficiency } from '@src/features/basic/act-resupply-optimal-efficiency';
 import type { MaterialFilter } from './config';
 
 // Computes the resupply material bill for a given planet and day count.
@@ -34,7 +35,7 @@ export function computeResupplyBill(
     production,
     workforce,
     (data.useBaseInv ?? true) ? stores : undefined,
-    true,
+    resupplyOptimalEfficiency.value,
   );
 
   const exclusions = data.exclusions ?? [];

--- a/src/features/basic/act-resupply-optimal-efficiency.ts
+++ b/src/features/basic/act-resupply-optimal-efficiency.ts
@@ -1,0 +1,13 @@
+import { ref } from 'vue';
+
+export const resupplyOptimalEfficiency = ref(false);
+
+function init() {
+  resupplyOptimalEfficiency.value = true;
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'XIT ACT: Resupply bill uses optimal (post-resupply) workforce efficiency instead of current degraded efficiency.',
+);


### PR DESCRIPTION
## Summary

- Adds `getOptimalEfficiencyRatio()` to `burn.ts` to calculate what workforce efficiency would be if all consumables were fully supplied (satisfaction = 100%)
- Threads an `useOptimalEfficiency` flag through `calculatePlanetBurn()` so callers can opt in
- Registers `act-resupply-optimal-efficiency` as a toggleable feature in XIT SET (on by default); when enabled, XIT ACT resupply bills use optimal efficiency instead of current degraded efficiency

## Problem

When resupplying a base for X days, the old calculation used current order durations — which are longer than normal because missing consumables reduce workforce efficiency. This made the predicted material needs too low: once the resupply arrived and consumables were fulfilled, efficiency improved and materials were consumed faster, running out before the expected number of days.

## Test plan

- [ ] Open XIT ACT with a resupply group for a base that has degraded efficiency (missing consumables)
- [ ] Confirm the bill amounts are higher than before (reflecting post-resupply efficiency)
- [ ] Open XIT SET → FEAT, find `act-resupply-optimal-efficiency`, disable it
- [ ] Confirm the bill reverts to the old (lower) amounts
- [ ] Re-enable and confirm it returns to optimal amounts
- [ ] Verify XIT BURN days-remaining is unaffected (still shows real current efficiency)

https://claude.ai/code/session_0155orVeSWwE2H7pyt6PN3v5

---
_Generated by [Claude Code](https://claude.ai/code/session_0155orVeSWwE2H7pyt6PN3v5)_