### PR TITLE
Error - Add Firefox XPI build workflow and fix version extraction

### DIFF
--- a/.github/workflows/build-firefox-xpi.yml
+++ b/.github/workflows/build-firefox-xpi.yml
@@ -1,0 +1,35 @@
+name: Build Firefox XPI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Firefox XPI
+        run: pnpm run build:firefox
+
+      - name: Upload Firefox XPI
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-xpi
+          path: "*.xpi"

--- a/scripts/build-firefox.sh
+++ b/scripts/build-firefox.sh
@@ -38,7 +38,8 @@ restore_font "fa-regular-400.woff2"
 echo "build-firefox: running pnpm build"
 pnpm build
 
-version="$(node -e "const m=require('./dist/manifest.json');process.stdout.write(m.version)")"
+version="$(cat VERSION)"
+npx dot-json@1 dist/manifest.json version "$version"
 xpi_name="refined-prun-${version}.xpi"
 
 echo "build-firefox: packaging dist -> ${xpi_name}"


### PR DESCRIPTION
## Summary

This PR adds automated CI/CD support for building Firefox XPI packages and fixes the version extraction logic in the build script.

**Changes:**
1. **New GitHub Actions workflow** (`.github/workflows/build-firefox-xpi.yml`): Automatically builds the Firefox XPI on every push and pull request, with artifact upload for easy access
2. **Fixed version extraction** in `scripts/build-firefox.sh`: Changed from dynamically reading the version from the built manifest.json to reading from a dedicated VERSION file, then injecting it into the manifest using `dot-json`

The version extraction fix ensures the build process is more reliable and decoupled from the manifest structure, while the new workflow enables continuous integration testing of Firefox builds.

## Standards Checklist

- [x] N/A - Infrastructure/CI changes only

https://claude.ai/code/session_01Ej6j8qvHxq7Lw7fR7Uwi85