### PR TITLE
POPI: shift-click details to open POPID as companion buffer

### DIFF
--- a/src/features/advanced/minimize-headers/minimize-headers.ts
+++ b/src/features/advanced/minimize-headers/minimize-headers.ts
@@ -22,6 +22,16 @@ function onTileReady(tile: PrunTile) {
       }),
     ).before(header);
   });
+
+  subscribe(
+    streamHtmlCollection(
+      tile.anchor,
+      tile.anchor.getElementsByClassName(C.FormComponent.containerPassive),
+    ),
+    () => {
+      setHeaders(tile, isMinimized.value);
+    },
+  );
 }
 
 function setHeaders(tile: PrunTile, isMinimized: boolean) {

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -71,7 +71,7 @@ function onTileReady(tile: PrunTile) {
         if (!ticker) {
           return;
         }
-        void openCompanionBuffer(tile, `POPID ${tile.parameter} ${ticker}`);
+        void openCompanionBuffer(tile, `POPID P-${tile.parameter} T-${ticker}`);
       });
     });
   });

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -1,9 +1,6 @@
 import { $ } from '@src/utils/select-dom';
 import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
 import { clickElement, changeInputValue } from '@src/util';
-import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
-import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
-import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
 import { PrunI18N } from '@src/infrastructure/prun-ui/i18n';
 
 const infraGlobalNames: Record<string, string> = {
@@ -108,11 +105,6 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
 }
 
 async function setChildCommand(child: Element, command: string) {
-  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
-  const id = tileEl !== null ? getPrunId(tileEl) : null;
-  if (id !== null && dispatchClientPrunMessage(UI_TILES_CHANGE_COMMAND(id, command))) {
-    return;
-  }
   const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
   changeInputValue(input, command);
   input.form!.requestSubmit();

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -1,9 +1,9 @@
-import { PrunI18N } from '@src/infrastructure/prun-ui/i18n';
 import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
 import { clickElement, changeInputValue } from '@src/util';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
 import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+import { PrunI18N } from '@src/infrastructure/prun-ui/i18n';
 
 const infraGlobalNames: Record<string, string> = {
   planetaryProjectSafetySmall: 'SST',
@@ -25,7 +25,7 @@ const infraGlobalNames: Record<string, string> = {
 function buildNameToTicker(): Map<string, string> {
   const map = new Map<string, string>();
   for (const [globalName, ticker] of Object.entries(infraGlobalNames)) {
-    const name = PrunI18N[globalName]?.[0]?.value;
+    const name = PrunI18N[`Reactor.${globalName}_name`]?.[0]?.value;
     if (name) {
       map.set(name, ticker);
     }
@@ -62,16 +62,6 @@ function onTileReady(tile: PrunTile) {
         e.stopPropagation();
         e.preventDefault();
         const name = getRowName(row);
-        const planetaryKeys = Object.keys(PrunI18N).filter(
-          k => k.includes('planetary') || k.includes('Safety'),
-        );
-        console.log('[popi-companion] name:', name);
-        console.log('[popi-companion] PrunI18N size:', Object.keys(PrunI18N).length);
-        console.log('[popi-companion] planetary/Safety keys sample:', planetaryKeys.slice(0, 10));
-        console.log(
-          '[popi-companion] tr attributes:',
-          Array.from(row.attributes).map(a => `${a.name}=${a.value}`),
-        );
         if (!name) {
           return;
         }

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -64,6 +64,12 @@ function onTileReady(tile: PrunTile) {
         e.stopPropagation();
         e.preventDefault();
         const name = getRowName(row);
+        console.log(
+          '[popi-companion] name:',
+          name,
+          '| ticker:',
+          name ? nameToTicker.get(name) : '(no name)',
+        );
         if (!name) {
           return;
         }

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -107,15 +107,14 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
 }
 
 async function setChildCommand(child: Element, command: string) {
-  const tileEl = (await $(child, C.Tile.tile)) as HTMLElement;
-
-  const id = getPrunId(tileEl)!;
-  const message = UI_TILES_CHANGE_COMMAND(id, command);
-  if (!dispatchClientPrunMessage(message)) {
-    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
-    changeInputValue(input, command);
-    input.form!.requestSubmit();
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  const id = tileEl !== null ? getPrunId(tileEl) : null;
+  if (id !== null && dispatchClientPrunMessage(UI_TILES_CHANGE_COMMAND(id, command))) {
+    return;
   }
+  const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+  changeInputValue(input, command);
+  input.form!.requestSubmit();
 }
 
 function init() {

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -1,6 +1,9 @@
 import { $ } from '@src/utils/select-dom';
 import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
 import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
 import { PrunI18N } from '@src/infrastructure/prun-ui/i18n';
 
 const infraGlobalNames: Record<string, string> = {
@@ -105,6 +108,11 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
 }
 
 async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  const id = tileEl !== null ? getPrunId(tileEl) : null;
+  if (id !== null && dispatchClientPrunMessage(UI_TILES_CHANGE_COMMAND(id, command))) {
+    return;
+  }
   const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
   changeInputValue(input, command);
   input.form!.requestSubmit();

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -1,0 +1,118 @@
+import { PrunI18N } from '@src/infrastructure/prun-ui/i18n';
+import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+
+const infraGlobalNames: Record<string, string> = {
+  planetaryProjectSafetySmall: 'SST',
+  planetaryProjectSafetyBig: 'SDP',
+  planetaryProjectSafetyHealth: 'EMC',
+  planetaryProjectHealthSmall: 'INF',
+  planetaryProjectHealthBig: 'HOS',
+  planetaryProjectHealthComfort: 'WCE',
+  planetaryProjectComfortSmall: 'PAR',
+  planetaryProjectComfortBig: '4DA',
+  planetaryProjectComfortCulture: 'ACA',
+  planetaryProjectCultureSmall: 'ART',
+  planetaryProjectCultureBig: 'VRT',
+  planetaryProjectCultureEducation: 'PBH',
+  planetaryProjectEducationBig: 'UNI',
+  planetaryProjectEducationSmall: 'LIB',
+};
+
+function buildNameToTicker(): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [globalName, ticker] of Object.entries(infraGlobalNames)) {
+    const name = PrunI18N[globalName]?.[0]?.value;
+    if (name) {
+      map.set(name, ticker);
+    }
+  }
+  return map;
+}
+
+function getRowName(row: Element): string | undefined {
+  const nameCell = _$$(row, 'td')[0];
+  if (!nameCell) return undefined;
+  const clone = nameCell.cloneNode(true) as HTMLElement;
+  _$(clone, C.BtnOpen.btnOpen)?.remove();
+  return clone.textContent?.trim() || undefined;
+}
+
+function onTileReady(tile: PrunTile) {
+  const nameToTicker = buildNameToTicker();
+
+  subscribe($$(tile.anchor, C.Population.table), table => {
+    subscribe($$(table, 'tr'), row => {
+      if (_$(row, 'th') !== undefined) return;
+
+      const detailsBtn = _$$(row, C.Button.btn).find(x => x.textContent === 'details');
+      if (!detailsBtn) return;
+
+      detailsBtn.addEventListener('click', (e: MouseEvent) => {
+        if (!e.shiftKey) return;
+        e.stopPropagation();
+        e.preventDefault();
+        const name = getRowName(row);
+        if (!name) return;
+        const ticker = nameToTicker.get(name);
+        if (!ticker) return;
+        void openCompanionBuffer(tile, `POPID ${tile.parameter} ${ticker}`);
+      });
+    });
+  });
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) return;
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) return;
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
+}
+
+function init() {
+  tiles.observe('POPI', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'POPI: Shift-click the details button to open the POPID buffer as a companion.',
+);

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -34,15 +34,11 @@ function buildNameToTicker(): Map<string, string> {
 }
 
 function getRowName(row: Element): string | undefined {
-  const cells = _$$(row, 'td');
-  if (cells.length === 0) {
+  if (row.children.length === 0) {
     return undefined;
   }
-  const clone = cells[0].cloneNode(true) as HTMLElement;
-  for (const child of Array.from(clone.children)) {
-    child.remove();
-  }
-  return clone.textContent?.trim() || undefined;
+  const text = row.children[0].firstElementChild?.textContent?.trim();
+  return text ?? undefined;
 }
 
 function onTileReady(tile: PrunTile) {
@@ -67,12 +63,8 @@ function onTileReady(tile: PrunTile) {
         e.preventDefault();
         const name = getRowName(row);
         const matchingKeys = Object.keys(PrunI18N).filter(k => PrunI18N[k]?.[0]?.value === name);
-        console.log(
-          '[popi-companion] name:',
-          name,
-          '| PrunI18N keys with that value:',
-          matchingKeys,
-        );
+        console.log('[popi-companion] firstCell HTML:', row.children[0]?.outerHTML?.slice(0, 300));
+        console.log('[popi-companion] name:', name, '| PrunI18N keys:', matchingKeys);
         if (!name) {
           return;
         }

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -37,7 +37,7 @@ function getRowName(row: Element): string | undefined {
   if (row.children.length === 0) {
     return undefined;
   }
-  const text = row.children[0].firstElementChild?.textContent?.trim();
+  const text = row.children[0].firstElementChild?.firstElementChild?.textContent?.trim();
   return text ?? undefined;
 }
 
@@ -62,9 +62,16 @@ function onTileReady(tile: PrunTile) {
         e.stopPropagation();
         e.preventDefault();
         const name = getRowName(row);
-        const matchingKeys = Object.keys(PrunI18N).filter(k => PrunI18N[k]?.[0]?.value === name);
-        console.log('[popi-companion] firstCell HTML:', row.children[0]?.outerHTML?.slice(0, 300));
-        console.log('[popi-companion] name:', name, '| PrunI18N keys:', matchingKeys);
+        const planetaryKeys = Object.keys(PrunI18N).filter(
+          k => k.includes('planetary') || k.includes('Safety'),
+        );
+        console.log('[popi-companion] name:', name);
+        console.log('[popi-companion] PrunI18N size:', Object.keys(PrunI18N).length);
+        console.log('[popi-companion] planetary/Safety keys sample:', planetaryKeys.slice(0, 10));
+        console.log(
+          '[popi-companion] tr attributes:',
+          Array.from(row.attributes).map(a => `${a.name}=${a.value}`),
+        );
         if (!name) {
           return;
         }

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -34,9 +34,11 @@ function buildNameToTicker(): Map<string, string> {
 }
 
 function getRowName(row: Element): string | undefined {
-  const nameCell = _$$(row, 'td')[0];
-  if (!nameCell) return undefined;
-  const clone = nameCell.cloneNode(true) as HTMLElement;
+  const cells = _$$(row, 'td');
+  if (cells.length === 0) {
+    return undefined;
+  }
+  const clone = cells[0].cloneNode(true) as HTMLElement;
   _$(clone, C.BtnOpen.btnOpen)?.remove();
   return clone.textContent?.trim() || undefined;
 }
@@ -46,19 +48,29 @@ function onTileReady(tile: PrunTile) {
 
   subscribe($$(tile.anchor, C.Population.table), table => {
     subscribe($$(table, 'tr'), row => {
-      if (_$(row, 'th') !== undefined) return;
+      if (_$(row, 'th') !== undefined) {
+        return;
+      }
 
       const detailsBtn = _$$(row, C.Button.btn).find(x => x.textContent === 'details');
-      if (!detailsBtn) return;
+      if (!detailsBtn) {
+        return;
+      }
 
       detailsBtn.addEventListener('click', (e: MouseEvent) => {
-        if (!e.shiftKey) return;
+        if (!e.shiftKey) {
+          return;
+        }
         e.stopPropagation();
         e.preventDefault();
         const name = getRowName(row);
-        if (!name) return;
+        if (!name) {
+          return;
+        }
         const ticker = nameToTicker.get(name);
-        if (!ticker) return;
+        if (!ticker) {
+          return;
+        }
         void openCompanionBuffer(tile, `POPID ${tile.parameter} ${ticker}`);
       });
     });
@@ -78,7 +90,9 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
     const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
     await clickElement(splitButton);
 
-    if (!windowEl) return;
+    if (!windowEl) {
+      return;
+    }
 
     const node = await $(windowEl, C.Node.node);
     const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
@@ -96,7 +110,9 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
 
 async function setChildCommand(child: Element, command: string) {
   const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
-  if (!tileEl) return;
+  if (!tileEl) {
+    return;
+  }
 
   const id = getPrunId(tileEl)!;
   const message = UI_TILES_CHANGE_COMMAND(id, command);

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -39,7 +39,9 @@ function getRowName(row: Element): string | undefined {
     return undefined;
   }
   const clone = cells[0].cloneNode(true) as HTMLElement;
-  _$(clone, C.BtnOpen.btnOpen)?.remove();
+  for (const child of Array.from(clone.children)) {
+    child.remove();
+  }
   return clone.textContent?.trim() || undefined;
 }
 
@@ -64,11 +66,12 @@ function onTileReady(tile: PrunTile) {
         e.stopPropagation();
         e.preventDefault();
         const name = getRowName(row);
+        const matchingKeys = Object.keys(PrunI18N).filter(k => PrunI18N[k]?.[0]?.value === name);
         console.log(
           '[popi-companion] name:',
           name,
-          '| ticker:',
-          name ? nameToTicker.get(name) : '(no name)',
+          '| PrunI18N keys with that value:',
+          matchingKeys,
         );
         if (!name) {
           return;

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -1,3 +1,4 @@
+import { $ } from '@src/utils/select-dom';
 import { setBufferSize } from '@src/infrastructure/prun-ui/buffers';
 import { clickElement, changeInputValue } from '@src/util';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';

--- a/src/features/basic/popi-details-companion-buffer.ts
+++ b/src/features/basic/popi-details-companion-buffer.ts
@@ -107,10 +107,7 @@ async function openCompanionBuffer(tile: PrunTile, command: string) {
 }
 
 async function setChildCommand(child: Element, command: string) {
-  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
-  if (!tileEl) {
-    return;
-  }
+  const tileEl = (await $(child, C.Tile.tile)) as HTMLElement;
 
   const id = getPrunId(tileEl)!;
   const message = UI_TILES_CHANGE_COMMAND(id, command);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new feature (`popi-details-companion-buffer.ts`): shift-clicking the **details** button in any POPI row opens the corresponding POPID buffer as a companion to the right of the POPI buffer, using the same horizontal-split pattern as `shpi-base-inv-button`
- Plain clicks are unchanged (game handles them normally)
- Building names are resolved via `PrunI18N` (`Reactor.{globalName}_name`) to support all game locales
- Fixes `minimize-headers` to re-apply header minimization when `dispatchClientPrunMessage` triggers an in-place React update (subtree-level subscription on `containerPassive` elements)

## Test plan

- [ ] Open a POPI buffer for any planet
- [ ] Shift-click a **details** button — a companion POPID buffer should open to the right with headers minimized
- [ ] Shift-click a different **details** button — the companion buffer should switch to that building's POPID, also with headers minimized
- [ ] Plain-click **details** still opens the POPID in a new buffer as before
- [ ] Verify the feature toggle appears in the XIT SET page under basic features

https://claude.ai/code/session_01WYwfjsLr19LaV193cxsZQV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYwfjsLr19LaV193cxsZQV)_