### PR TITLE
Add XIT INV: all-inventories overview with cargo bars and filters

### DIFF
--- a/src/features/XIT/INV/INV.ts
+++ b/src/features/XIT/INV/INV.ts
@@ -1,0 +1,9 @@
+import INV from './INV.vue';
+
+xit.add({
+  command: 'INV',
+  name: 'INVENTORIES',
+  description: 'Lists all inventories with cargo bars and filters by type.',
+  component: () => INV,
+  bufferSize: [620, 400],
+});

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import {
+  getEntityNameFromAddress,
+  getEntityNaturalIdFromAddress,
+  isStationLine,
+  getLocationLineFromAddress,
+} from '@src/infrastructure/prun-api/data/addresses';
+import RadioItem from '@src/components/forms/RadioItem.vue';
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import InvBar from '@src/features/XIT/BS/InvBar.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { fixed0 } from '@src/utils/format';
+import { useTileState } from './tile-state';
+
+type InvType = 'BASE' | 'SHIP' | 'WAREHOUSE' | 'CX';
+
+const TYPE_ORDER: Record<InvType, number> = { BASE: 0, SHIP: 1, WAREHOUSE: 2, CX: 3 };
+
+interface InvRow {
+  storeId: string;
+  type: InvType;
+  label: string;
+  naturalId?: string;
+  warehousePlanetId?: string;
+  onClickCmd: string;
+  weightCapacity: number;
+  volumeCapacity: number;
+}
+
+const showBase = useTileState('showBase');
+const showShip = useTileState('showShip');
+const showWarehouse = useTileState('showWarehouse');
+const showCx = useTileState('showCx');
+const showBaseWar = useTileState('showBaseWar');
+
+const basePlanetIds = computed(() => {
+  const sites = sitesStore.all.value;
+  if (!sites) return new Set<string>();
+  return new Set(
+    sites
+      .map(site => getEntityNaturalIdFromAddress(site.address))
+      .filter((id): id is string => !!id),
+  );
+});
+
+const allRows = computed<InvRow[] | undefined>(() => {
+  const stores = storagesStore.nonFuelStores.value;
+  const sites = sitesStore.all.value;
+  const ships = shipsStore.all.value;
+  const warehouses = warehousesStore.all.value;
+
+  if (!stores || !sites || !ships || !warehouses) return undefined;
+
+  const rows: InvRow[] = [];
+
+  for (const store of stores) {
+    if (store.type === 'STORE') {
+      const site = sitesStore.getById(store.addressableId);
+      if (!site) continue;
+      const naturalId = getEntityNaturalIdFromAddress(site.address);
+      if (!naturalId) continue;
+      rows.push({
+        storeId: store.id,
+        type: 'BASE',
+        label: getEntityNameFromAddress(site.address) ?? naturalId,
+        naturalId,
+        onClickCmd: `INV ${store.id.substring(0, 8)}`,
+        weightCapacity: store.weightCapacity,
+        volumeCapacity: store.volumeCapacity,
+      });
+    } else if (store.type === 'SHIP_STORE') {
+      const ship = ships.find(s => s.idShipStore === store.id);
+      if (!ship) continue;
+      rows.push({
+        storeId: store.id,
+        type: 'SHIP',
+        label: ship.name || ship.registration,
+        onClickCmd: `SHPI ${ship.registration}`,
+        weightCapacity: store.weightCapacity,
+        volumeCapacity: store.volumeCapacity,
+      });
+    } else if (store.type === 'WAREHOUSE_STORE') {
+      const warehouse = warehouses.find(w => w.storeId === store.id);
+      if (!warehouse) continue;
+      const locationLine = getLocationLineFromAddress(warehouse.address);
+      const isCx = isStationLine(locationLine);
+      const naturalId = getEntityNaturalIdFromAddress(warehouse.address);
+      const label = getEntityNameFromAddress(warehouse.address) ?? naturalId ?? 'Unknown';
+      rows.push({
+        storeId: store.id,
+        type: isCx ? 'CX' : 'WAREHOUSE',
+        label,
+        warehousePlanetId: isCx ? undefined : naturalId,
+        onClickCmd: `INV ${store.id.substring(0, 8)}`,
+        weightCapacity: store.weightCapacity,
+        volumeCapacity: store.volumeCapacity,
+      });
+    }
+  }
+
+  rows.sort((a, b) => {
+    const typeOrder = TYPE_ORDER[a.type] - TYPE_ORDER[b.type];
+    if (typeOrder !== 0) return typeOrder;
+    return a.label.localeCompare(b.label);
+  });
+
+  return rows;
+});
+
+const filteredRows = computed(() => {
+  const rows = allRows.value;
+  if (!rows) return undefined;
+
+  return rows.filter(row => {
+    if (row.type === 'BASE' && !showBase.value) return false;
+    if (row.type === 'SHIP' && !showShip.value) return false;
+    if (row.type === 'WAREHOUSE' && !showWarehouse.value) return false;
+    if (row.type === 'CX' && !showCx.value) return false;
+    if (!showBaseWar.value && row.type === 'WAREHOUSE' && row.warehousePlanetId) {
+      if (basePlanetIds.value.has(row.warehousePlanetId)) return false;
+    }
+    return true;
+  });
+});
+
+function formatCapacity(row: InvRow) {
+  return `${fixed0(row.weightCapacity)}t / ${fixed0(row.volumeCapacity)}m³`;
+}
+</script>
+
+<template>
+  <LoadingSpinner v-if="!filteredRows" />
+  <template v-else>
+    <div :class="C.ComExOrdersPanel.filter">
+      <RadioItem v-model="showBase" horizontal>BASE</RadioItem>
+      <RadioItem v-model="showShip" horizontal>SHIP</RadioItem>
+      <RadioItem v-model="showWarehouse" horizontal>WAREHOUSE</RadioItem>
+      <RadioItem v-model="showCx" horizontal>CX</RadioItem>
+      <div :class="$style.separator" />
+      <RadioItem v-model="showBaseWar" horizontal>BASE WAR</RadioItem>
+    </div>
+    <table :class="$style.table">
+      <thead>
+        <tr>
+          <th :class="$style.nameCol">Name</th>
+          <th :class="$style.typeCol">Type</th>
+          <th :class="$style.barCol">Inventory</th>
+          <th :class="$style.sizeCol">Capacity</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in filteredRows" :key="row.storeId" :class="$style.row">
+          <td :class="$style.nameCell">
+            <span :class="C.Link.link" @click="showBuffer(row.onClickCmd)">{{ row.label }}</span>
+          </td>
+          <td :class="$style.typeCell">{{ row.type }}</td>
+          <td :class="$style.barCell">
+            <InvBar
+              :store-id="row.storeId"
+              :natural-id="row.naturalId"
+              :on-click-cmd="row.onClickCmd" />
+          </td>
+          <td :class="$style.sizeCell">{{ formatCapacity(row) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </template>
+</template>
+
+<style module>
+.separator {
+  width: 1px;
+  align-self: stretch;
+  background-color: #2b485a;
+  margin: 0 0.25rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.nameCol {
+  width: auto;
+}
+
+.typeCol {
+  width: 0;
+  white-space: nowrap;
+}
+
+.barCol {
+  width: 40%;
+  min-width: 80px;
+}
+
+.sizeCol {
+  width: 0;
+  white-space: nowrap;
+}
+
+.row {
+  border-bottom: 1px solid #2b485a;
+}
+
+.nameCell {
+  padding: 4px 6px;
+  max-width: 20ch;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.typeCell {
+  padding: 4px 6px;
+  font-size: 11px;
+  opacity: 0.7;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.barCell {
+  padding: 2px;
+  padding-bottom: 0;
+}
+
+.sizeCell {
+  padding: 4px 6px;
+  white-space: nowrap;
+  font-size: 11px;
+  text-align: right;
+}
+</style>

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -20,7 +20,7 @@ import fa from '@src/utils/font-awesome.module.css';
 
 type InvType = 'BASE' | 'SHIP' | 'WAREHOUSE' | 'CX';
 
-const TYPE_ORDER: Record<InvType, number> = { BASE: 0, SHIP: 1, WAREHOUSE: 2, CX: 3 };
+const TYPE_ORDER: Record<InvType, number> = { CX: 0, BASE: 1, SHIP: 2, WAREHOUSE: 3 };
 const TYPE_LABELS: Record<InvType, string> = {
   BASE: 'BS',
   SHIP: 'SHP',

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -39,7 +39,9 @@ const showBaseWar = useTileState('showBaseWar');
 
 const basePlanetIds = computed(() => {
   const sites = sitesStore.all.value;
-  if (!sites) return new Set<string>();
+  if (!sites) {
+    return new Set<string>();
+  }
   return new Set(
     sites
       .map(site => getEntityNaturalIdFromAddress(site.address))
@@ -53,16 +55,22 @@ const allRows = computed<InvRow[] | undefined>(() => {
   const ships = shipsStore.all.value;
   const warehouses = warehousesStore.all.value;
 
-  if (!stores || !sites || !ships || !warehouses) return undefined;
+  if (!stores || !sites || !ships || !warehouses) {
+    return undefined;
+  }
 
   const rows: InvRow[] = [];
 
   for (const store of stores) {
     if (store.type === 'STORE') {
       const site = sitesStore.getById(store.addressableId);
-      if (!site) continue;
+      if (!site) {
+        continue;
+      }
       const naturalId = getEntityNaturalIdFromAddress(site.address);
-      if (!naturalId) continue;
+      if (!naturalId) {
+        continue;
+      }
       rows.push({
         storeId: store.id,
         type: 'BASE',
@@ -74,7 +82,9 @@ const allRows = computed<InvRow[] | undefined>(() => {
       });
     } else if (store.type === 'SHIP_STORE') {
       const ship = ships.find(s => s.idShipStore === store.id);
-      if (!ship) continue;
+      if (!ship) {
+        continue;
+      }
       rows.push({
         storeId: store.id,
         type: 'SHIP',
@@ -85,7 +95,9 @@ const allRows = computed<InvRow[] | undefined>(() => {
       });
     } else if (store.type === 'WAREHOUSE_STORE') {
       const warehouse = warehouses.find(w => w.storeId === store.id);
-      if (!warehouse) continue;
+      if (!warehouse) {
+        continue;
+      }
       const locationLine = getLocationLineFromAddress(warehouse.address);
       const isCx = isStationLine(locationLine);
       const naturalId = getEntityNaturalIdFromAddress(warehouse.address);
@@ -104,7 +116,9 @@ const allRows = computed<InvRow[] | undefined>(() => {
 
   rows.sort((a, b) => {
     const typeOrder = TYPE_ORDER[a.type] - TYPE_ORDER[b.type];
-    if (typeOrder !== 0) return typeOrder;
+    if (typeOrder !== 0) {
+      return typeOrder;
+    }
     return a.label.localeCompare(b.label);
   });
 
@@ -113,15 +127,27 @@ const allRows = computed<InvRow[] | undefined>(() => {
 
 const filteredRows = computed(() => {
   const rows = allRows.value;
-  if (!rows) return undefined;
+  if (!rows) {
+    return undefined;
+  }
 
   return rows.filter(row => {
-    if (row.type === 'BASE' && !showBase.value) return false;
-    if (row.type === 'SHIP' && !showShip.value) return false;
-    if (row.type === 'WAREHOUSE' && !showWarehouse.value) return false;
-    if (row.type === 'CX' && !showCx.value) return false;
+    if (row.type === 'BASE' && !showBase.value) {
+      return false;
+    }
+    if (row.type === 'SHIP' && !showShip.value) {
+      return false;
+    }
+    if (row.type === 'WAREHOUSE' && !showWarehouse.value) {
+      return false;
+    }
+    if (row.type === 'CX' && !showCx.value) {
+      return false;
+    }
     if (!showBaseWar.value && row.type === 'WAREHOUSE' && row.warehousePlanetId) {
-      if (basePlanetIds.value.has(row.warehousePlanetId)) return false;
+      if (basePlanetIds.value.has(row.warehousePlanetId)) {
+        return false;
+      }
     }
     return true;
   });

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -12,9 +12,11 @@ import {
 import RadioItem from '@src/components/forms/RadioItem.vue';
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
 import InvBar from '@src/features/XIT/BS/InvBar.vue';
+import PrunButton from '@src/components/PrunButton.vue';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { store as planetContextMenu } from '@src/features/XIT/planet-context-menu';
 import { useTileState } from './tile-state';
+import fa from '@src/utils/font-awesome.module.css';
 
 type InvType = 'BASE' | 'SHIP' | 'WAREHOUSE' | 'CX';
 
@@ -41,6 +43,7 @@ const showShip = useTileState('showShip');
 const showWarehouse = useTileState('showWarehouse');
 const showCx = useTileState('showCx');
 const showBaseWar = useTileState('showBaseWar');
+const locationFilter = ref('');
 
 const basePlanetIds = computed(() => {
   const sites = sitesStore.all.value;
@@ -132,6 +135,8 @@ const filteredRows = computed(() => {
     return undefined;
   }
 
+  const query = locationFilter.value.trim().toUpperCase();
+
   return rows.filter(row => {
     if (row.type === 'BASE' && !showBase.value) {
       return false;
@@ -150,6 +155,9 @@ const filteredRows = computed(() => {
         return false;
       }
     }
+    if (query && !row.label.toUpperCase().includes(query)) {
+      return false;
+    }
     return true;
   });
 });
@@ -165,6 +173,24 @@ const filteredRows = computed(() => {
       <RadioItem v-model="showCx" horizontal>CX</RadioItem>
       <div :class="$style.separator" />
       <RadioItem v-model="showBaseWar" horizontal>BASE WAR</RadioItem>
+      <div :class="$style.spacer" />
+      <div :class="$style.searchContainer">
+        <input
+          v-model="locationFilter"
+          type="text"
+          autocomplete="off"
+          data-1p-ignore="true"
+          data-lpignore="true"
+          placeholder="Enter location"
+          :class="$style.searchInput" />
+        <PrunButton
+          v-if="locationFilter"
+          dark
+          :class="[fa.solid, $style.clearButton]"
+          @click="locationFilter = ''">
+          {{ '' }}
+        </PrunButton>
+      </div>
     </div>
     <table :class="$style.table">
       <thead>
@@ -204,6 +230,41 @@ const filteredRows = computed(() => {
   align-self: stretch;
   background-color: #2b485a;
   margin: 0 0.25rem;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.searchContainer {
+  display: flex;
+  align-items: center;
+}
+
+.searchInput {
+  background-color: #42361d;
+  border-width: 0 0 1px;
+  border-bottom: 1px solid #8d6411;
+  color: #cccccc;
+  padding: 0 5px;
+
+  &::placeholder {
+    color: #666;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.clearButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 2px;
+  width: 18px;
+  height: 18px;
+  font-size: 11px;
 }
 
 .table {

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -159,9 +159,9 @@ const filteredRows = computed(() => {
   <LoadingSpinner v-if="!filteredRows" />
   <template v-else>
     <div :class="C.ComExOrdersPanel.filter">
-      <RadioItem v-model="showBase" horizontal>BASE</RadioItem>
-      <RadioItem v-model="showShip" horizontal>SHIP</RadioItem>
-      <RadioItem v-model="showWarehouse" horizontal>WAREHOUSE</RadioItem>
+      <RadioItem v-model="showBase" horizontal>BS</RadioItem>
+      <RadioItem v-model="showShip" horizontal>SHP</RadioItem>
+      <RadioItem v-model="showWarehouse" horizontal>WAR</RadioItem>
       <RadioItem v-model="showCx" horizontal>CX</RadioItem>
       <div :class="$style.separator" />
       <RadioItem v-model="showBaseWar" horizontal>BASE WAR</RadioItem>
@@ -212,7 +212,7 @@ const filteredRows = computed(() => {
 }
 
 .nameCol {
-  /* max-width on th does not constrain table layout; nameCell handles the cap */
+  padding: 4px 6px;
 }
 
 .typeCol {
@@ -230,12 +230,13 @@ const filteredRows = computed(() => {
 }
 
 .nameCell {
-  max-width: 30ch;
-  white-space: nowrap;
+  width: 1px;
+  padding: 4px 6px;
 }
 
 .nameText {
   display: block;
+  max-width: 200px;
   font-weight: bold;
   font-size: 12px;
   cursor: pointer;

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -221,7 +221,6 @@ const filteredRows = computed(() => {
 }
 
 .barCol {
-  width: 40%;
   min-width: 80px;
 }
 

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -13,12 +13,18 @@ import RadioItem from '@src/components/forms/RadioItem.vue';
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
 import InvBar from '@src/features/XIT/BS/InvBar.vue';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
-import { fixed0 } from '@src/utils/format';
+import { store as planetContextMenu } from '@src/features/XIT/planet-context-menu';
 import { useTileState } from './tile-state';
 
 type InvType = 'BASE' | 'SHIP' | 'WAREHOUSE' | 'CX';
 
 const TYPE_ORDER: Record<InvType, number> = { BASE: 0, SHIP: 1, WAREHOUSE: 2, CX: 3 };
+const TYPE_LABELS: Record<InvType, string> = {
+  BASE: 'BS',
+  SHIP: 'SHP',
+  WAREHOUSE: 'WAR',
+  CX: 'CX',
+};
 
 interface InvRow {
   storeId: string;
@@ -26,9 +32,8 @@ interface InvRow {
   label: string;
   naturalId?: string;
   warehousePlanetId?: string;
+  contextMenuId?: string;
   onClickCmd: string;
-  weightCapacity: number;
-  volumeCapacity: number;
 }
 
 const showBase = useTileState('showBase');
@@ -76,9 +81,8 @@ const allRows = computed<InvRow[] | undefined>(() => {
         type: 'BASE',
         label: getEntityNameFromAddress(site.address) ?? naturalId,
         naturalId,
+        contextMenuId: naturalId,
         onClickCmd: `INV ${store.id.substring(0, 8)}`,
-        weightCapacity: store.weightCapacity,
-        volumeCapacity: store.volumeCapacity,
       });
     } else if (store.type === 'SHIP_STORE') {
       const ship = ships.find(s => s.idShipStore === store.id);
@@ -90,8 +94,6 @@ const allRows = computed<InvRow[] | undefined>(() => {
         type: 'SHIP',
         label: ship.name || ship.registration,
         onClickCmd: `SHPI ${ship.registration}`,
-        weightCapacity: store.weightCapacity,
-        volumeCapacity: store.volumeCapacity,
       });
     } else if (store.type === 'WAREHOUSE_STORE') {
       const warehouse = warehouses.find(w => w.storeId === store.id);
@@ -107,9 +109,8 @@ const allRows = computed<InvRow[] | undefined>(() => {
         type: isCx ? 'CX' : 'WAREHOUSE',
         label,
         warehousePlanetId: isCx ? undefined : naturalId,
+        contextMenuId: isCx ? undefined : (naturalId ?? undefined),
         onClickCmd: `INV ${store.id.substring(0, 8)}`,
-        weightCapacity: store.weightCapacity,
-        volumeCapacity: store.volumeCapacity,
       });
     }
   }
@@ -152,10 +153,6 @@ const filteredRows = computed(() => {
     return true;
   });
 });
-
-function formatCapacity(row: InvRow) {
-  return `${fixed0(row.weightCapacity)}t / ${fixed0(row.volumeCapacity)}m³`;
-}
 </script>
 
 <template>
@@ -175,22 +172,26 @@ function formatCapacity(row: InvRow) {
           <th :class="$style.nameCol">Name</th>
           <th :class="$style.typeCol">Type</th>
           <th :class="$style.barCol">Inventory</th>
-          <th :class="$style.sizeCol">Capacity</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="row in filteredRows" :key="row.storeId" :class="$style.row">
-          <td :class="$style.nameCell">
-            <span :class="C.Link.link" @click="showBuffer(row.onClickCmd)">{{ row.label }}</span>
+          <td
+            :class="$style.nameCell"
+            @contextmenu.prevent="
+              row.contextMenuId && planetContextMenu.showMenu($event, row.contextMenuId)
+            ">
+            <span :class="$style.nameText" @click="showBuffer(row.onClickCmd)">{{
+              row.label
+            }}</span>
           </td>
-          <td :class="$style.typeCell">{{ row.type }}</td>
+          <td :class="$style.typeCell">{{ TYPE_LABELS[row.type] }}</td>
           <td :class="$style.barCell">
             <InvBar
               :store-id="row.storeId"
               :natural-id="row.naturalId"
               :on-click-cmd="row.onClickCmd" />
           </td>
-          <td :class="$style.sizeCell">{{ formatCapacity(row) }}</td>
         </tr>
       </tbody>
     </table>
@@ -211,7 +212,7 @@ function formatCapacity(row: InvRow) {
 }
 
 .nameCol {
-  width: auto;
+  /* max-width on th does not constrain table layout; nameCell handles the cap */
 }
 
 .typeCol {
@@ -224,20 +225,22 @@ function formatCapacity(row: InvRow) {
   min-width: 80px;
 }
 
-.sizeCol {
-  width: 0;
-  white-space: nowrap;
-}
-
 .row {
   border-bottom: 1px solid #2b485a;
 }
 
 .nameCell {
-  padding: 4px 6px;
-  max-width: 20ch;
-  overflow: hidden;
+  max-width: 30ch;
   white-space: nowrap;
+}
+
+.nameText {
+  display: block;
+  font-weight: bold;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
   text-overflow: ellipsis;
 }
 
@@ -247,17 +250,11 @@ function formatCapacity(row: InvRow) {
   opacity: 0.7;
   text-align: center;
   white-space: nowrap;
+  width: 0;
 }
 
 .barCell {
   padding: 2px;
   padding-bottom: 0;
-}
-
-.sizeCell {
-  padding: 4px 6px;
-  white-space: nowrap;
-  font-size: 11px;
-  text-align: right;
 }
 </style>

--- a/src/features/XIT/INV/INV.vue
+++ b/src/features/XIT/INV/INV.vue
@@ -167,10 +167,10 @@ const filteredRows = computed(() => {
   <LoadingSpinner v-if="!filteredRows" />
   <template v-else>
     <div :class="C.ComExOrdersPanel.filter">
+      <RadioItem v-model="showCx" horizontal>CX</RadioItem>
       <RadioItem v-model="showBase" horizontal>BS</RadioItem>
       <RadioItem v-model="showShip" horizontal>SHP</RadioItem>
       <RadioItem v-model="showWarehouse" horizontal>WAR</RadioItem>
-      <RadioItem v-model="showCx" horizontal>CX</RadioItem>
       <div :class="$style.separator" />
       <RadioItem v-model="showBaseWar" horizontal>BASE WAR</RadioItem>
       <div :class="$style.spacer" />

--- a/src/features/XIT/INV/tile-state.ts
+++ b/src/features/XIT/INV/tile-state.ts
@@ -1,0 +1,9 @@
+import { createTileStateHook } from '@src/store/user-data-tiles';
+
+export const useTileState = createTileStateHook({
+  showBase: true,
+  showShip: true,
+  showWarehouse: true,
+  showCx: true,
+  showBaseWar: true,
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `XIT INV` command — a new panel listing all non-fuel inventories (base, ship, warehouse, CX) in a single table
- Each row shows the location name, a type badge (CX/BS/SHP/WAR), and a full-width cargo bar using the same `InvBar` component as XIT BS
- Filter toggles at the top mirror XIT BURN's style; a location search bar sits at the far right

## Features

**Filter bar (left → right):** CX · BS · SHP · WAR | separator | BASE WAR | spacer | search

- **CX / BS / SHP / WAR** — show/hide each inventory type; CX first in both the filter bar and the row sort order
- **BASE WAR** — when deselected, hides planet warehouses co-located with a player base (useful for players who prefer to manage those via XIT BS)
- **Location search** — case-insensitive substring filter on the name column; placeholder text reads "Enter location"; clear button (×) appears when there is input

**Table columns:** Name · Type · Inventory bar

- Name: bold 12 px, BURN-style planet header — left-click opens the relevant buffer (`INV`, `SHPI`); right-click on BASE and planet WAREHOUSE rows opens the planet context menu (PLI / COGC / POPR / POPI / ADM), matching XIT BS behaviour
- Type: narrow badge (CX / BS / SHP / WAR)
- Inventory bar: stretches to fill remaining cell width; animated stripe background on updates, same as XIT FLT cargo bars

**CX detection:** warehouses at space-station addresses (`isStationLine`) are classified as CX. All six commodity exchanges (CI1, NC1, IC1, AI1, CI2, NC2) are at stations, so this is a clean, reliable check.

**Row ordering:** CX → BASE → SHIP → WAREHOUSE, alphabetical within each group.

## Test plan

- [ ] Open `XIT INV` — panel loads with all inventories listed
- [ ] Toggle each filter (CX, BS, SHP, WAR) — correct rows hide/show
- [ ] Toggle BASE WAR off — warehouses on the same planet as a base disappear
- [ ] Type in the search bar — rows filter to matching names; × clears it
- [ ] Left-click a BASE name — `INV` buffer opens
- [ ] Left-click a SHIP name — `SHPI` buffer opens
- [ ] Right-click a BASE or WAREHOUSE name — planet context menu appears
- [ ] Right-click a SHIP or CX name — no context menu (no-op)
- [ ] Cargo bars fill the full width of their cell and animate on inventory change

https://claude.ai/code/session_01GXyotGsMf6ZziTkGPwrxLr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXyotGsMf6ZziTkGPwrxLr)_