### PR TITLE
Add planet identifier filtering to BASE OVERVIEW command

### DIFF
--- a/src/features/XIT/BS/BS.ts
+++ b/src/features/XIT/BS/BS.ts
@@ -4,6 +4,7 @@ xit.add({
   command: 'BS',
   name: 'BASE OVERVIEW',
   description: 'Lists all player bases with links to key base commands.',
+  optionalParameters: 'Planet Identifier(s)',
   component: () => BS,
   bufferSize: [660, 300],
 });

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -17,6 +17,16 @@ import { getPlanetBurn } from '@src/core/burn';
 import { countDays } from '@src/features/XIT/BURN/utils';
 import { getPlanetRepairAge } from '@src/features/XIT/REP/entries';
 import { timestampEachMinute } from '@src/utils/dayjs';
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { findWithQuery } from '@src/utils/find-with-query';
+import { convertToPlanetNaturalId } from '@src/core/planet-natural-id';
+
+const parameters = useXitParameters();
+
+function findSite(term: string, parts: string[]) {
+  const naturalId = convertToPlanetNaturalId(term, parts);
+  return sitesStore.getByPlanetNaturalId(naturalId);
+}
 
 type SortKey = 'name' | 'burn' | 'repair';
 type SortDirection = 'asc' | 'desc';
@@ -109,11 +119,25 @@ const filteredBases = computed(() => {
   if (!all) {
     return undefined;
   }
+
+  let result = all;
+  if (parameters.length > 0 && sitesStore.all.value) {
+    const query = findWithQuery(parameters, findSite);
+    let included = query.include;
+    if (query.includeAll) included = sitesStore.all.value;
+    const includedIds = new Set(
+      included
+        .filter(x => !query.exclude.has(x))
+        .map(x => getEntityNaturalIdFromAddress(x.address)),
+    );
+    result = result.filter(x => includedIds.has(x.naturalId));
+  }
+
   const filter = planetFilter.value.trim().toUpperCase();
   if (!filter) {
-    return all;
+    return result;
   }
-  return all.filter(
+  return result.filter(
     x => x.naturalId.toUpperCase().includes(filter) || x.planetName.toUpperCase().includes(filter),
   );
 });

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -124,7 +124,9 @@ const filteredBases = computed(() => {
   if (parameters.length > 0 && sitesStore.all.value) {
     const query = findWithQuery(parameters, findSite);
     let included = query.include;
-    if (query.includeAll) included = sitesStore.all.value;
+    if (query.includeAll) {
+      included = sitesStore.all.value;
+    }
     const includedIds = new Set(
       included
         .filter(x => !query.exclude.has(x))


### PR DESCRIPTION
## Summary

Adds support for optional planet identifier parameters to the BASE OVERVIEW (BS) command, allowing users to filter bases by planet. The filtering leverages existing planet natural ID conversion and query utilities to match specified planets against the displayed base list.

## Changes

- Added `useXitParameters` hook to retrieve command parameters
- Implemented `findSite` helper function to resolve planet identifiers to sites
- Extended `filteredBases` computed property to filter results based on planet parameters before applying text search
- Updated command metadata to document the optional planet identifier parameter

## Standards Checklist

- [x] No upward imports across layers (features -> core -> infrastructure -> utils)
- [x] No explicit imports of auto-imported symbols
- [x] CSS rules scoped to commands where applicable
- [x] Numbers use formatters from `@src/utils/format`
- [x] No `title=` attributes (use `data-tooltip`)
- [x] No `onApiMessage` in features (use `computed` from stores)
- [x] Feature has single responsibility, no cross-feature deps
- [x] CSS class names describe WHERE, not WHAT
- [x] Uses `C.Component.className` not hardcoded hashed classes
- [x] CHANGELOG.md not modified

## Test Plan

Existing tests should cover the filtering logic. Manual verification: running `BS` with and without planet identifiers should correctly filter the base list.

https://claude.ai/code/session_01Whf7hfoUYvXE4CBQpLn8L9