### PR TITLE
put runner edits in branch 

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -35,6 +35,32 @@ jobs:
       - name: Build extension
         run: pnpm run build:fast
 
+      - name: Write commit info
+        shell: powershell
+        run: |
+          $sha = $env:GITHUB_SHA
+          $shortSha = $sha.Substring(0, 8)
+          $commitMsg = git log -1 --format="%s"
+          $author = git log -1 --format="%an"
+          $commitTimestamp = git log -1 --format="%aI"
+          $dt = [DateTimeOffset]::Parse($commitTimestamp).UtcDateTime
+          $fileTimestamp = $dt.ToString("yyyyMMdd-HHmmss")
+
+          $outDir = "C:\Users\cyrus\Codex\refined-prun-commits"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          $json = [ordered]@{
+            sha           = $sha
+            shortSha      = $shortSha
+            branch        = $env:GITHUB_REF_NAME
+            message       = $commitMsg
+            author        = $author
+            timestamp     = $commitTimestamp
+            runId         = $env:GITHUB_RUN_ID
+          } | ConvertTo-Json
+
+          $json | Set-Content -Path "$outDir\${fileTimestamp}_${shortSha}.json" -Encoding UTF8
+
       - name: Restart Edge with new build
         shell: powershell
         run: |


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md not modified
