### PR TITLE
Fix Edge not opening after deploy: launch via Scheduled Task

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -80,14 +80,14 @@ jobs:
           Remove-Item "$profile\SingletonLock" -Force -ErrorAction SilentlyContinue
           $dist = Join-Path $env:GITHUB_WORKSPACE "dist"
 
-          Write-Output "Edge: $edge"
-          Write-Output "Dist: $dist (exists: $(Test-Path $dist))"
-          Write-Output "Profile: $profile"
-
-          $proc = Start-Process $edge -ArgumentList "--load-extension=$dist", "--user-data-dir=$profile", "https://apex.prosperousuniverse.com" -PassThru
-          Start-Sleep -Seconds 5
-          if ($proc.HasExited) {
-            Write-Output "Edge exited immediately! Exit code: $($proc.ExitCode)"
-          } else {
-            Write-Output "Edge running OK (PID $($proc.Id))"
-          }
+          # Launch via Scheduled Task so Edge runs in the interactive desktop session,
+          # not the runner's hidden window station.
+          $taskName = "rprun-launch-edge"
+          $args = "--load-extension=`"$dist`" --user-data-dir=`"$profile`" https://apex.prosperousuniverse.com"
+          $action = New-ScheduledTaskAction -Execute $edge -Argument $args
+          $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(3)
+          $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+          $settings = New-ScheduledTaskSettingsSet -DeleteExpiredTaskAfter (New-TimeSpan -Minutes 2)
+          Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+          Start-ScheduledTask -TaskName $taskName
+          Write-Output "Scheduled Edge launch in interactive session"

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -79,4 +79,15 @@ jobs:
           $profile = "$env:LOCALAPPDATA\rprun-edge-profile"
           Remove-Item "$profile\SingletonLock" -Force -ErrorAction SilentlyContinue
           $dist = Join-Path $env:GITHUB_WORKSPACE "dist"
-          Start-Process $edge -ArgumentList "--load-extension=$dist", "--user-data-dir=$profile", "https://apex.prosperousuniverse.com"
+
+          Write-Output "Edge: $edge"
+          Write-Output "Dist: $dist (exists: $(Test-Path $dist))"
+          Write-Output "Profile: $profile"
+
+          $proc = Start-Process $edge -ArgumentList "--load-extension=$dist", "--user-data-dir=$profile", "https://apex.prosperousuniverse.com" -PassThru
+          Start-Sleep -Seconds 5
+          if ($proc.HasExited) {
+            Write-Output "Edge exited immediately! Exit code: $($proc.ExitCode)"
+          } else {
+            Write-Output "Edge running OK (PID $($proc.Id))"
+          }

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -86,6 +86,7 @@ jobs:
           $args = "--load-extension=`"$dist`" --user-data-dir=`"$profile`" https://apex.prosperousuniverse.com"
           $action = New-ScheduledTaskAction -Execute $edge -Argument $args
           $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(3)
+          $trigger.EndBoundary = (Get-Date).AddMinutes(5).ToString('s')
           $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
           $settings = New-ScheduledTaskSettingsSet -DeleteExpiredTaskAfter (New-TimeSpan -Minutes 2)
           Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null

--- a/scripts/restart-runner.ps1
+++ b/scripts/restart-runner.ps1
@@ -1,0 +1,4 @@
+Get-Process -Name "Runner.Worker" -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-Process -Name "run" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-Sleep -Seconds 2
+Start-Process "C:\actions-runner\run.cmd"


### PR DESCRIPTION
## Problem

`Start-Process` in the GitHub Actions runner's PowerShell step runs in a hidden window station, so Edge launched successfully (process existed, no crash) but was never visible on the desktop.

## Changes

- **`scripts/restart-runner.ps1`** — convenience script to kill and restart the self-hosted runner without logging out; copy to PC and run with PowerShell
- **`.github/workflows/deploy-local.yml`** — replace `Start-Process` with a Scheduled Task using `-LogonType Interactive`, which forces Edge to launch in the active desktop session where it's visible; also fixes a Windows XML schema error (`EndBoundary` must be set on `Once` triggers)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6Xj69BTESU8e5EPqd9URV)_