### PR TITLE
CONTD: Add "all" buttons to fill amount/price across commodity sections

### DIFF
--- a/src/features/basic/contd-fill-all-button.module.css
+++ b/src/features/basic/contd-fill-all-button.module.css
@@ -1,0 +1,3 @@
+.allButton {
+  margin-right: 4px;
+}

--- a/src/features/basic/contd-fill-all-button.tsx
+++ b/src/features/basic/contd-fill-all-button.tsx
@@ -29,7 +29,7 @@ function addAllButton(anchor: Element, sourceInput: HTMLInputElement, selector: 
     <PrunButton dark inline onClick={() => fillAll(anchor, sourceInput, selector)}>
       all
     </PrunButton>
-  )).after(sourceInput);
+  )).before(sourceInput);
 }
 
 function fillAll(anchor: Element, sourceInput: HTMLInputElement, selector: string) {

--- a/src/features/basic/contd-fill-all-button.tsx
+++ b/src/features/basic/contd-fill-all-button.tsx
@@ -1,5 +1,6 @@
 import { changeInputValue, focusElement } from '@src/util';
 import PrunButton from '@src/components/PrunButton.vue';
+import $style from './contd-fill-all-button.module.css';
 
 function onTileReady(tile: PrunTile) {
   let firstGroup: Element | undefined;
@@ -26,7 +27,11 @@ function onTileReady(tile: PrunTile) {
 
 function addAllButton(anchor: Element, sourceInput: HTMLInputElement, selector: string) {
   createFragmentApp(() => (
-    <PrunButton dark inline onClick={() => fillAll(anchor, sourceInput, selector)}>
+    <PrunButton
+      dark
+      inline
+      class={$style.allButton}
+      onClick={() => fillAll(anchor, sourceInput, selector)}>
       all
     </PrunButton>
   )).before(sourceInput);

--- a/src/features/basic/contd-fill-all-button.tsx
+++ b/src/features/basic/contd-fill-all-button.tsx
@@ -1,0 +1,54 @@
+import { changeInputValue, focusElement } from '@src/util';
+import PrunButton from '@src/components/PrunButton.vue';
+
+function onTileReady(tile: PrunTile) {
+  let firstGroup: Element | undefined;
+
+  subscribe($$(tile.anchor, C.TemplateSelection.group), group => {
+    if (firstGroup !== undefined) {
+      return;
+    }
+    firstGroup = group;
+
+    const amountInput = group.querySelector(
+      'input[inputmode="numeric"]',
+    ) as HTMLInputElement | null;
+    if (amountInput) {
+      addAllButton(tile.anchor, amountInput, 'input[inputmode="numeric"]');
+    }
+
+    const priceInput = group.querySelector('input[inputmode="decimal"]') as HTMLInputElement | null;
+    if (priceInput) {
+      addAllButton(tile.anchor, priceInput, 'input[inputmode="decimal"]');
+    }
+  });
+}
+
+function addAllButton(anchor: Element, sourceInput: HTMLInputElement, selector: string) {
+  createFragmentApp(() => (
+    <PrunButton dark inline onClick={() => fillAll(anchor, sourceInput, selector)}>
+      all
+    </PrunButton>
+  )).after(sourceInput);
+}
+
+function fillAll(anchor: Element, sourceInput: HTMLInputElement, selector: string) {
+  const value = sourceInput.value;
+  for (const group of _$$(anchor, C.TemplateSelection.group)) {
+    const target = group.querySelector(selector) as HTMLInputElement | null;
+    if (target && target !== sourceInput) {
+      focusElement(target);
+      changeInputValue(target, value);
+    }
+  }
+}
+
+function init() {
+  tiles.observe('CONTD', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'CONTD: Adds "all" buttons next to the first amount/price per unit fields to copy the value to every commodity section.',
+);


### PR DESCRIPTION
## Summary

- Adds small gray "all" buttons immediately to the left of the first commodity section's amount and price per unit inputs in CONTD.
- Clicking a button copies that field's current value into the same field (amount or price per unit) in every other commodity section of the contract draft template.
- Fields are located via the existing `C.TemplateSelection.group` pattern (same one used by `contd-bulk-add-commodity.tsx`) and the `input[inputmode="numeric"]` / `input[inputmode="decimal"]` selectors already established in `cont-utils.ts` / `CONT_TRADE.ts`.

## Standards Checklist

- [x] No upward imports across layers (features -> core -> infrastructure -> utils)
- [x] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [x] CSS rules scoped to commands where applicable
- [x] Numbers use formatters from `@src/utils/format`
- [x] No `title=` attributes (use `data-tooltip`)
- [x] No `onApiMessage` in features (use `computed` from stores)
- [x] Feature has single responsibility, no cross-feature deps
- [x] CSS class names describe WHERE, not WHAT
- [x] Uses `C.Component.className` not hardcoded hashed classes
- [x] CHANGELOG.md not modified

## Test plan

- [x] `pnpm run compile` (typecheck) passes
- [x] `pnpm exec eslint` passes on changed files
- [ ] Manual click-through in a live CONTD buffer (not possible in this sandboxed environment — no live game connection)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GsPB6u8GsvZxTZktyy3xpE)_