### PR TITLE
feat(ACT): Refuel All Exchanges + REFUELACT button

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -97,6 +97,45 @@ The file is auto-imported via `import.meta.glob` in `src/features/index.ts` — 
 
 The command should be short. Refer to `docs/game/commands.csv` for an example of game commands. Alias is usually added for backwards compatibility or if the community REALLY wants it.
 
+### One-Click Preconfigured Action Packages
+
+To give users a single button that runs a specific ACT action package without opening the ACT editor (e.g. `BURNACT`, `REFUELACT`), pair two files next to the relevant action:
+
+```ts
+// <NAME>ACT.ts
+import '@src/features/XIT/ACT/actions/refuel/refuel'; // ensure the action type is registered
+
+xit.add({
+  command: 'REFUELACT',
+  name: 'REFUEL ALL EXCHANGES',
+  description: 'Executes a refuel action package for all ships docked at exchanges.',
+  component: () => RefuelActWindow,
+});
+```
+
+```vue
+<!-- <Name>ActWindow.vue -->
+<script setup lang="ts">
+import ExecuteActionPackage from '@src/features/XIT/ACT/ExecuteActionPackage.vue';
+
+const pkg: UserData.ActionPackageData = {
+  global: { name: 'Refuel All Exchanges' },
+  groups: [],
+  actions: [{ type: 'Refuel', name: 'Refuel', origin: allExchangesValue, buyMissingFuel: true }],
+};
+</script>
+
+<template>
+  <ExecuteActionPackage :pkg="pkg" />
+</template>
+```
+
+The `pkg` is a plain hardcoded object, not persisted user data — `ExecuteActionPackage` runs it exactly like a saved package (CONFIGURE only appears if an action still needs runtime input; PREVIEW/EXECUTE always available). Trigger it from anywhere with `showBuffer('XIT REFUELACT')` (see `PlanetHeader.vue`'s `XIT BURNACT` button for a row-level example, or `FLT.vue`'s Fuel-column header button for another).
+
+### Action-Specific Sentinel Values
+
+`configurableValue` and `groupTargetPrefix` (`shared-types.ts`) are sentinels shared across every ACT action/material-group type. If an action needs an extra dropdown option unique to itself (e.g. Refuel's "All Exchanges" origin, alongside "Configure on Execution" and specific storages), define that sentinel in the action's own `utils.ts`/`config.ts` instead of adding it to `shared-types.ts`.
+
 ---
 
 ## Auto-Imports (no explicit import needed)

--- a/src/features/XIT/ACT/actions/refuel/Edit.vue
+++ b/src/features/XIT/ACT/actions/refuel/Edit.vue
@@ -4,7 +4,7 @@ import SelectInput from '@src/components/forms/SelectInput.vue';
 import { serializeStorage, storageSort } from '@src/features/XIT/ACT/actions/utils';
 import { configurableValue } from '@src/features/XIT/ACT/shared-types';
 import RadioItem from '@src/components/forms/RadioItem.vue';
-import { getRefuelOrigins } from '@src/features/XIT/ACT/actions/refuel/utils';
+import { allExchangesValue, getRefuelOrigins } from '@src/features/XIT/ACT/actions/refuel/utils';
 
 const { action } = defineProps<{
   action: UserData.ActionData;
@@ -13,6 +13,7 @@ const { action } = defineProps<{
 
 const storages = computed(() => {
   const storages = getRefuelOrigins().sort(storageSort).map(serializeStorage);
+  storages.unshift(allExchangesValue);
   storages.unshift(configurableValue);
   return storages;
 });

--- a/src/features/XIT/ACT/actions/refuel/REFUELACT.ts
+++ b/src/features/XIT/ACT/actions/refuel/REFUELACT.ts
@@ -1,0 +1,10 @@
+import '@src/features/XIT/ACT/actions/refuel/refuel';
+
+import RefuelActWindow from '@src/features/XIT/ACT/actions/refuel/RefuelActWindow.vue';
+
+xit.add({
+  command: 'REFUELACT',
+  name: 'REFUEL ALL EXCHANGES',
+  description: 'Executes a refuel action package for all ships docked at exchanges.',
+  component: () => RefuelActWindow,
+});

--- a/src/features/XIT/ACT/actions/refuel/RefuelActWindow.vue
+++ b/src/features/XIT/ACT/actions/refuel/RefuelActWindow.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import ExecuteActionPackage from '@src/features/XIT/ACT/ExecuteActionPackage.vue';
+import { allExchangesValue } from '@src/features/XIT/ACT/actions/refuel/utils';
+
+const pkg: UserData.ActionPackageData = {
+  global: { name: 'Refuel All Exchanges' },
+  groups: [],
+  actions: [
+    {
+      type: 'Refuel',
+      name: 'Refuel',
+      origin: allExchangesValue,
+      buyMissingFuel: true,
+    },
+  ],
+};
+</script>
+
+<template>
+  <ExecuteActionPackage :pkg="pkg" />
+</template>

--- a/src/features/XIT/ACT/actions/refuel/refuel.ts
+++ b/src/features/XIT/ACT/actions/refuel/refuel.ts
@@ -2,21 +2,31 @@ import { act } from '@src/features/XIT/ACT/act-registry';
 import Edit from '@src/features/XIT/ACT/actions/refuel/Edit.vue';
 import Configure from '@src/features/XIT/ACT/actions/refuel/Configure.vue';
 import { Config } from '@src/features/XIT/ACT/actions/refuel/config';
+import { allExchangesValue, getRefuelOrigins } from '@src/features/XIT/ACT/actions/refuel/utils';
 import { CXPO_BUY } from '@src/features/XIT/ACT/action-steps/CXPO_BUY';
 import { MTRA_TRANSFER } from '@src/features/XIT/ACT/action-steps/MTRA_TRANSFER';
-import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
-import { atSameLocation, deserializeStorage } from '@src/features/XIT/ACT/actions/utils';
+import { ActionStep, AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
+import {
+  atSameLocation,
+  deserializeStorage,
+  isCXWarehouse,
+  serializeStorage,
+} from '@src/features/XIT/ACT/actions/utils';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
 import { clamp } from '@src/utils/clamp';
+import { Logger } from '@src/features/XIT/ACT/runner/logger';
 
 act.addAction<Config>({
   type: 'Refuel',
   shortDescription: 'Refuel all ships docked near a storage',
   description: action => {
+    if (action.origin === allExchangesValue) {
+      return 'Refuel all ships docked at exchanges';
+    }
     return action.origin ? 'Refuel all ships near ' + action.origin : '--';
   },
   editComponent: Edit,
@@ -31,115 +41,139 @@ act.addAction<Config>({
     const { data, config, log, emitStep } = ctx;
     const assert: AssertFn = ctx.assert;
 
-    const serializedOrigin = data.origin === configurableValue ? config?.origin : data.origin;
-    const origin = deserializeStorage(serializedOrigin);
-    assert(origin, 'Invalid origin');
-
-    const exchangeCode = getExchangeCode(origin);
-    const isCX = exchangeCode !== undefined;
-
-    const dockedStl =
-      storagesStore.getByType('STL_FUEL_STORE')?.filter(x => atSameLocation(x, origin)) ?? [];
-
-    const dockedFtl =
-      storagesStore.getByType('FTL_FUEL_STORE')?.filter(x => atSameLocation(x, origin)) ?? [];
-
-    if (dockedStl.length === 0 && dockedFtl.length === 0) {
-      log.warning('No ships are docked near the origin');
-      return;
-    }
-
     const stlMaterial = materialsStore.getByTicker('SF');
     assert(stlMaterial, 'SF material not found');
 
     const ftlMaterial = materialsStore.getByTicker('FF');
     assert(ftlMaterial, 'FF material not found');
 
-    const totalStlRefuel = sumBy(dockedStl, x => calculateRefuelAmount(x, stlMaterial));
-    const totalFtlRefuel = sumBy(dockedFtl, x => calculateRefuelAmount(x, ftlMaterial));
-
-    if (totalFtlRefuel === 0 && totalStlRefuel === 0) {
-      log.info('No ships need refueling');
+    if (data.origin === allExchangesValue) {
+      const origins = getRefuelOrigins().filter(isCXWarehouse);
+      if (origins.length === 0) {
+        log.warning('No exchange warehouses found');
+        return;
+      }
+      for (const origin of origins) {
+        refuelFromOrigin(origin, data, stlMaterial, ftlMaterial, log, emitStep);
+      }
       return;
     }
 
-    let presentStlFuel =
-      origin.items.find(x => x.quantity?.material.ticker === stlMaterial.ticker)?.quantity
-        ?.amount ?? 0;
+    const serializedOrigin = data.origin === configurableValue ? config?.origin : data.origin;
+    const origin = deserializeStorage(serializedOrigin);
+    assert(origin, 'Invalid origin');
 
-    if (presentStlFuel < totalStlRefuel) {
-      if (isCX && data.buyMissingFuel) {
-        emitStep(
-          CXPO_BUY({
-            exchange: exchangeCode,
-            ticker: stlMaterial.ticker,
-            amount: totalStlRefuel - presentStlFuel,
-            priceLimit: Number.POSITIVE_INFINITY,
-            buyPartial: false,
-            allowUnfilled: false,
-          }),
-        );
-        presentStlFuel = totalStlRefuel;
-      } else {
-        log.warning('Not enough SF at the origin. Some ships will not be refueled.');
-      }
-    }
-
-    let presentFtlFuel =
-      origin.items.find(x => x.quantity?.material.ticker === ftlMaterial.ticker)?.quantity
-        ?.amount ?? 0;
-
-    if (presentFtlFuel < totalFtlRefuel) {
-      if (isCX && data.buyMissingFuel) {
-        emitStep(
-          CXPO_BUY({
-            exchange: exchangeCode,
-            ticker: ftlMaterial.ticker,
-            amount: totalFtlRefuel - presentFtlFuel,
-            priceLimit: Number.POSITIVE_INFINITY,
-            buyPartial: false,
-            allowUnfilled: false,
-          }),
-        );
-        presentFtlFuel = totalFtlRefuel;
-      } else {
-        log.warning('Not enough FF at the origin. Some ships will not be refueled.');
-      }
-    }
-
-    for (const store of dockedStl) {
-      const amount = clamp(calculateRefuelAmount(store, stlMaterial), 0, presentStlFuel);
-      if (amount === 0) {
-        continue;
-      }
-      emitStep(
-        MTRA_TRANSFER({
-          from: origin.id,
-          to: store.id,
-          ticker: stlMaterial.ticker,
-          amount,
-        }),
-      );
-      presentStlFuel -= amount;
-    }
-
-    for (const store of dockedFtl) {
-      const amount = clamp(calculateRefuelAmount(store, ftlMaterial), 0, presentFtlFuel);
-      if (amount === 0) {
-        continue;
-      }
-      emitStep(
-        MTRA_TRANSFER({
-          from: origin.id,
-          to: store.id,
-          ticker: ftlMaterial.ticker,
-          amount,
-        }),
-      );
-      presentFtlFuel -= amount;
-    }
+    refuelFromOrigin(origin, data, stlMaterial, ftlMaterial, log, emitStep);
   },
 });
+
+function refuelFromOrigin(
+  origin: PrunApi.Store,
+  data: UserData.ActionData,
+  stlMaterial: PrunApi.Material,
+  ftlMaterial: PrunApi.Material,
+  log: Logger,
+  emitStep: (step: ActionStep) => void,
+) {
+  const originName = serializeStorage(origin);
+  const exchangeCode = getExchangeCode(origin);
+  const isCX = exchangeCode !== undefined;
+
+  const dockedStl =
+    storagesStore.getByType('STL_FUEL_STORE')?.filter(x => atSameLocation(x, origin)) ?? [];
+
+  const dockedFtl =
+    storagesStore.getByType('FTL_FUEL_STORE')?.filter(x => atSameLocation(x, origin)) ?? [];
+
+  if (dockedStl.length === 0 && dockedFtl.length === 0) {
+    log.info(`No ships are docked near ${originName}`);
+    return;
+  }
+
+  const totalStlRefuel = sumBy(dockedStl, x => calculateRefuelAmount(x, stlMaterial));
+  const totalFtlRefuel = sumBy(dockedFtl, x => calculateRefuelAmount(x, ftlMaterial));
+
+  if (totalFtlRefuel === 0 && totalStlRefuel === 0) {
+    log.info(`No ships need refueling near ${originName}`);
+    return;
+  }
+
+  let presentStlFuel =
+    origin.items.find(x => x.quantity?.material.ticker === stlMaterial.ticker)?.quantity?.amount ??
+    0;
+
+  if (presentStlFuel < totalStlRefuel) {
+    if (isCX && data.buyMissingFuel) {
+      emitStep(
+        CXPO_BUY({
+          exchange: exchangeCode,
+          ticker: stlMaterial.ticker,
+          amount: totalStlRefuel - presentStlFuel,
+          priceLimit: Number.POSITIVE_INFINITY,
+          buyPartial: false,
+          allowUnfilled: false,
+        }),
+      );
+      presentStlFuel = totalStlRefuel;
+    } else {
+      log.warning(`Not enough SF at ${originName}. Some ships will not be refueled.`);
+    }
+  }
+
+  let presentFtlFuel =
+    origin.items.find(x => x.quantity?.material.ticker === ftlMaterial.ticker)?.quantity?.amount ??
+    0;
+
+  if (presentFtlFuel < totalFtlRefuel) {
+    if (isCX && data.buyMissingFuel) {
+      emitStep(
+        CXPO_BUY({
+          exchange: exchangeCode,
+          ticker: ftlMaterial.ticker,
+          amount: totalFtlRefuel - presentFtlFuel,
+          priceLimit: Number.POSITIVE_INFINITY,
+          buyPartial: false,
+          allowUnfilled: false,
+        }),
+      );
+      presentFtlFuel = totalFtlRefuel;
+    } else {
+      log.warning(`Not enough FF at ${originName}. Some ships will not be refueled.`);
+    }
+  }
+
+  for (const store of dockedStl) {
+    const amount = clamp(calculateRefuelAmount(store, stlMaterial), 0, presentStlFuel);
+    if (amount === 0) {
+      continue;
+    }
+    emitStep(
+      MTRA_TRANSFER({
+        from: origin.id,
+        to: store.id,
+        ticker: stlMaterial.ticker,
+        amount,
+      }),
+    );
+    presentStlFuel -= amount;
+  }
+
+  for (const store of dockedFtl) {
+    const amount = clamp(calculateRefuelAmount(store, ftlMaterial), 0, presentFtlFuel);
+    if (amount === 0) {
+      continue;
+    }
+    emitStep(
+      MTRA_TRANSFER({
+        from: origin.id,
+        to: store.id,
+        ticker: ftlMaterial.ticker,
+        amount,
+      }),
+    );
+    presentFtlFuel -= amount;
+  }
+}
 
 function getExchangeCode(store: PrunApi.Store) {
   const warehouse = warehousesStore.getById(store.addressableId);

--- a/src/features/XIT/ACT/actions/refuel/utils.ts
+++ b/src/features/XIT/ACT/actions/refuel/utils.ts
@@ -1,5 +1,7 @@
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 
+export const allExchangesValue = 'All Exchanges';
+
 export function getRefuelOrigins() {
   return storagesStore.nonFuelStores.value ?? [];
 }

--- a/src/features/XIT/FLT/FLT.vue
+++ b/src/features/XIT/FLT/FLT.vue
@@ -10,6 +10,7 @@ import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { useTileState } from '@src/store/user-data-tiles';
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
 import RadioItem from '@src/components/forms/RadioItem.vue';
+import PrunButton from '@src/components/PrunButton.vue';
 import FleetStatusCell from './FleetStatusCell.vue';
 import CargoBar from './CargoBar.vue';
 import { fixed0 } from '@src/utils/format';
@@ -418,6 +419,10 @@ function onFuel(registration: string) {
   showBuffer(`SHPF ${registration}`);
 }
 
+function onRefuelAllExchanges() {
+  showBuffer('XIT REFUELACT');
+}
+
 function toggleFilters() {
   showFilters.value = !showFilters.value;
 }
@@ -663,14 +668,26 @@ function getCargoState(cargoRatio: number) {
             :key="column.key"
             :class="[$style.headerCell, $style.sortable]"
             @click="setSort(column.key)">
-            {{ column.label }}
-            <span
-              :class="{
-                [$style.sortPrimary]: isPrimarySort(column.key),
-                [$style.sortSecondary]: isSecondarySort(column.key),
-              }">
-              {{ getSortIndicator(column.key) }}
-            </span>
+            <div :class="$style.headerCellContent">
+              <span>
+                {{ column.label }}
+                <span
+                  :class="{
+                    [$style.sortPrimary]: isPrimarySort(column.key),
+                    [$style.sortSecondary]: isSecondarySort(column.key),
+                  }">
+                  {{ getSortIndicator(column.key) }}
+                </span>
+              </span>
+              <PrunButton
+                v-if="column.key === 'fuel'"
+                dark
+                inline
+                :class="$style.refuelActButton"
+                @click.stop="onRefuelAllExchanges">
+                REFUEL
+              </PrunButton>
+            </div>
           </th>
         </tr>
       </thead>
@@ -798,6 +815,17 @@ function getCargoState(cargoRatio: number) {
 .headerCell {
   text-align: left;
   padding: 4px 6px;
+}
+
+.headerCellContent {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.refuelActButton {
+  flex: 0 0 auto;
 }
 
 .sortable {


### PR DESCRIPTION
## Summary
- Refuel action packages support a new "All Exchanges" origin: evaluates refuel needs and generates buy/transfer steps independently per CX warehouse instead of one fixed origin.
- New `XIT REFUELACT` one-click preconfigured action package (same pattern as `BURNACT`), triggered from a REFUEL button on the XIT FLT Fuel-column header.

Cherry-picked from #107's `0e1bb709`, dropping that PR's `reload-extension`/harness changes which depended on #106 commits not yet on main. See #107 for the original combined PR (to be closed in favor of this one plus a follow-up once #106 lands).

## Test plan
- [x] `pnpm run compile` / lint clean on this branch (verified fresh after cherry-pick)
- [x] Originally verified live in the browser on #107: FLT header button placement/sort behavior, `REFUELACT` preview output across multiple exchanges, ACT editor's "All Exchanges" dropdown option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiJzmRAhaFYQieWR4TWn83