### PR TITLE
chore: reduce grok/task permission friction, cap game-tester retries

### DIFF
--- a/.claude/agents/game-tester.md
+++ b/.claude/agents/game-tester.md
@@ -31,6 +31,12 @@ and only a short text report returns to the main session.
 5. Prefer data-only pw-act actions (`list-windows`, `dump-windows`, `styles`,
    `open-contd-template`, ...) over bespoke `eval`. Batch steps; screenshot only at
    decision points.
+6. **Retry cap: 2 attempts per verification method.** If the same approach (e.g. a
+   cropped hover screenshot) fails twice, stop iterating on it — switch to a cheaper,
+   more reliable method instead (usually `eval` reading computed style / DOM attributes
+   directly rather than a pixel screenshot). Never rewrite the same script a third time
+   hoping the selector or timing will work; if the DOM-level check also isn't feasible,
+   report what you tried and stop rather than continuing to iterate.
 
 ## Reporting
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,16 +23,23 @@
       "Bash(node .local/scratch/*)",
       "Bash(pgrep *)",
       "Bash(grok --no-auto-update --no-alt-screen --always-approve -p *)",
+      "Bash(git merge-base *)",
       "Agent",
       "SendMessage",
       "ToolSearch",
-      "Skill"
+      "Skill",
+      "TaskCreate",
+      "TaskUpdate",
+      "TaskGet",
+      "TaskList",
+      "TaskOutput",
+      "TaskStop"
     ]
   },
   "sandbox": {
     "autoAllowBashIfSandboxed": true,
     "network": {
-      "allowedDomains": ["api.x.ai"]
+      "allowedDomains": ["api.x.ai", "auth.x.ai"]
     },
     "excludedCommands": [
       "node scripts/local-browser-test.mjs",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,11 @@ For small tasks (one-line fixes, running tests, infra chores, questions): skip t
 
 The Bash sandbox denies writes to `.claude/` control files (skills, hooks, settings) by design. Some of those files are also git-tracked and differ between branches, so a sandboxed `git checkout`/`git stash` crossing such branches fails **midway** ("Read-only file system"), leaving git half-done. When a branch switch involves `.claude/` file changes, run that git command unsandboxed from the start.
 
+`grok` also refreshes its OAuth token against `auth.x.ai` on every invocation, not just at
+`grok login` — that host needs to be in `sandbox.network.allowedDomains` in
+`.claude/settings.json`, or every call falls back to a manual sandbox-bypass approval. That
+setting isn't exposed through the `/sandbox` command; edit `.claude/settings.json` directly.
+
 ## DISTILL
 
 The distill skill captures session learnings into the docs. Run it once per session, near the end — not after every task.


### PR DESCRIPTION
## What

Config/doc fixes for agent-permission friction discovered while working the CONTD paste-import branch (PR #106) — split out here since they're unrelated to that feature, per this repo's existing split precedent (#109).

- **`.claude/settings.json`**: allowlists the `Task*` tools (`TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList`/`TaskOutput`/`TaskStop`) — pure bookkeeping, same trust class as `Agent`/`SendMessage`/`Skill` which were already allowlisted, but the Task family wasn't and was prompting on every call. Also adds `auth.x.ai` alongside this branch's existing `api.x.ai` sandbox-network entry: `grok` refreshes its OAuth token against `auth.x.ai` on *every* invocation (not just `grok login`), separate from whatever `api.x.ai` covers, and without it the only fallback was a full `dangerouslyDisableSandbox` bypass requiring manual approval each time.
- **`AGENTS.md`**: records the `auth.x.ai` requirement next to this branch's existing sandbox/`.claude`-file gotcha in `SANDBOX & GIT`, so it doesn't have to be rediscovered by strings-grepping the installed CLI binary again.
- **`.claude/agents/game-tester.md`**: caps retries at 2 attempts per verification method before switching approach (e.g. a pixel-cropped hover-screenshot check → a DOM `eval` reading computed style/attributes instead), after a verification run stalled for **3+ hours** retrying the identical screenshot script ~10 times without ever landing one.

## Verified

- `.claude/settings.json` is valid JSON (checked with `python3 -c "import json; json.load(...)"`).
- The `auth.x.ai` sandbox-network fix was live-verified on the other branch: `grok models` ran fully sandboxed with zero approval prompts after adding the host (previously required a `dangerouslyDisableSandbox` bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1iuZehpehMDgqrNSHeRVf