### PR TITLE
fix(CONTD): drag pane footprint, game-style scrollbar, centered hint

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -90,6 +90,12 @@ type errors surfaced). Output goes to `dist/`.
 step 3). That's the full loop for iterating on a change without a fresh launch or an
 agent: rebuild, reload-extension, look.
 
+**A stale build fails silently.** The running browser holds whatever branch was last
+built — and the user swaps active branches often, so assume it's NOT yours. A feature
+missing from the loaded build renders zero DOM and no console error, indistinguishable
+from a broken feature. Always rebuild + reload-extension before verifying, and before
+concluding a feature is broken or absent.
+
 ### 2. Launch the browser
 
 ```

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -677,6 +677,44 @@ re-themes:
 Layer your own module class alongside it for structural overrides only (width, resize,
 min-height) — let the `C` class own the colors/border/font.
 
+Two verified quirks when pairing such an input with sibling elements:
+
+- `C.TextareaInput.textarea` sets colors and the focus underline but leaves the font at
+  the browser default (13.3333px monospace). A sibling element meant to read like the
+  textarea's placeholder (e.g. an empty-state hint on an alternate pane) must set
+  `font: 13.3333px monospace` explicitly — panel text is otherwise Droid Sans.
+- A bare `<textarea>` is inline-block: it sits on the text baseline and leaves a few px
+  of descender gap below it. Give it `display: block` when its footprint must match a
+  block-level sibling pane, or the panes' total heights differ even with identical rects.
+
+### Matching the Game's Scrollbar
+
+An overflowing element added to the game UI gets the wide native browser scrollbar
+(arrow buttons included), which looks foreign in a buffer. The game's narrow gray
+scrollbar (chat, command suggestions, production lines) is plain CSS — mirror its own
+rules verbatim:
+
+```css
+.textarea {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(51, 51, 51) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgb(51, 51, 51);
+    border-radius: 5px;
+  }
+}
+```
+
+There is no game class to reuse for this: the game's main `ScrollView` machinery never
+restyles the scrollbar — it hides the native one by pushing it outside a clipped parent
+(`margin-right: -15px`) — so copy the values.
+
 ### `:has` Selector
 
 Use `:has` to implement conditional styling in pure CSS, avoiding unnecessary JS.

--- a/src/features/basic/contd-paste-import/contd-paste-import.module.css
+++ b/src/features/basic/contd-paste-import/contd-paste-import.module.css
@@ -51,7 +51,28 @@
 }
 
 .textarea {
+  /* A bare <textarea> is inline-block, so it sits on the text baseline and
+     leaves a few px of descender gap below it that the block-level .dropZone
+     doesn't have — the panes' outer rects match, but the JSON/Sheets tabs end
+     up a few px taller overall. Block layout removes the gap. */
+  display: block;
   resize: vertical;
+  /* The browser-native scrollbar (wide, with arrow buttons) looks foreign in
+     a game buffer. These values mirror the game's own narrow gray scrollbar
+     rules verbatim (e.g. its command-suggestions container): thin standard
+     scrollbar for engines that support it, 6px #333 thumb for older WebKit. */
+  scrollbar-width: thin;
+  scrollbar-color: rgb(51, 51, 51) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgb(51, 51, 51);
+    border-radius: 5px;
+  }
 }
 
 .dropZone {
@@ -65,9 +86,22 @@
   border-color: rgb(247, 166, 0);
 }
 
+/* Empty-state hint, playing the same role as the text tabs' placeholder text —
+   so it copies the textarea's type instead of the panel's Droid Sans:
+   C.TextareaInput.textarea leaves the browser-default textarea font in place,
+   which computes to 13.3333px monospace. Filling the zone with a flex box
+   centers the hint vertically; the placeholder can't be centered the same way,
+   but a top-anchored line reads fine in a textarea while it looked lost in the
+   taller empty drop zone. */
 .dropZoneHint {
-  padding: 12px 4px;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
   text-align: center;
+  font: 13.3333px monospace;
   color: rgb(136, 136, 136);
 }
 

--- a/src/features/basic/contd-paste-import/contd-paste-import.tsx
+++ b/src/features/basic/contd-paste-import/contd-paste-import.tsx
@@ -552,7 +552,7 @@ function insertPasteBox(container: Element, anchor: Element) {
             onDragleave={onZoneDragLeave}
             onDrop={onZoneDrop}>
             {dragMaterials.value.length === 0 && !dragHover.value && !amountPrompt.value && (
-              <div class={[$style.dropZoneHint, C.type.typeSmall]}>
+              <div class={$style.dropZoneHint}>
                 Drag a material stack here from another inventory
               </div>
             )}


### PR DESCRIPTION
Follow-up polish for the CONTD paste-import box (#106):

- **Footprint**: the paste `<textarea>` was inline-block, leaving a baseline descender gap below it that made the JSON/Sheets/PrunPlanner panes a few px taller than the Drag pane (outer rects were identical). Now `display: block`; verified the tab-row→button-row span is now equal (86px) on both tabs.
- **Scrollbar**: overflowing textareas showed the wide native scrollbar with arrow buttons. Now mirrors the game's own narrow gray scrollbar rules verbatim (`scrollbar-width: thin`, `scrollbar-color: #333 transparent`, 6px WebKit thumb fallback).
- **Hint**: the Drag pane's "Drag a material stack here…" hint was top-anchored Droid Sans 10px. Now flex-centered in the zone and set in the same browser-default 13.33px monospace the other tabs' placeholders render in.

All three verified in the live game via the browser harness. Also distills the game scrollbar recipe + textarea quirks into `docs/feature-patterns.md` and a stale-build gotcha into the run skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdZWjrB59kKQQ9dqQMp1ae