### PR TITLE
feat(SFC): show total flight cost (fuel + fees) in the mission plan

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -359,6 +359,8 @@ const text = computed(() => someCondition ? 'value' : undefined);
 existingElement.appendChild(createReactiveSpan(owner, text));
 ```
 
+When deriving values from `textContent` on a container that also contains injected extension nodes, exclude the extension nodes from the parsed text. Otherwise reactive updates can feed the injected value back into the source value and create self-amplifying loops.
+
 ---
 
 ## Wrapping DOM Values as Refs

--- a/docs/game/screens-fleet.md
+++ b/docs/game/screens-fleet.md
@@ -15,7 +15,7 @@ Optional Address parameter filters the fleet by location.
 
 ## SFC — Ship Flight Control
 
-Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). Fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`.
+Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). On flights that incur fees the segment table gains a `Fee` column (absent otherwise — column indices shift); fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`. The summary row (empty first cell) sits in its own `tbody` inside the table.
 
 ## SHP — Ship Information
 

--- a/docs/game/screens-fleet.md
+++ b/docs/game/screens-fleet.md
@@ -15,7 +15,7 @@ Optional Address parameter filters the fleet by location.
 
 ## SFC — Ship Flight Control
 
-Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). On flights that incur fees the segment table gains a `Fee` column (absent otherwise — column indices shift); fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`. The summary row (empty first cell) sits in its own `tbody` inside the table.
+Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). On flights that incur fees the segment table gains a `Fee` column (absent otherwise — column indices shift); fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`. The summary row (empty first cell) sits in its own `tbody` inside the table — that `tbody` is what `C.MissionPlan.stats` matches (there is no separate stats bar), so extension content injected into a summary-row cell is a descendant of `stats`.
 
 ## SHP — Ship Information
 

--- a/docs/game/screens-fleet.md
+++ b/docs/game/screens-fleet.md
@@ -15,7 +15,7 @@ Optional Address parameter filters the fleet by location.
 
 ## SFC — Ship Flight Control
 
-Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). On flights that incur fees the segment table gains a `Fee` column (absent otherwise — column indices shift); fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`. The summary row (empty first cell) sits in its own `tbody` inside the table — that `tbody` is what `C.MissionPlan.stats` matches (there is no separate stats bar), so extension content injected into a summary-row cell is a descendant of `stats`.
+Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). On flights that incur fees the segment table gains a `Fees` column and the `Damage` header gains an ⓘ info icon (both absent otherwise — column indices shift and header text changes); fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`, and the summary row totals them per currency. The summary row (empty first cell) sits in its own `tbody` inside the table — that `tbody` is what `C.MissionPlan.stats` matches (there is no separate stats bar), so extension content injected into a summary-row cell is a descendant of `stats`.
 
 ## SHP — Ship Information
 

--- a/docs/game/screens-fleet.md
+++ b/docs/game/screens-fleet.md
@@ -9,7 +9,7 @@ Per-row command buttons:
 - `cargo` → `SHPI <transponder>`
 - `fuel` → `SHPF <transponder>`
 - `unload` — server action (transfers cargo to local store)
-- `fly` — opens flight configuration; the departure submit is a server action
+- `fly` — opens flight configuration; the departure submit is a server action. Selecting a destination renders the full mission-plan table (including the fee-bearing `Fees` column) as a client-side preview — safe for testing without launching a flight.
 
 Optional Address parameter filters the fleet by location.
 

--- a/docs/game/screens-fleet.md
+++ b/docs/game/screens-fleet.md
@@ -15,7 +15,7 @@ Optional Address parameter filters the fleet by location.
 
 ## SFC — Ship Flight Control
 
-Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens).
+Shows Ship (name + transponder links), Origin, Destination and the flight segment table: #, Type, Destination, Duration, Distance, Damage, Consumption. `abort` button cancels an active flight (server). Location names are links (station/planet screens). Fee cells can contain multiple currency amounts concatenated without spacing, e.g. `12,000 AIC4,000 CIS`.
 
 ## SHP — Ship Information
 

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -1,107 +1,59 @@
-import { flightPlansStore } from '@src/infrastructure/prun-api/data/flight-plans';
-import { flightsStore } from '@src/infrastructure/prun-api/data/flights';
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { flightsStore } from '@src/infrastructure/prun-api/data/flights';
+import { flightPlansStore } from '@src/infrastructure/prun-api/data/flight-plans';
 import { getPrice } from '@src/infrastructure/fio/cx';
-import { fixed0, formatCurrency } from '@src/utils/format';
-import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
-
-const costLineSelector = '[data-rp-sfc-flight-cost]';
+import { formatCurrency } from '@src/utils/format';
+import { createReactiveDiv } from '@src/utils/reactive-element';
+import { keepLast } from '@src/utils/keep-last';
+import { refPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { refTextContent } from '@src/utils/reactive-dom';
 
 function onTileReady(tile: PrunTile) {
-  void onMissionPlanReady(tile);
+  const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
+  subscribe($$(tile.anchor, C.MissionPlan.table), x => onTableReady(x, ship));
 }
 
-async function onMissionPlanReady(tile: PrunTile) {
-  const [table, stats] = await Promise.all([
-    $(tile.anchor, C.MissionPlan.table),
-    $(tile.anchor, C.MissionPlan.stats),
-  ]);
-  const line = getOrCreateCostLine(table);
-
-  let scheduled = false;
-  const update = () => {
-    scheduled = false;
-    if (!tile.anchor.isConnected) {
-      observer.disconnect();
-      return;
-    }
-
-    updateCostLine(tile, table, stats, line);
-  };
-  const scheduleUpdate = () => {
-    if (scheduled) {
-      return;
-    }
-    scheduled = true;
-    requestAnimationFrame(update);
-  };
-
-  const observer = new MutationObserver(scheduleUpdate);
-  observer.observe(table, { childList: true, subtree: true, characterData: true });
-  observer.observe(stats, { childList: true, subtree: true, characterData: true });
-
-  scheduleUpdate();
-  setTimeout(scheduleUpdate, 2000);
-  setTimeout(scheduleUpdate, 10000);
+function onTableReady(table: HTMLElement, ship: Ref<PrunApi.Ship | undefined>) {
+  const planId = refPrunId(table);
+  subscribe($$(table, C.MissionPlan.stats), stats => {
+    subscribe($$(stats, 'tr'), x => onSummaryRowReady(table, x, ship, planId));
+  });
 }
 
-function getOrCreateCostLine(table: HTMLElement) {
-  const existing = table.querySelector(costLineSelector);
-  if (existing instanceof HTMLElement) {
-    return existing;
-  }
-
-  const line = document.createElement('div');
-  line.dataset.rpSfcFlightCost = 'true';
-  return line;
-}
-
-function updateCostLine(tile: PrunTile, table: HTMLElement, stats: Element, line: HTMLElement) {
-  const damageCell = getSummaryDamageCell(table);
-  if (!damageCell) {
+function onSummaryRowReady(
+  table: HTMLElement,
+  row: HTMLElement,
+  ship: Ref<PrunApi.Ship | undefined>,
+  planId: Ref<string | null>,
+) {
+  const thead = _$(table, 'thead');
+  const headerRow = thead ? _$(thead, 'tr') : undefined;
+  if (!headerRow) {
     return;
   }
 
-  const ship = shipsStore.getByRegistration(tile.parameter);
-  const planId = getPrunId(table);
-  const cost = getFlightCost(ship, planId, getStatsText(stats));
-  const text = `Cost: ${formatCurrency(cost, fixed0)}`;
-  if (line.textContent !== text) {
-    line.textContent = text;
+  const headerCells = Array.from(headerRow.children);
+  const damageIndex = headerCells.findIndex(x => x.textContent?.trim() === 'Damage');
+  const feeIndex = headerCells.findIndex(x => x.textContent?.trim() === 'Fee');
+  if (damageIndex === -1) {
+    return;
   }
-  if (line.parentElement !== damageCell) {
-    damageCell.appendChild(line);
-  }
-}
 
-function getStatsText(stats: Element) {
-  const clone = stats.cloneNode(true) as Element;
-  for (const line of Array.from(clone.querySelectorAll(costLineSelector))) {
-    line.remove();
-  }
-  return clone.textContent;
-}
+  const feeText = feeIndex >= 0 ? refTextContent(row.children[feeIndex]) : ref(null);
 
-function getSummaryDamageCell(table: HTMLElement) {
-  const rows = Array.from(table.getElementsByTagName('tr'));
-  const summary = rows.find(
-    x => x.children[0]?.textContent?.trim() === '' && x.children[5] !== undefined,
+  const cost = computed(() => {
+    const fuelCost = getFuelCost(ship.value, planId.value);
+    if (fuelCost === undefined) {
+      return undefined;
+    }
+    return fuelCost + parseFee(feeText.value);
+  });
+
+  const text = computed(() =>
+    cost.value !== undefined ? `Cost: ${formatCurrency(cost.value)}` : undefined,
   );
-  const row = summary ?? rows.findLast(x => x.children[5] !== undefined);
-  return row?.children[5];
-}
-
-function getFlightCost(
-  ship: PrunApi.Ship | undefined,
-  planId: string | null,
-  statsText: string | null,
-) {
-  const fuelCost = getFuelCost(ship, planId);
-  if (fuelCost === undefined) {
-    return undefined;
-  }
-
-  return fuelCost + (parseFee(statsText) ?? 0);
+  const div = createReactiveDiv(row, text);
+  keepLast(row, () => row.children[damageIndex], div);
 }
 
 function getFuelCost(ship: PrunApi.Ship | undefined, planId: string | null) {
@@ -153,35 +105,18 @@ function getSegments(ship: PrunApi.Ship | undefined, planId: string | null) {
 
 function parseFee(text: string | null) {
   if (!text) {
-    return undefined;
+    return 0;
   }
 
   let fee = 0;
-  let hasFee = false;
-  for (const match of text.matchAll(/([\d.,]+)\s*(?:AIC|CIS|ICA|NCC)/gi)) {
-    const value = parseFeeNumber(match[1]);
-    if (value === undefined) {
+  for (const match of text.matchAll(/([\d.,]+)\s*[A-Z]{3}\b/g)) {
+    const value = Number(match[1].replaceAll(',', ''));
+    if (!isFinite(value)) {
       continue;
     }
     fee += value;
-    hasFee = true;
   }
-
-  if (hasFee) {
-    return fee;
-  }
-
-  if (/fees?\s*--/i.test(text)) {
-    return undefined;
-  }
-
-  const match = /fees?\s*[^\dA-Za-z]*([\d.,]+)/i.exec(text);
-  return match?.[1] ? parseFeeNumber(match[1]) : undefined;
-}
-
-function parseFeeNumber(text: string) {
-  const value = Number(text.replaceAll(',', ''));
-  return isFinite(value) ? value : undefined;
+  return fee;
 }
 
 function init() {

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -9,21 +9,21 @@ import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 
 function onTileReady(tile: PrunTile) {
   const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
-  subscribe($$(tile.anchor, C.MissionPlan.container), async container =>
-    onMissionPlanReady(container, ship),
-  );
+  void onMissionPlanReady(tile.anchor, ship);
 }
 
-async function onMissionPlanReady(container: HTMLElement, ship: Ref<PrunApi.Ship | undefined>) {
-  const table = await $(container, C.MissionPlan.table);
-  const stats = await $(container, C.MissionPlan.stats);
+async function onMissionPlanReady(anchor: HTMLElement, ship: Ref<PrunApi.Ship | undefined>) {
+  const [table, stats] = await Promise.all([
+    $(anchor, C.MissionPlan.table),
+    $(anchor, C.MissionPlan.stats),
+  ]);
   const statsText = refTextContent(stats);
   const planId = refPrunId(table);
   const cost = computed(() => getFlightCost(ship.value, planId.value, statsText.value));
   const line = document.createElement('div');
   line.textContent = 'Cost: --';
 
-  watchEffectWhileNodeAlive(container, () => {
+  watchEffectWhileNodeAlive(anchor, () => {
     line.textContent = `Cost: ${formatCurrency(cost.value)}`;
     if (stats.lastChild !== line) {
       stats.appendChild(line);
@@ -55,12 +55,6 @@ function getFuelCost(ship: PrunApi.Ship | undefined, planId: string | null) {
     return undefined;
   }
 
-  const sfPrice = getPrice('SF');
-  const ffPrice = getPrice('FF');
-  if (sfPrice === undefined || ffPrice === undefined) {
-    return undefined;
-  }
-
   let sf = 0;
   let ff = 0;
   for (const segment of segments) {
@@ -68,7 +62,22 @@ function getFuelCost(ship: PrunApi.Ship | undefined, planId: string | null) {
     ff += segment.ftlFuelConsumption ?? 0;
   }
 
-  return sf * sfPrice + ff * ffPrice;
+  const sfCost = getFuelTypeCost('SF', sf);
+  const ffCost = getFuelTypeCost('FF', ff);
+  if (sfCost === undefined || ffCost === undefined) {
+    return undefined;
+  }
+
+  return sfCost + ffCost;
+}
+
+function getFuelTypeCost(ticker: string, amount: number) {
+  if (amount === 0) {
+    return 0;
+  }
+
+  const price = getPrice(ticker);
+  return price === undefined ? undefined : amount * price;
 }
 
 function getSegments(ship: PrunApi.Ship | undefined, planId: string | null) {
@@ -92,7 +101,7 @@ function parseFee(text: string | null) {
     return undefined;
   }
 
-  const match = /fees?\D*([\d.,]+)/i.exec(text);
+  const match = /fees?\s*(?:--|[^\dA-Za-z]*([\d.,]+))/i.exec(text);
   if (!match) {
     return undefined;
   }

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -103,12 +103,32 @@ function parseFee(text: string | null) {
     return undefined;
   }
 
+  const feesText = text.replace(/^.*fees?/i, '');
+  let fee = 0;
+  let hasFee = false;
+  for (const match of feesText.matchAll(/([\d.,]+)\s*(?:AIC|CIS|ICA|NCC)/gi)) {
+    const value = parseFeeNumber(match[1]);
+    if (value === undefined) {
+      continue;
+    }
+    fee += value;
+    hasFee = true;
+  }
+
+  if (hasFee) {
+    return fee;
+  }
+
   const match = /fees?\s*(?:--|[^\dA-Za-z]*([\d.,]+))/i.exec(text);
-  if (!match) {
+  if (!match?.[1]) {
     return undefined;
   }
 
-  const value = Number(match[1].replaceAll(',', ''));
+  return parseFeeNumber(match[1]);
+}
+
+function parseFeeNumber(text: string) {
+  const value = Number(text.replaceAll(',', ''));
   return isFinite(value) ? value : undefined;
 }
 

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -2,35 +2,85 @@ import { flightPlansStore } from '@src/infrastructure/prun-api/data/flight-plans
 import { flightsStore } from '@src/infrastructure/prun-api/data/flights';
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { getPrice } from '@src/infrastructure/fio/cx';
-import { formatCurrency } from '@src/utils/format';
-import { refPrunId } from '@src/infrastructure/prun-ui/attributes';
-import { refTextContent } from '@src/utils/reactive-dom';
-import { createReactiveDiv } from '@src/utils/reactive-element';
-import { keepLast } from '@src/utils/keep-last';
+import { fixed0, formatCurrency } from '@src/utils/format';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+
+const costLineSelector = '[data-rp-sfc-flight-cost]';
 
 function onTileReady(tile: PrunTile) {
-  const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
-  void onMissionPlanReady(tile.anchor, ship);
+  void onMissionPlanReady(tile);
 }
 
-async function onMissionPlanReady(anchor: HTMLElement, ship: Ref<PrunApi.Ship | undefined>) {
+async function onMissionPlanReady(tile: PrunTile) {
   const [table, stats] = await Promise.all([
-    $(anchor, C.MissionPlan.table),
-    $(anchor, C.MissionPlan.stats),
+    $(tile.anchor, C.MissionPlan.table),
+    $(tile.anchor, C.MissionPlan.stats),
   ]);
-  const statsText = refTextContent(stats);
-  const planId = refPrunId(table);
-  const cost = computed(() => getFlightCost(ship.value, planId.value, statsText.value));
-  subscribe($$(table, 'tr'), row => onRowReady(row, cost));
+  const line = getOrCreateCostLine(table);
+
+  let scheduled = false;
+  const update = () => {
+    scheduled = false;
+    if (!tile.anchor.isConnected) {
+      observer.disconnect();
+      return;
+    }
+
+    updateCostLine(tile, table, stats, line);
+  };
+  const scheduleUpdate = () => {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    requestAnimationFrame(update);
+  };
+
+  const observer = new MutationObserver(scheduleUpdate);
+  observer.observe(table, { childList: true, subtree: true, characterData: true });
+  observer.observe(stats, { childList: true, subtree: true, characterData: true });
+
+  scheduleUpdate();
+  setTimeout(scheduleUpdate, 2000);
+  setTimeout(scheduleUpdate, 10000);
 }
 
-function onRowReady(row: HTMLElement, cost: Ref<number | undefined>) {
-  const firstColumn = refTextContent(row.children[0]);
-  const costText = computed(() =>
-    firstColumn.value?.trim() === '' ? `Cost: ${formatCurrency(cost.value)}` : undefined,
+function getOrCreateCostLine(table: HTMLElement) {
+  const existing = table.querySelector(costLineSelector);
+  if (existing instanceof HTMLElement) {
+    return existing;
+  }
+
+  const line = document.createElement('div');
+  line.dataset.rpSfcFlightCost = 'true';
+  return line;
+}
+
+function updateCostLine(tile: PrunTile, table: HTMLElement, stats: Element, line: HTMLElement) {
+  const damageCell = getSummaryDamageCell(table);
+  if (!damageCell) {
+    return;
+  }
+
+  const ship = shipsStore.getByRegistration(tile.parameter);
+  const planId = getPrunId(table);
+  const cost = getFlightCost(ship, planId, stats.textContent);
+  const text = `Cost: ${formatCurrency(cost, fixed0)}`;
+  if (line.textContent !== text) {
+    line.textContent = text;
+  }
+  if (line.parentElement !== damageCell) {
+    damageCell.appendChild(line);
+  }
+}
+
+function getSummaryDamageCell(table: HTMLElement) {
+  const rows = Array.from(table.getElementsByTagName('tr'));
+  const summary = rows.find(
+    x => x.children[0]?.textContent?.trim() === '' && x.children[5] !== undefined,
   );
-  const div = createReactiveDiv(row, costText);
-  keepLast(row, () => row.children[5], div);
+  const row = summary ?? rows.findLast(x => x.children[5] !== undefined);
+  return row?.children[5];
 }
 
 function getFlightCost(
@@ -43,12 +93,7 @@ function getFlightCost(
     return undefined;
   }
 
-  const fee = parseFee(statsText);
-  if (fee === undefined) {
-    return fuelCost;
-  }
-
-  return fee + fuelCost;
+  return fuelCost + (parseFee(statsText) ?? 0);
 }
 
 function getFuelCost(ship: PrunApi.Ship | undefined, planId: string | null) {
@@ -103,10 +148,9 @@ function parseFee(text: string | null) {
     return undefined;
   }
 
-  const feesText = text.replace(/^.*fees?/i, '');
   let fee = 0;
   let hasFee = false;
-  for (const match of feesText.matchAll(/([\d.,]+)\s*(?:AIC|CIS|ICA|NCC)/gi)) {
+  for (const match of text.matchAll(/([\d.,]+)\s*(?:AIC|CIS|ICA|NCC)/gi)) {
     const value = parseFeeNumber(match[1]);
     if (value === undefined) {
       continue;
@@ -119,12 +163,12 @@ function parseFee(text: string | null) {
     return fee;
   }
 
-  const match = /fees?\s*(?:--|[^\dA-Za-z]*([\d.,]+))/i.exec(text);
-  if (!match?.[1]) {
+  if (/fees?\s*--/i.test(text)) {
     return undefined;
   }
 
-  return parseFeeNumber(match[1]);
+  const match = /fees?\s*[^\dA-Za-z]*([\d.,]+)/i.exec(text);
+  return match?.[1] ? parseFeeNumber(match[1]) : undefined;
 }
 
 function parseFeeNumber(text: string) {

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -64,7 +64,7 @@ function updateCostLine(tile: PrunTile, table: HTMLElement, stats: Element, line
 
   const ship = shipsStore.getByRegistration(tile.parameter);
   const planId = getPrunId(table);
-  const cost = getFlightCost(ship, planId, stats.textContent);
+  const cost = getFlightCost(ship, planId, getStatsText(stats));
   const text = `Cost: ${formatCurrency(cost, fixed0)}`;
   if (line.textContent !== text) {
     line.textContent = text;
@@ -72,6 +72,14 @@ function updateCostLine(tile: PrunTile, table: HTMLElement, stats: Element, line
   if (line.parentElement !== damageCell) {
     damageCell.appendChild(line);
   }
+}
+
+function getStatsText(stats: Element) {
+  const clone = stats.cloneNode(true) as Element;
+  for (const line of Array.from(clone.querySelectorAll(costLineSelector))) {
+    line.remove();
+  }
+  return clone.textContent;
 }
 
 function getSummaryDamageCell(table: HTMLElement) {

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -1,0 +1,108 @@
+import { flightPlansStore } from '@src/infrastructure/prun-api/data/flight-plans';
+import { flightsStore } from '@src/infrastructure/prun-api/data/flights';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { getPrice } from '@src/infrastructure/fio/cx';
+import { formatCurrency } from '@src/utils/format';
+import { refPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { refTextContent } from '@src/utils/reactive-dom';
+import { watchEffectWhileNodeAlive } from '@src/utils/watch';
+
+function onTileReady(tile: PrunTile) {
+  const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
+  subscribe($$(tile.anchor, C.MissionPlan.container), async container =>
+    onMissionPlanReady(container, ship),
+  );
+}
+
+async function onMissionPlanReady(container: HTMLElement, ship: Ref<PrunApi.Ship | undefined>) {
+  const table = await $(container, C.MissionPlan.table);
+  const stats = await $(container, C.MissionPlan.stats);
+  const statsText = refTextContent(stats);
+  const planId = refPrunId(table);
+  const cost = computed(() => getFlightCost(ship.value, planId.value, statsText.value));
+  const line = document.createElement('div');
+  line.textContent = 'Cost: --';
+
+  watchEffectWhileNodeAlive(container, () => {
+    line.textContent = `Cost: ${formatCurrency(cost.value)}`;
+    if (stats.lastChild !== line) {
+      stats.appendChild(line);
+    }
+  });
+}
+
+function getFlightCost(
+  ship: PrunApi.Ship | undefined,
+  planId: string | null,
+  statsText: string | null,
+) {
+  const fuelCost = getFuelCost(ship, planId);
+  if (fuelCost === undefined) {
+    return undefined;
+  }
+
+  const fee = parseFee(statsText);
+  if (fee === undefined) {
+    return fuelCost;
+  }
+
+  return fee + fuelCost;
+}
+
+function getFuelCost(ship: PrunApi.Ship | undefined, planId: string | null) {
+  const segments = getSegments(ship, planId);
+  if (!segments) {
+    return undefined;
+  }
+
+  const sfPrice = getPrice('SF');
+  const ffPrice = getPrice('FF');
+  if (sfPrice === undefined || ffPrice === undefined) {
+    return undefined;
+  }
+
+  let sf = 0;
+  let ff = 0;
+  for (const segment of segments) {
+    sf += segment.stlFuelConsumption ?? 0;
+    ff += segment.ftlFuelConsumption ?? 0;
+  }
+
+  return sf * sfPrice + ff * ffPrice;
+}
+
+function getSegments(ship: PrunApi.Ship | undefined, planId: string | null) {
+  if (!ship) {
+    return undefined;
+  }
+
+  if (ship.flightId) {
+    return flightsStore.getById(ship.flightId)?.segments;
+  }
+
+  if (!planId) {
+    return undefined;
+  }
+
+  return flightPlansStore.getById(planId)?.segments;
+}
+
+function parseFee(text: string | null) {
+  if (!text) {
+    return undefined;
+  }
+
+  const match = /fees?\D*([\d.,]+)/i.exec(text);
+  if (!match) {
+    return undefined;
+  }
+
+  const value = Number(match[1].replaceAll(',', ''));
+  return isFinite(value) ? value : undefined;
+}
+
+function init() {
+  tiles.observe('SFC', onTileReady);
+}
+
+features.add(import.meta.url, init, 'SFC: Shows the total flight cost including fees and fuel.');

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -5,7 +5,8 @@ import { getPrice } from '@src/infrastructure/fio/cx';
 import { formatCurrency } from '@src/utils/format';
 import { refPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { refTextContent } from '@src/utils/reactive-dom';
-import { watchEffectWhileNodeAlive } from '@src/utils/watch';
+import { createReactiveDiv } from '@src/utils/reactive-element';
+import { keepLast } from '@src/utils/keep-last';
 
 function onTileReady(tile: PrunTile) {
   const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
@@ -20,15 +21,16 @@ async function onMissionPlanReady(anchor: HTMLElement, ship: Ref<PrunApi.Ship | 
   const statsText = refTextContent(stats);
   const planId = refPrunId(table);
   const cost = computed(() => getFlightCost(ship.value, planId.value, statsText.value));
-  const line = document.createElement('div');
-  line.textContent = 'Cost: --';
+  subscribe($$(table, 'tr'), row => onRowReady(row, cost));
+}
 
-  watchEffectWhileNodeAlive(anchor, () => {
-    line.textContent = `Cost: ${formatCurrency(cost.value)}`;
-    if (stats.lastChild !== line) {
-      stats.appendChild(line);
-    }
-  });
+function onRowReady(row: HTMLElement, cost: Ref<number | undefined>) {
+  const firstColumn = refTextContent(row.children[0]);
+  const costText = computed(() =>
+    firstColumn.value?.trim() === '' ? `Cost: ${formatCurrency(cost.value)}` : undefined,
+  );
+  const div = createReactiveDiv(row, costText);
+  keepLast(row, () => row.children[5], div);
 }
 
 function getFlightCost(

--- a/src/features/basic/sfc-flight-cost.ts
+++ b/src/features/basic/sfc-flight-cost.ts
@@ -32,9 +32,11 @@ function onSummaryRowReady(
     return;
   }
 
+  // Header labels can carry extra content (Damage has an info icon on fee-bearing flights),
+  // so match by prefix instead of full text.
   const headerCells = Array.from(headerRow.children);
-  const damageIndex = headerCells.findIndex(x => x.textContent?.trim() === 'Damage');
-  const feeIndex = headerCells.findIndex(x => x.textContent?.trim() === 'Fee');
+  const damageIndex = headerCells.findIndex(x => x.textContent?.trim().startsWith('Damage'));
+  const feeIndex = headerCells.findIndex(x => x.textContent?.trim().startsWith('Fee'));
   if (damageIndex === -1) {
     return;
   }
@@ -108,8 +110,10 @@ function parseFee(text: string | null) {
     return 0;
   }
 
+  // Amounts can be concatenated without spacing ("12,000 AIC4,000 CIS"), so a \b after
+  // the currency code would fail — use a lookahead for "not another letter" instead.
   let fee = 0;
-  for (const match of text.matchAll(/([\d.,]+)\s*[A-Z]{3}\b/g)) {
+  for (const match of text.matchAll(/([\d.,]+)\s*[A-Z]{3}(?![A-Z])/g)) {
     const value = Number(match[1].replaceAll(',', ''));
     if (!isFinite(value)) {
       continue;


### PR DESCRIPTION
Adds a total flight cost line (fuel + fees) to the SFC mission plan's summary row, inside the Damage cell.

## What it does

- Sums per-segment SF/FTL fuel consumption and prices it via `getPrice('SF')`/`getPrice('FF')`.
- Parses the summary row's `Fees` cell (only present on fee-bearing flights) and adds it to the total; multiple concatenated currency amounts (`12,000 AIC4,000 CIS`) are summed. No FX conversion — amounts are added as raw numbers by design.
- Renders `Cost: <total>` via `createReactiveDiv` + `keepLast`; hides when data isn't available yet.

## Implementation notes

- Written in the `sfc-flight-eta` reactive idiom (`computed` + `refPrunId` + `refTextContent` + `subscribe($$)`), so the line updates when CX prices load or the plan changes, and survives table re-renders.
- Column indices are located by header-text prefix (`Damage`, `Fee`): the `Fees` column only exists on fee-bearing flights, where the `Damage` header also gains an ⓘ icon — exact-text matching breaks there.
- Fees are read only from the Fees cell, never from the Damage cell where the line is injected, so the parsed value can't feed back into itself.
- The original codex draft used MutationObserver + rAF + setTimeout retries; that was replaced wholesale (see commit history).

## Verified live

- Fee-bearing plan (Shadow Garden - Malahat): `Cost: 22,046 AIC` = 16,000 fees + 6,046 fuel.
- Fee-free active flight (Antares Station): fuel-only `Cost: 4,553 AIC`.
- Single injected div, no console errors, line reappears after tile close/reopen.

Docs updated: SFC `Fees` column behavior + summary-row `tbody` structure (`screens-fleet.md`), fly-planner preview testing note (FLT section), injected-node feedback-loop warning (`feature-patterns.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Viip1BeSxdiBGqLsnQAQFA
