### PR TITLE
fix(XIT FLT): review fixes for problem-fuel 'any' threshold and disabled-sort fallback

### DIFF
--- a/src/features/XIT/FLT/FLT.vue
+++ b/src/features/XIT/FLT/FLT.vue
@@ -304,6 +304,8 @@ const rows = computed(() => {
       activePrimaryKey = secondaryKey;
       activePrimaryDirection = secondaryDirection;
       activeSecondaryKey = undefined;
+    } else {
+      activePrimaryKey = 'none';
     }
   } else {
     if (secondaryDirection !== 'none' && secondaryKey !== primaryKey) {
@@ -348,25 +350,20 @@ const activeFilterCount = computed(() => {
   ].filter(Boolean).length;
 });
 
-const problemFuelThresholdValue = computed(() => {
-  return problemFuelThreshold.value === 'any' ? 1 : Number(problemFuelThreshold.value) / 100;
-});
+const problemFuelThresholdValue = computed(() => fuelAlertThresholdMap[problemFuelThreshold.value]);
 
 function hasFuelProblem(row: FlightRow): boolean {
-  const threshold = problemFuelThresholdValue.value;
-  const ftlRatio = row.ftlFuelRatio ?? 1;
-  const stlRatio = row.stlFuelRatio ?? 1;
-  return ftlRatio < threshold || stlRatio < threshold;
+  return hasStlFuelProblem(row) || hasFtlFuelProblem(row);
 }
 
 function hasStlFuelProblem(row: FlightRow): boolean {
   const threshold = problemFuelThresholdValue.value;
-  return (row.stlFuelRatio ?? 1) < threshold;
+  return threshold < 1 && (row.stlFuelRatio ?? 1) < threshold;
 }
 
 function hasFtlFuelProblem(row: FlightRow): boolean {
   const threshold = problemFuelThresholdValue.value;
-  return (row.ftlFuelRatio ?? 1) < threshold;
+  return threshold < 1 && (row.ftlFuelRatio ?? 1) < threshold;
 }
 
 const hasAnyProblems = computed(() => {


### PR DESCRIPTION
Fast-follow to #117 with the two bugs found in code review.

## What changed

- **'any' problematic-fuel threshold no longer flags every non-full ship.** Deselecting the "Problematic fuel level" radio set the threshold to 1, marking any ship below 100% fuel as a problem. Now reuses `fuelAlertThresholdMap` with the same `< 1` guard the fuel filter already uses, so 'any' means the check is off.
- **Disabled sorts fall back to name sort.** When both primary and secondary sort directions were 'none', the 'none' direction fell into the `? 1 : -1` descending branch, silently sorting by the disabled key with no header indicator. Now the sort key is cleared so the comparator falls through to the name sort.

## Validation

- `pnpm run compile`
- `pnpm run build:fast` + live reload in the local game harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TppBhHDYK6jz7o4F7H12Es