### PR TITLE
Expand context to include material group prices

### DIFF
--- a/src/features/XIT/ACT/actions/cx-buy/cx-buy.ts
+++ b/src/features/XIT/ACT/actions/cx-buy/cx-buy.ts
@@ -30,7 +30,8 @@ act.addAction<Config>({
     data.exchange !== configurableValue ||
     config.exchange !== undefined,
   generateSteps: async ctx => {
-    const { data, config, state, log, fail, getMaterialGroup, emitStep } = ctx;
+    const { data, config, state, log, fail, getMaterialGroup, getMaterialGroupPrices, emitStep } =
+      ctx;
 
     if (data.skippable && config.skip) {
       return;
@@ -41,6 +42,8 @@ act.addAction<Config>({
 
     const materials = await getMaterialGroup(data.group);
     assert(materials, 'Invalid material group');
+
+    const priceLimits = { ...data.priceLimits, ...getMaterialGroupPrices(data.group) };
 
     const exchange = data.exchange === configurableValue ? config.exchange : data.exchange;
     assert(exchange, 'Missing exchange');
@@ -73,7 +76,7 @@ act.addAction<Config>({
         continue;
       }
       const amount = materials[ticker];
-      const priceLimit = data.priceLimits?.[ticker] ?? Infinity;
+      const priceLimit = priceLimits[ticker] ?? Infinity;
       if (isNaN(priceLimit)) {
         log.error('Non-numerical price limit on ' + ticker);
         continue;


### PR DESCRIPTION
## Summary

Fixes a bug in handling of price field in CSV. Respects configured price limit in task payload and allows a hierarchical overload by the csv configuration.

### DEMO


https://github.com/user-attachments/assets/c9bac32d-2378-49fc-8a0f-e60071aa5fe9

## Standards Checklist

- [X] No upward imports across layers (features -> core -> infrastructure -> utils)
- [X] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [X] CSS rules scoped to commands where applicable
- [X] Numbers use formatters from `@src/utils/format`
- [X] No `title=` attributes (use `data-tooltip`)
- [X] No `onApiMessage` in features (use `computed` from stores)
- [X] Feature has single responsibility, no cross-feature deps
- [X] CSS class names describe WHERE, not WHAT
- [X] Uses `C.Component.className` not hardcoded hashed classes
- [X] CHANGELOG.md not modified
