### PR TITLE
feat: add passive data catalog and explorer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,4 +12,5 @@ The project is a browser extension for the game. Throughout the chat and the doc
 - **Game commands:** `docs/game/commands.csv`. Columns: Command, Description, Mandatory parameters, Optional parameters.
 - **Game screens:** `docs/game/sidebar-screens.md`. Left-sidebar shortcuts, screen connection map, server-action buttons to avoid in tests; per-area details in `docs/game/screens-*.md` (bases, production, inventory, fleet, trade, contracts, company, comms).
 - **Browser testing / visual verification:** `.claude/skills/run/SKILL.md`. Launch harness, pw-act actions, hard-won gotchas. Use it for anything that must be verified against the live game.
+- **Data catalog and agent queries:** `docs/data-catalog.md`. Passive snapshots, provenance and completeness semantics, `XIT DATA`, tile exports, and the authenticated loopback query protocol.
 - **Planetary governance:** `docs/game/planetary-governance.md`. Population, happiness, governors, CoGC, POPI.

--- a/docs/data-catalog.md
+++ b/docs/data-catalog.md
@@ -1,0 +1,197 @@
+# Data Catalog and Explorer
+
+The data catalog provides one explicit, typed index of serializable data already held in Refined PrUn
+memory. `XIT DATA`, Alt-click tile export, and the optional local agent connection all use the same
+query engine and result envelopes.
+
+## Passive-read guarantee
+
+Listing sources, reading a snapshot, running a query, previewing results, downloading JSON, exporting
+a tile, and answering an agent query are passive operations. They must not:
+
+- open a buffer;
+- dispatch a PrUn request;
+- call a request-on-miss getter;
+- load an unloaded source;
+- mutate extension or game state; or
+- expose DOM nodes, Vue/React objects, callbacks, credentials, or arbitrary settings.
+
+Request-wrapped stores expose a separate `peek()` path for the catalog. CX and FX order stores expose
+their passive entity-store view separately from their request-on-read `all` computed. Tests cover these
+boundaries.
+
+The only catalog operation allowed to request data is an explicit human click on **LOAD FROM PRUN** in
+`XIT DATA`. The selected descriptor must declare a loader. Production and workforce loaders also
+require a valid site ID already present in the sites store.
+
+## Provenance
+
+Each source declares one provenance value:
+
+- `prun-live`: values observed from the active PrUn connection.
+- `prun-live-with-defaults`: bundled defaults patched when matching live PrUn values arrive. Exchanges
+  and stations use this value.
+- `fio-reference-with-prun-overrides`: stale FIO fallback/reference values with selected live PrUn
+  fields overlaid. Planets use this value and always display a warning.
+
+FIO provenance never implies that a value is current empire state.
+
+## Completeness
+
+- `not-loaded`: no in-memory snapshot has been observed.
+- `partial`: the store contains observations for only some entities, sites, tickers, or views.
+- `complete`: the corresponding full-store message has been observed, or the source is complete by
+  definition for its declared scope.
+
+Broker views, local ads, experts, flight plans, users, workforces, and site-scoped production are
+partial. Production becomes complete only after the global production-lines response is observed.
+Completeness returns to the store's correct reset state on reconnect.
+
+`generatedAt` in a query result is when the catalog took the snapshot and executed the query. It is not
+the age of the underlying PrUn or FIO data.
+
+## Query contract
+
+The public internal contract is defined in `src/core/data-query/types.ts`.
+
+```ts
+interface DataQuery {
+  sourceId: string;
+  search?: string;
+  filters?: Array<{
+    path: string;
+    operator:
+      | 'eq'
+      | 'neq'
+      | 'contains'
+      | 'startsWith'
+      | 'gt'
+      | 'gte'
+      | 'lt'
+      | 'lte'
+      | 'exists';
+    value?: unknown;
+  }>;
+  sort?: { path: string; direction: 'asc' | 'desc' };
+  limit?: number;
+}
+```
+
+Rules:
+
+- Dot-separated paths traverse own properties only. Empty paths and the prototype-related segments
+  `__proto__`, `prototype`, and `constructor` are rejected.
+- Filters are AND-combined.
+- Missing paths fail normal comparisons. `exists` matches present paths by default; `value: false`
+  matches missing paths.
+- Equality is strict and supports structural comparison of JSON arrays and objects. No loose equality
+  or arbitrary evaluation is used.
+- String `contains` and `startsWith` comparisons are case-insensitive. Array `contains` uses strict
+  structural element equality.
+- Ordered comparisons require two numbers or two strings.
+- Text search is a case-insensitive substring search over the serialized row.
+- Sorting keeps missing and null values last in both directions. Unlike types fall back to string
+  comparison.
+- The default limit is 250. Limits above 5,000 are capped at 5,000; invalid non-positive or
+  non-integer limits are rejected.
+
+Every query and JSON download returns a `DataQueryResult` envelope with source provenance and
+completeness, the normalized query, counts, truncation metadata, timestamp, and rows.
+
+## XIT DATA
+
+Open `XIT DATA` to use the human explorer. Selecting datasets, editing search/filter/sort inputs,
+previewing, and downloading are passive.
+
+Filter values are parsed as JSON when valid. For example, `true`, `42`, `null`, `["RAT"]`, and
+`{"mode":"safe"}` retain their JSON types. Other input is treated as a string.
+
+Lazy sources show **LOAD FROM PRUN** only when they declare a loader. The button is disabled if the
+request transport is unavailable or a required site ID is empty. Loader failures are shown in the
+tile.
+
+## Tile catalog and Alt-click export
+
+The catalog includes:
+
+- `stored-layout-tiles`: serializable stored tile nodes, screen identity where resolvable, tile-local
+  game state, and tile-local Refined PrUn state;
+- `active-rendered-tiles`: IDs, commands, parameters, docked/buffer state, and narrowly scoped tile
+  state for currently rendered tiles.
+
+Neither source exports DOM nodes or framework objects.
+
+Tile data providers map supported commands to one or more catalog queries. Hold `Alt` and click the
+tile command as before. The downloaded envelope now contains:
+
+- one serializable tile metadata object;
+- the provider ID, when a provider matches; and
+- one or more standard `DataQueryResult` datasets sharing the same `generatedAt` timestamp.
+
+Unloaded lazy datasets remain unloaded and are exported with `not-loaded` completeness and zero rows.
+New providers register explicitly through `registerTileDataProvider`.
+
+## Local agent query connection
+
+The agent connection is an optional WebSocket client configured in `XIT DATA`. It is disabled and
+disconnected on every page load. Endpoint and token fields are held in memory only; they are not added
+to user data, backups, catalog snapshots, logs, URLs, or exports.
+
+Security requirements enforced by the client:
+
+- Only literal `ws://` or `wss://` endpoints on `127.0.0.1` or `[::1]` are accepted. Hostnames such as
+  `localhost`, private-network addresses, URL credentials, query parameters, and fragments are
+  rejected.
+- Tokens must be 32–256 characters and contain no control characters.
+- The first client message authenticates protocol version 1. No query is accepted until the server
+  returns `{"type":"authenticated"}`.
+- Incoming messages are limited to 64 KiB. Outgoing responses are limited to 4 MiB.
+- There is no automatic reconnect.
+- The remote surface supports only `list-sources` and `query`. Loader, export, settings, DOM, request,
+  and gameplay-action methods do not exist.
+
+Chrome may show its Local Network Access permission prompt on the first loopback connection. The user
+must grant that browser permission for the connection to proceed.
+
+### Protocol
+
+Client authentication:
+
+```json
+{ "type": "authenticate", "version": 1, "token": "<shared session token>" }
+```
+
+Server acknowledgement:
+
+```json
+{ "type": "authenticated" }
+```
+
+List sources:
+
+```json
+{ "type": "list-sources", "id": "request-1" }
+```
+
+Query:
+
+```json
+{
+  "type": "query",
+  "id": "request-2",
+  "query": {
+    "sourceId": "ships",
+    "filters": [{ "path": "registration", "operator": "startsWith", "value": "ABC" }],
+    "limit": 100
+  }
+}
+```
+
+Responses use `sources`, `result`, or `error` as their `type` and echo the request `id`. Query results
+are the same `DataQueryResult` envelopes used by `XIT DATA`.
+
+## Tests
+
+Run `pnpm test`. Focused tests cover query semantics and validation, passive catalog behavior,
+request-wrapper peeking, tile provider envelopes, authentication, loopback validation, message limits,
+and rejection of unauthorized transport methods.

--- a/guides/how-to-export-tile-data.md
+++ b/guides/how-to-export-tile-data.md
@@ -3,4 +3,11 @@
 You can export the data from most tiles by holding `Alt` and clicking on the tile command. This will
 download a JSON file with the tile data. The tile command is a small gray label right after the tile name.
 
+The trigger is unchanged, but exports now use the passive data catalog. The JSON contains serializable
+tile metadata and standard query-result envelopes for every dataset supplied by the matching tile
+provider. Exporting never loads missing data: an unloaded lazy source is represented as `not-loaded`
+with zero rows.
+
+See `docs/data-catalog.md` for the envelope, provenance, completeness, and provider details.
+
 <img width="1242" height="1208" alt="image" src="https://github.com/user-attachments/assets/fe0e3dee-9a35-42f9-84de-8847d85ec23e" />

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "pnpm exec eslint --concurrency auto",
     "prepare": "husky",
     "prettier": "prettier . --write --ignore-path .prettierignore",
-    "open": "scripts\\open-local.bat"
+    "open": "scripts\\open-local.bat",
+    "test": "vitest run"
   },
   "type": "module",
   "dependencies": {
@@ -69,6 +70,7 @@
     "typescript-eslint": "^8.41.0",
     "unimport": "^5.2.0",
     "vite": "^7.1.11",
+    "vitest": "^4.1.10",
     "web-ext": "^8.4.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       vite:
         specifier: ^7.1.11
         version: 7.1.11(@types/node@22.18.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.18.0)(vite@7.1.11(@types/node@22.18.0)(yaml@2.8.3))
       web-ext:
         specifier: ^8.4.0
         version: 8.10.0
@@ -754,8 +757,17 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chrome@0.1.4':
     resolution: {integrity: sha512-vfISO7SPppN3OKVUqWujtZ4vux3nhDqKaHYEHgfQuPARHuWJ3jjyc1s13H0ckzEc86/neTkCl1TeW72UK6jYKA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -877,6 +889,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
@@ -1045,6 +1086,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1142,6 +1187,10 @@ packages:
 
   caniuse-lite@1.0.30001739:
     resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1446,6 +1495,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1674,6 +1726,10 @@ packages:
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
@@ -2298,6 +2354,9 @@ packages:
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -2403,6 +2462,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -2741,6 +2804,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2780,6 +2846,12 @@ packages:
 
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2889,8 +2961,15 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
@@ -2899,6 +2978,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -3069,6 +3152,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue-chartjs@5.3.2:
     resolution: {integrity: sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==}
     peerDependencies:
@@ -3142,6 +3266,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -3745,10 +3874,19 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chrome@0.1.4':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint@9.6.1':
     dependencies:
@@ -3902,6 +4040,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.1.11(@types/node@22.18.0)(yaml@2.8.3)
       vue: 3.5.20(typescript@5.9.2)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.1.11(@types/node@22.18.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.1.11(@types/node@22.18.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
@@ -4136,6 +4315,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4230,6 +4411,8 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001739: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4567,6 +4750,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4920,6 +5105,8 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.7: {}
 
@@ -5523,6 +5710,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-error@1.3.6: {}
 
   marky@1.3.0: {}
@@ -5629,6 +5820,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obug@2.1.4: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -6015,6 +6208,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@5.0.0:
@@ -6057,6 +6252,10 @@ snapshots:
   split@1.0.1:
     dependencies:
       through: 2.3.8
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6173,7 +6372,11 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.14:
     dependencies:
@@ -6184,6 +6387,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmp@0.2.5: {}
 
@@ -6354,6 +6559,33 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.3
 
+  vitest@4.1.10(@types/node@22.18.0)(vite@7.1.11(@types/node@22.18.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.1.11(@types/node@22.18.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.1.11(@types/node@22.18.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.0
+    transitivePeerDependencies:
+      - msw
+
   vue-chartjs@5.3.2(chart.js@4.5.0)(vue@3.5.20(typescript@5.9.2)):
     dependencies:
       chart.js: 4.5.0
@@ -6485,6 +6717,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/src/core/data-query/catalog.test.ts
+++ b/src/core/data-query/catalog.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCollectionSource, DataCatalog } from '@src/core/data-query/catalog';
+import { DataQueryError } from '@src/core/data-query/query';
+
+describe('DataCatalog passive access', () => {
+  it('lists, snapshots, queries, and exports without invoking a loader', () => {
+    const loader = vi.fn();
+    const snapshot = vi.fn(() => [{ id: 1 }, { id: 2 }]);
+    const catalog = new DataCatalog([
+      createCollectionSource({
+        id: 'inert',
+        label: 'Inert',
+        description: 'An inert fake store.',
+        provenance: 'prun-live',
+        completeness: () => 'partial',
+        snapshot,
+        load: { execute: loader },
+      }),
+    ]);
+
+    expect(catalog.list()).toEqual([
+      {
+        id: 'inert',
+        label: 'Inert',
+        description: 'An inert fake store.',
+        provenance: 'prun-live',
+        shape: 'collection',
+        completeness: 'partial',
+        load: { parameter: undefined },
+      },
+    ]);
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(loader).not.toHaveBeenCalled();
+
+    expect(catalog.snapshot('inert').rows).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(catalog.query({ sourceId: 'inert', limit: 1 }).rows).toEqual([{ id: 1 }]);
+    expect(catalog.export({ sourceId: 'inert', search: '"id":2' }).rows).toEqual([{ id: 2 }]);
+
+    expect(snapshot).toHaveBeenCalledTimes(3);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('invokes a loader only through explicit load and validates site IDs', () => {
+    const loader = vi.fn();
+    const catalog = new DataCatalog([
+      createCollectionSource({
+        id: 'production',
+        label: 'Production',
+        description: 'Site production.',
+        provenance: 'prun-live',
+        completeness: () => 'not-loaded',
+        snapshot: () => undefined,
+        load: { parameter: 'siteId', execute: loader },
+      }),
+    ]);
+
+    expect(() => catalog.load('production', '')).toThrow(DataQueryError);
+    expect(loader).not.toHaveBeenCalled();
+    catalog.load('production', ' site-1 ');
+    expect(loader).toHaveBeenCalledWith('site-1');
+  });
+
+  it('rejects duplicate and unknown source IDs', () => {
+    const descriptor = createCollectionSource({
+      id: 'same',
+      label: 'Same',
+      description: 'Duplicate.',
+      provenance: 'prun-live',
+      completeness: () => 'complete',
+      snapshot: () => [],
+    });
+    expect(() => new DataCatalog([descriptor, descriptor])).toThrow(DataQueryError);
+
+    const catalog = new DataCatalog([descriptor]);
+    expect(() => catalog.query({ sourceId: 'unknown' })).toThrow(DataQueryError);
+    expect(() => catalog.snapshot('unknown')).toThrow(DataQueryError);
+  });
+});

--- a/src/core/data-query/catalog.ts
+++ b/src/core/data-query/catalog.ts
@@ -1,0 +1,106 @@
+import { cloneDataSnapshot, executeDataQuery, DataQueryError } from '@src/core/data-query/query';
+import {
+  DataQuery,
+  DataQueryResult,
+  DataSnapshot,
+  DataSourceDescriptor,
+  DataSourceSummary,
+} from '@src/core/data-query/types';
+
+export class DataCatalog {
+  private readonly descriptors = new Map<string, DataSourceDescriptor>();
+
+  constructor(descriptors: DataSourceDescriptor[]) {
+    for (const descriptor of descriptors) {
+      if (this.descriptors.has(descriptor.id)) {
+        throw new DataQueryError(`Duplicate data source ID "${descriptor.id}".`);
+      }
+      this.descriptors.set(descriptor.id, descriptor);
+    }
+  }
+
+  list(): DataSourceSummary[] {
+    return [...this.descriptors.values()]
+      .map(x => summarizeSource(x))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
+
+  get(sourceId: string): DataSourceDescriptor | undefined {
+    return this.descriptors.get(sourceId);
+  }
+
+  snapshot(sourceId: string): DataSnapshot {
+    const descriptor = this.getRequired(sourceId);
+    return {
+      source: summarizeSource(descriptor),
+      rows: cloneDataSnapshot(descriptor.snapshot()),
+    };
+  }
+
+  query(query: DataQuery, generatedAt?: Date): DataQueryResult {
+    return executeDataQuery(this.getRequired(query.sourceId), query, generatedAt);
+  }
+
+  export(query: DataQuery, generatedAt?: Date): DataQueryResult {
+    return this.query(query, generatedAt);
+  }
+
+  load(sourceId: string, parameter?: string) {
+    const descriptor = this.getRequired(sourceId);
+    if (!descriptor.load) {
+      throw new DataQueryError(`Data source "${sourceId}" does not support loading.`);
+    }
+    if (descriptor.load.parameter === 'siteId' && !parameter?.trim()) {
+      throw new DataQueryError('A site ID is required for this data source.');
+    }
+    descriptor.load.execute(parameter?.trim());
+  }
+
+  private getRequired(sourceId: string) {
+    const descriptor = this.descriptors.get(sourceId);
+    if (!descriptor) {
+      throw new DataQueryError(`Unknown data source ID "${sourceId}".`);
+    }
+    return descriptor;
+  }
+}
+
+function summarizeSource(descriptor: DataSourceDescriptor): DataSourceSummary {
+  return {
+    id: descriptor.id,
+    label: descriptor.label,
+    description: descriptor.description,
+    provenance: descriptor.provenance,
+    shape: descriptor.shape,
+    completeness: descriptor.completeness(),
+    ...(descriptor.warning ? { warning: descriptor.warning } : {}),
+    ...(descriptor.load ? { load: { parameter: descriptor.load.parameter } } : {}),
+  };
+}
+
+export function createCollectionSource(
+  descriptor: Omit<DataSourceDescriptor, 'shape' | 'snapshot'> & {
+    snapshot(): unknown[] | undefined;
+  },
+): DataSourceDescriptor {
+  return {
+    ...descriptor,
+    shape: 'collection',
+  };
+}
+
+export function createRecordSource(
+  descriptor: Omit<DataSourceDescriptor, 'shape' | 'snapshot'> & {
+    snapshotRecord(): unknown | undefined;
+  },
+): DataSourceDescriptor {
+  const { snapshotRecord, ...source } = descriptor;
+  return {
+    ...source,
+    shape: 'record',
+    snapshot: () => {
+      const record = snapshotRecord();
+      return record === undefined ? undefined : [record];
+    },
+  };
+}

--- a/src/core/data-query/query.test.ts
+++ b/src/core/data-query/query.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import { createCollectionSource, createRecordSource } from '@src/core/data-query/catalog';
+import { DataQueryError, executeDataQuery, parseFilterValue } from '@src/core/data-query/query';
+import { DataSourceDescriptor, MAX_DATA_QUERY_LIMIT } from '@src/core/data-query/types';
+
+const rows = [
+  {
+    id: 1,
+    name: 'Alpha Base',
+    active: true,
+    score: 12,
+    nested: { code: 'AI1' },
+    tags: ['ore', 'fuel'],
+    config: { mode: 'safe' },
+  },
+  {
+    id: 2,
+    name: 'beta station',
+    active: false,
+    score: 4,
+    nested: { code: 'NC1' },
+    tags: ['food'],
+    config: { mode: 'fast' },
+  },
+  { id: 3, name: 'Gamma', active: true, score: null },
+];
+
+function source(snapshot: unknown[] = rows, overrides: Partial<DataSourceDescriptor> = {}) {
+  return createCollectionSource({
+    id: 'test',
+    label: 'Test Source',
+    description: 'Test data.',
+    provenance: 'prun-live',
+    completeness: () => 'complete',
+    snapshot: () => snapshot,
+    ...overrides,
+  });
+}
+
+function matchingIds(
+  filter: NonNullable<Parameters<typeof executeDataQuery>[1]['filters']>[number],
+) {
+  return executeDataQuery(source(), { sourceId: 'test', filters: [filter] }).rows.map(
+    x => (x as { id: number }).id,
+  );
+}
+
+describe('parseFilterValue', () => {
+  it.each([
+    ['true', true],
+    ['false', false],
+    ['null', null],
+    ['42', 42],
+    ['"AI1"', 'AI1'],
+    ['["ore"]', ['ore']],
+    ['{"mode":"safe"}', { mode: 'safe' }],
+    ['plain text', 'plain text'],
+    ['', ''],
+  ])('parses %s as a typed literal when valid', (input, expected) => {
+    expect(parseFilterValue(input)).toEqual(expected);
+  });
+});
+
+describe('executeDataQuery filters', () => {
+  it('supports strict equality and inequality with typed values', () => {
+    expect(matchingIds({ path: 'active', operator: 'eq', value: true })).toEqual([1, 3]);
+    expect(matchingIds({ path: 'active', operator: 'neq', value: true })).toEqual([2]);
+    expect(matchingIds({ path: 'id', operator: 'eq', value: '1' })).toEqual([]);
+    expect(matchingIds({ path: 'config', operator: 'eq', value: { mode: 'safe' } })).toEqual([1]);
+  });
+
+  it('supports contains and startsWith without case sensitivity', () => {
+    expect(matchingIds({ path: 'name', operator: 'contains', value: 'BASE' })).toEqual([1]);
+    expect(matchingIds({ path: 'name', operator: 'startsWith', value: 'BETA' })).toEqual([2]);
+    expect(matchingIds({ path: 'tags', operator: 'contains', value: 'fuel' })).toEqual([1]);
+  });
+
+  it('supports every ordered comparison', () => {
+    expect(matchingIds({ path: 'score', operator: 'gt', value: 4 })).toEqual([1]);
+    expect(matchingIds({ path: 'score', operator: 'gte', value: 4 })).toEqual([1, 2]);
+    expect(matchingIds({ path: 'score', operator: 'lt', value: 12 })).toEqual([2]);
+    expect(matchingIds({ path: 'score', operator: 'lte', value: 12 })).toEqual([1, 2]);
+  });
+
+  it('resolves nested paths and treats missing paths explicitly', () => {
+    expect(matchingIds({ path: 'nested.code', operator: 'eq', value: 'AI1' })).toEqual([1]);
+    expect(matchingIds({ path: 'nested.code', operator: 'neq', value: 'AI1' })).toEqual([2]);
+    expect(matchingIds({ path: 'nested.code', operator: 'exists' })).toEqual([1, 2]);
+    expect(matchingIds({ path: 'nested.code', operator: 'exists', value: false })).toEqual([3]);
+  });
+
+  it('AND-combines filters', () => {
+    const result = executeDataQuery(source(), {
+      sourceId: 'test',
+      filters: [
+        { path: 'active', operator: 'eq', value: true },
+        { path: 'score', operator: 'gt', value: 10 },
+      ],
+    });
+    expect(result.rows).toEqual([rows[0]]);
+  });
+});
+
+describe('executeDataQuery search and sorting', () => {
+  it('searches serialized rows with a case-insensitive substring', () => {
+    const result = executeDataQuery(source(), { sourceId: 'test', search: 'nc1' });
+    expect(result.rows).toEqual([rows[1]]);
+  });
+
+  it('sorts ascending and descending while keeping null and missing values last', () => {
+    const sortable = [
+      { id: 'missing' },
+      { id: 'two', value: 2 },
+      { id: 'null', value: null },
+      { id: 'undefined', value: undefined },
+      { id: 'one', value: 1 },
+    ];
+    const asc = executeDataQuery(source(sortable), {
+      sourceId: 'test',
+      sort: { path: 'value', direction: 'asc' },
+    });
+    const desc = executeDataQuery(source(sortable), {
+      sourceId: 'test',
+      sort: { path: 'value', direction: 'desc' },
+    });
+    expect(asc.rows.map(x => (x as { id: string }).id)).toEqual([
+      'one',
+      'two',
+      'missing',
+      'null',
+      'undefined',
+    ]);
+    expect(desc.rows.map(x => (x as { id: string }).id)).toEqual([
+      'two',
+      'one',
+      'missing',
+      'null',
+      'undefined',
+    ]);
+  });
+
+  it('falls back to string comparison for unlike types', () => {
+    const result = executeDataQuery(source([{ value: 2 }, { value: '10' }, { value: true }]), {
+      sourceId: 'test',
+      sort: { path: 'value', direction: 'asc' },
+    });
+    expect(result.rows).toEqual([{ value: '10' }, { value: 2 }, { value: true }]);
+  });
+});
+
+describe('executeDataQuery result envelope', () => {
+  it('applies the default limit and reports truncation metadata', () => {
+    const manyRows = Array.from({ length: 300 }, (_, id) => ({ id }));
+    const result = executeDataQuery(source(manyRows), { sourceId: 'test' });
+    expect(result.rows).toHaveLength(250);
+    expect(result.totalRows).toBe(300);
+    expect(result.matchedRows).toBe(300);
+    expect(result.truncated).toBe(true);
+    expect(result.query.limit).toBe(250);
+  });
+
+  it('caps requested limits at the maximum', () => {
+    const manyRows = Array.from({ length: MAX_DATA_QUERY_LIMIT + 10 }, (_, id) => ({ id }));
+    const result = executeDataQuery(source(manyRows), {
+      sourceId: 'test',
+      limit: MAX_DATA_QUERY_LIMIT + 100,
+    });
+    expect(result.rows).toHaveLength(MAX_DATA_QUERY_LIMIT);
+    expect(result.query.limit).toBe(MAX_DATA_QUERY_LIMIT);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('normalizes record sources into one row and preserves export metadata', () => {
+    const descriptor = createRecordSource({
+      id: 'company',
+      label: 'Company',
+      description: 'Company record.',
+      provenance: 'fio-reference-with-prun-overrides',
+      completeness: () => 'partial',
+      snapshotRecord: () => ({ id: 'company-1' }),
+    });
+    const generatedAt = new Date('2026-07-19T12:00:00.000Z');
+    const result = executeDataQuery(descriptor, { sourceId: 'company' }, generatedAt);
+    expect(result.rows).toEqual([{ id: 'company-1' }]);
+    expect(result.source).toEqual({
+      id: 'company',
+      label: 'Company',
+      provenance: 'fio-reference-with-prun-overrides',
+      completeness: 'partial',
+    });
+    expect(result.generatedAt).toBe('2026-07-19T12:00:00.000Z');
+  });
+});
+
+describe('executeDataQuery validation', () => {
+  it.each([
+    { sourceId: '' },
+    { sourceId: 'test', filters: {} },
+    { sourceId: 'test', filters: [{ path: '', operator: 'eq', value: 1 }] },
+    { sourceId: 'test', filters: [{ path: '__proto__.x', operator: 'eq', value: 1 }] },
+    { sourceId: 'test', filters: [{ path: 'id', operator: 'wat', value: 1 }] },
+    { sourceId: 'test', filters: [{ path: 'id', operator: 'exists', value: 'yes' }] },
+    { sourceId: 'test', sort: { path: 'id', direction: 'sideways' } },
+    { sourceId: 'test', limit: 0 },
+    { sourceId: 'test', limit: 1.5 },
+  ])('rejects malformed query %#', query => {
+    expect(() => executeDataQuery(source(), query as never)).toThrow(DataQueryError);
+  });
+
+  it('rejects a query for a different descriptor', () => {
+    expect(() => executeDataQuery(source(), { sourceId: 'unknown' })).toThrow(DataQueryError);
+  });
+});

--- a/src/core/data-query/query.ts
+++ b/src/core/data-query/query.ts
@@ -1,0 +1,331 @@
+import {
+  DataQuery,
+  DataQueryFilter,
+  DataQueryResult,
+  DataSourceDescriptor,
+  DEFAULT_DATA_QUERY_LIMIT,
+  MAX_DATA_QUERY_LIMIT,
+} from '@src/core/data-query/types';
+
+const operators = new Set([
+  'eq',
+  'neq',
+  'contains',
+  'startsWith',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'exists',
+]);
+
+const blockedPathSegments = new Set(['__proto__', 'prototype', 'constructor']);
+
+interface PathValue {
+  exists: boolean;
+  value: unknown;
+}
+
+export class DataQueryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DataQueryError';
+  }
+}
+
+export function parseFilterValue(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function cloneDataSnapshot(rows: unknown[] | undefined) {
+  return rows === undefined ? undefined : cloneSerializableRows(rows);
+}
+
+export function executeDataQuery(
+  descriptor: DataSourceDescriptor,
+  query: DataQuery,
+  generatedAt = new Date(),
+): DataQueryResult {
+  const normalizedQuery = validateAndNormalizeQuery(query);
+  if (normalizedQuery.sourceId !== descriptor.id) {
+    throw new DataQueryError(
+      `Query source "${normalizedQuery.sourceId}" does not match descriptor.`,
+    );
+  }
+
+  const snapshot = descriptor.snapshot();
+  const rows = cloneSerializableRows(snapshot ?? []);
+  const totalRows = rows.length;
+  const search = normalizedQuery.search?.toLocaleLowerCase();
+  const filters = normalizedQuery.filters ?? [];
+
+  let matched = rows.filter(row => {
+    if (search && !serializeForSearch(row).toLocaleLowerCase().includes(search)) {
+      return false;
+    }
+    return filters.every(filter => matchesFilter(row, filter));
+  });
+
+  if (normalizedQuery.sort) {
+    const { direction, path } = normalizedQuery.sort;
+    matched = matched
+      .map((row, index) => ({ index, row }))
+      .sort((a, b) => {
+        const compared = comparePathValues(a.row, b.row, path, direction);
+        return compared === 0 ? a.index - b.index : compared;
+      })
+      .map(x => x.row);
+  }
+
+  const matchedRows = matched.length;
+  const limit = normalizedQuery.limit!;
+  const limitedRows = matched.slice(0, limit);
+
+  return {
+    source: {
+      id: descriptor.id,
+      label: descriptor.label,
+      provenance: descriptor.provenance,
+      completeness: descriptor.completeness(),
+    },
+    generatedAt: generatedAt.toISOString(),
+    query: cloneSerializable(normalizedQuery),
+    totalRows,
+    matchedRows,
+    truncated: matchedRows > limitedRows.length,
+    rows: limitedRows,
+  };
+}
+
+export function validateAndNormalizeQuery(input: unknown): DataQuery {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new DataQueryError('Query must be an object.');
+  }
+  const query = input as DataQuery;
+  if (typeof query.sourceId !== 'string' || query.sourceId.trim() === '') {
+    throw new DataQueryError('sourceId must be a non-empty string.');
+  }
+  if (query.search !== undefined && typeof query.search !== 'string') {
+    throw new DataQueryError('search must be a string.');
+  }
+  if (query.filters !== undefined && !Array.isArray(query.filters)) {
+    throw new DataQueryError('filters must be an array.');
+  }
+
+  const filters = query.filters?.map((filter, index) => validateFilter(filter, index));
+  let sort: DataQuery['sort'];
+  if (query.sort !== undefined) {
+    const sortInput: unknown = query.sort;
+    if (typeof sortInput !== 'object' || sortInput === null || Array.isArray(sortInput)) {
+      throw new DataQueryError('sort must be an object.');
+    }
+    validatePath(query.sort.path, 'sort path');
+    if (query.sort.direction !== 'asc' && query.sort.direction !== 'desc') {
+      throw new DataQueryError('sort direction must be "asc" or "desc".');
+    }
+    sort = { path: query.sort.path, direction: query.sort.direction };
+  }
+
+  let limit = DEFAULT_DATA_QUERY_LIMIT;
+  if (query.limit !== undefined) {
+    if (!Number.isInteger(query.limit) || query.limit <= 0) {
+      throw new DataQueryError('limit must be a positive integer.');
+    }
+    limit = Math.min(query.limit, MAX_DATA_QUERY_LIMIT);
+  }
+
+  return {
+    sourceId: query.sourceId,
+    ...(query.search !== undefined ? { search: query.search } : {}),
+    ...(filters !== undefined ? { filters } : {}),
+    ...(sort !== undefined ? { sort } : {}),
+    limit,
+  };
+}
+
+function validateFilter(input: unknown, index: number): DataQueryFilter {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new DataQueryError(`Filter ${index + 1} must be an object.`);
+  }
+  const filter = input as DataQueryFilter;
+  validatePath(filter.path, `filter ${index + 1} path`);
+  if (!operators.has(filter.operator)) {
+    throw new DataQueryError(`Filter ${index + 1} has an unknown operator.`);
+  }
+  if (
+    filter.operator === 'exists' &&
+    filter.value !== undefined &&
+    typeof filter.value !== 'boolean'
+  ) {
+    throw new DataQueryError(`Filter ${index + 1} exists value must be a boolean when provided.`);
+  }
+  return {
+    path: filter.path,
+    operator: filter.operator,
+    ...(filter.value !== undefined ? { value: cloneSerializable(filter.value) } : {}),
+  };
+}
+
+function validatePath(path: string, label: string) {
+  if (typeof path !== 'string' || path.trim() === '') {
+    throw new DataQueryError(`${label} must be a non-empty dot-separated path.`);
+  }
+  const segments = path.split('.');
+  if (segments.some(x => x === '' || blockedPathSegments.has(x))) {
+    throw new DataQueryError(`${label} contains an invalid segment.`);
+  }
+}
+
+function matchesFilter(row: unknown, filter: DataQueryFilter): boolean {
+  const pathValue = getPathValue(row, filter.path);
+  if (filter.operator === 'exists') {
+    return filter.value === false ? !pathValue.exists : pathValue.exists;
+  }
+  if (!pathValue.exists) {
+    return false;
+  }
+
+  const value = pathValue.value;
+  switch (filter.operator) {
+    case 'eq':
+      return deepEqual(value, filter.value);
+    case 'neq':
+      return !deepEqual(value, filter.value);
+    case 'contains':
+      if (typeof value === 'string' && typeof filter.value === 'string') {
+        return value.toLocaleLowerCase().includes(filter.value.toLocaleLowerCase());
+      }
+      return Array.isArray(value) && value.some(x => deepEqual(x, filter.value));
+    case 'startsWith':
+      return (
+        typeof value === 'string' &&
+        typeof filter.value === 'string' &&
+        value.toLocaleLowerCase().startsWith(filter.value.toLocaleLowerCase())
+      );
+    case 'gt':
+      return compareComparable(value, filter.value, x => x > 0);
+    case 'gte':
+      return compareComparable(value, filter.value, x => x >= 0);
+    case 'lt':
+      return compareComparable(value, filter.value, x => x < 0);
+    case 'lte':
+      return compareComparable(value, filter.value, x => x <= 0);
+  }
+}
+
+function compareComparable(
+  left: unknown,
+  right: unknown,
+  predicate: (comparison: number) => boolean,
+) {
+  if (typeof left === 'number' && typeof right === 'number') {
+    return predicate(left - right);
+  }
+  if (typeof left === 'string' && typeof right === 'string') {
+    return predicate(left.localeCompare(right));
+  }
+  return false;
+}
+
+function comparePathValues(
+  leftRow: unknown,
+  rightRow: unknown,
+  path: string,
+  direction: 'asc' | 'desc',
+) {
+  const left = getPathValue(leftRow, path);
+  const right = getPathValue(rightRow, path);
+  const leftMissing = !left.exists || left.value === null || left.value === undefined;
+  const rightMissing = !right.exists || right.value === null || right.value === undefined;
+  if (leftMissing || rightMissing) {
+    if (leftMissing && rightMissing) {
+      return 0;
+    }
+    return leftMissing ? 1 : -1;
+  }
+
+  const comparison = compareValues(left.value, right.value);
+  return direction === 'desc' ? -comparison : comparison;
+}
+
+function compareValues(left: unknown, right: unknown): number {
+  if (typeof left === 'number' && typeof right === 'number') {
+    return left - right;
+  }
+  if (typeof left === 'string' && typeof right === 'string') {
+    return left.localeCompare(right);
+  }
+  if (typeof left === 'boolean' && typeof right === 'boolean') {
+    return Number(left) - Number(right);
+  }
+  return stableString(left).localeCompare(stableString(right));
+}
+
+function getPathValue(row: unknown, path: string): PathValue {
+  let value = row;
+  for (const segment of path.split('.')) {
+    if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+      return { exists: false, value: undefined };
+    }
+    if (!Object.hasOwn(value, segment)) {
+      return { exists: false, value: undefined };
+    }
+    value = (value as Record<string, unknown>)[segment];
+  }
+  return { exists: true, value };
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((x, index) => deepEqual(x, right[index]))
+    );
+  }
+  if (typeof left === 'object' && left !== null && typeof right === 'object' && right !== null) {
+    const leftObject = left as Record<string, unknown>;
+    const rightObject = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftObject);
+    const rightKeys = Object.keys(rightObject);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        key => Object.hasOwn(rightObject, key) && deepEqual(leftObject[key], rightObject[key]),
+      )
+    );
+  }
+  return false;
+}
+
+function serializeForSearch(value: unknown) {
+  const serialized = JSON.stringify(value);
+  return serialized ?? String(value);
+}
+
+function stableString(value: unknown) {
+  if (typeof value === 'object') {
+    return JSON.stringify(value) ?? String(value);
+  }
+  return String(value);
+}
+
+function cloneSerializableRows(rows: unknown[]) {
+  return cloneSerializable(rows);
+}
+
+function cloneSerializable<T>(value: T): T {
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    throw new DataQueryError('Data is not serializable.');
+  }
+}

--- a/src/core/data-query/types.ts
+++ b/src/core/data-query/types.ts
@@ -1,0 +1,84 @@
+export type DataProvenance =
+  | 'prun-live'
+  | 'prun-live-with-defaults'
+  | 'fio-reference-with-prun-overrides';
+
+export type DataCompleteness = 'not-loaded' | 'partial' | 'complete';
+
+export type DataSourceShape = 'collection' | 'record';
+
+export interface DataSourceDescriptor {
+  id: string;
+  label: string;
+  description: string;
+  provenance: DataProvenance;
+  shape: DataSourceShape;
+  completeness(): DataCompleteness;
+  snapshot(): unknown[] | undefined;
+  warning?: string;
+  load?: {
+    parameter?: 'siteId';
+    execute(parameter?: string): void;
+  };
+}
+
+export type DataFilterOperator =
+  | 'eq'
+  | 'neq'
+  | 'contains'
+  | 'startsWith'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'exists';
+
+export interface DataQueryFilter {
+  path: string;
+  operator: DataFilterOperator;
+  value?: unknown;
+}
+
+export interface DataQuery {
+  sourceId: string;
+  search?: string;
+  filters?: DataQueryFilter[];
+  sort?: { path: string; direction: 'asc' | 'desc' };
+  limit?: number;
+}
+
+export interface DataQueryResult {
+  source: {
+    id: string;
+    label: string;
+    provenance: DataProvenance;
+    completeness: DataCompleteness;
+  };
+  generatedAt: string;
+  query: DataQuery;
+  totalRows: number;
+  matchedRows: number;
+  truncated: boolean;
+  rows: unknown[];
+}
+
+export interface DataSourceSummary {
+  id: string;
+  label: string;
+  description: string;
+  provenance: DataProvenance;
+  shape: DataSourceShape;
+  completeness: DataCompleteness;
+  warning?: string;
+  load?: {
+    parameter?: 'siteId';
+  };
+}
+
+export interface DataSnapshot {
+  source: DataSourceSummary;
+  rows: unknown[] | undefined;
+}
+
+export const DEFAULT_DATA_QUERY_LIMIT = 250;
+export const MAX_DATA_QUERY_LIMIT = 5000;

--- a/src/features/XIT/DATA/DATA.ts
+++ b/src/features/XIT/DATA/DATA.ts
@@ -1,0 +1,9 @@
+import DATA from '@src/features/XIT/DATA/DATA.vue';
+
+xit.add({
+  command: 'DATA',
+  name: 'DATA EXPLORER',
+  description: 'Passively explores in-memory Refined PrUn game and tile data.',
+  component: () => DATA,
+  bufferSize: [1080, 720],
+});

--- a/src/features/XIT/DATA/DATA.vue
+++ b/src/features/XIT/DATA/DATA.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import PrunButton from '@src/components/PrunButton.vue';
+import ActionBar from '@src/components/ActionBar.vue';
 import Active from '@src/components/forms/Active.vue';
 import NumberInput from '@src/components/forms/NumberInput.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
@@ -235,74 +236,81 @@ function buildPreview(result?: DataQueryResult): {
 <template>
   <div :class="$style.root">
     <div :class="$style.controls">
-      <SectionHeader>Dataset</SectionHeader>
-      <form>
-        <Active label="Source">
-          <SelectInput
-            v-model="selectedSourceId"
-            :class="$style.sourceSelect"
-            :options="sourceOptions" />
-        </Active>
-      </form>
+      <div :class="$style.settingsGrid">
+        <section :class="$style.settingsPanel">
+          <SectionHeader>Dataset</SectionHeader>
+          <form>
+            <Active label="Source">
+              <SelectInput
+                v-model="selectedSourceId"
+                :class="$style.sourceSelect"
+                :options="sourceOptions" />
+            </Active>
+          </form>
 
-      <div v-if="source" :class="$style.sourceInfo">
-        <div :class="$style.sourceDescription">{{ source.description }}</div>
-        <div :class="$style.badges">
-          <span :class="$style.badge">{{ provenanceLabel }}</span>
-          <span :class="[$style.badge, $style[source.completeness]]">
-            {{ completenessLabel.toUpperCase() }}
-          </span>
-        </div>
-        <div v-if="source.warning" :class="$style.warning">{{ source.warning }}</div>
-      </div>
-
-      <SectionHeader>Query</SectionHeader>
-      <form>
-        <Active label="Text search">
-          <TextInput v-model="search" />
-        </Active>
-        <Active label="Sort path">
-          <div :class="$style.inlineInputs">
-            <TextInput v-model="sortPath" />
-            <SelectInput v-model="sortDirection" :options="directionOptions" />
+          <div v-if="source" :class="$style.sourceInfo">
+            <div :class="$style.sourceDescription">{{ source.description }}</div>
+            <div :class="$style.badges">
+              <span :class="$style.badge">{{ provenanceLabel }}</span>
+              <span :class="[$style.badge, $style[source.completeness]]">
+                {{ completenessLabel.toUpperCase() }}
+              </span>
+            </div>
+            <div v-if="source.warning" :class="$style.warning">{{ source.warning }}</div>
           </div>
-        </Active>
-        <Active label="Result limit" :error="limit !== undefined && limit <= 0">
-          <NumberInput v-model="limit" />
-        </Active>
-      </form>
+        </section>
 
-      <div v-if="filters.length > 0" :class="$style.filters">
-        <div v-for="filter in filters" :key="filter.id" :class="$style.filterRow">
-          <span :class="$style.filterLabel">FILTER {{ filter.id }}</span>
-          <input
-            v-model="filter.path"
-            :class="$style.pathInput"
-            placeholder="property.path"
-            type="text" />
-          <select v-model="filter.operator" :class="$style.operatorSelect">
-            <option v-for="option in operatorOptions" :key="option.value" :value="option.value">
-              {{ option.label }}
-            </option>
-          </select>
-          <input
-            v-model="filter.value"
-            :class="$style.valueInput"
-            :placeholder="
-              filter.operator === 'exists' ? 'true/false; blank = true' : 'JSON or text'
-            "
-            type="text" />
-          <PrunButton danger inline @click="removeFilter(filter.id)">REMOVE</PrunButton>
+        <section :class="$style.settingsPanel">
+          <SectionHeader>Query</SectionHeader>
+          <form>
+            <Active label="Text search">
+              <TextInput v-model="search" />
+            </Active>
+            <Active label="Sort path">
+              <div :class="$style.inlineInputs">
+                <TextInput v-model="sortPath" />
+                <SelectInput v-model="sortDirection" :options="directionOptions" />
+              </div>
+            </Active>
+            <Active label="Result limit" :error="limit !== undefined && limit <= 0">
+              <NumberInput v-model="limit" />
+            </Active>
+          </form>
+        </section>
+      </div>
+
+      <ActionBar :class="$style.actionBar">
+        <PrunButton primary @click="addFilter">ADD FILTER</PrunButton>
+        <PrunButton neutral @click="resetQuery">RESET QUERY</PrunButton>
+        <PrunButton primary :disabled="!result" @click="exportResult">DOWNLOAD JSON</PrunButton>
+      </ActionBar>
+
+      <template v-if="filters.length > 0">
+        <SectionHeader>Filters</SectionHeader>
+        <div :class="$style.filters">
+          <div v-for="filter in filters" :key="filter.id" :class="$style.filterRow">
+            <span :class="$style.filterLabel">FILTER {{ filter.id }}</span>
+            <input
+              v-model="filter.path"
+              :class="$style.pathInput"
+              placeholder="property.path"
+              type="text" />
+            <select v-model="filter.operator" :class="$style.operatorSelect">
+              <option v-for="option in operatorOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+            <input
+              v-model="filter.value"
+              :class="$style.valueInput"
+              :placeholder="
+                filter.operator === 'exists' ? 'true/false; blank = true' : 'JSON or text'
+              "
+              type="text" />
+            <PrunButton danger @click="removeFilter(filter.id)">REMOVE</PrunButton>
+          </div>
         </div>
-      </div>
-
-      <div :class="$style.commands">
-        <PrunButton primary inline @click="addFilter">ADD FILTER</PrunButton>
-        <PrunButton neutral inline @click="resetQuery">RESET QUERY</PrunButton>
-        <PrunButton primary inline :disabled="!result" @click="exportResult">
-          DOWNLOAD JSON
-        </PrunButton>
-      </div>
+      </template>
 
       <template v-if="source?.load">
         <SectionHeader>Explicit Load</SectionHeader>
@@ -390,9 +398,8 @@ function buildPreview(result?: DataQueryResult): {
 
 <style module>
 .root {
-  display: grid;
-  grid-template-columns: minmax(360px, 42%) minmax(0, 1fr);
-  grid-template-rows: auto auto minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: 7px;
   box-sizing: border-box;
   width: 100%;
@@ -403,7 +410,8 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .controls {
-  grid-row: 1 / -1;
+  flex: 0 1 auto;
+  max-height: 48%;
   min-height: 0;
   border: 1px solid rgb(51, 51, 51);
   background: rgb(31, 31, 31);
@@ -419,6 +427,19 @@ function buildPreview(result?: DataQueryResult): {
     background-color: rgb(51, 51, 51);
     border-radius: 5px;
   }
+}
+
+.settingsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  padding: 6px;
+}
+
+.settingsPanel {
+  min-width: 0;
+  border: 1px solid rgb(51, 51, 51);
+  background: rgb(28, 28, 28);
 }
 
 .sourceSelect {
@@ -492,15 +513,12 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .filters {
-  padding: 5px 8px 0;
+  padding: 6px 8px 1px;
 }
 
 .filterRow {
   display: grid;
-  grid-template-columns: 62px minmax(90px, 1fr) minmax(110px, 1fr) auto;
-  grid-template-areas:
-    'label path operator remove'
-    '. value value remove';
+  grid-template-columns: 62px minmax(120px, 1.1fr) minmax(130px, 0.8fr) minmax(130px, 1fr) auto;
   align-items: center;
   gap: 6px;
   margin-bottom: 5px;
@@ -509,25 +527,8 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .filterLabel {
-  grid-area: label;
   color: rgb(153, 153, 153);
   font-size: 10px;
-}
-
-.pathInput {
-  grid-area: path;
-}
-
-.operatorSelect {
-  grid-area: operator;
-}
-
-.valueInput {
-  grid-area: value;
-}
-
-.filterRow > :last-child {
-  grid-area: remove;
 }
 
 .pathInput,
@@ -564,6 +565,10 @@ function buildPreview(result?: DataQueryResult): {
   flex-wrap: wrap;
   gap: 6px;
   padding: 6px 10px 9px;
+}
+
+.actionBar {
+  margin: 0 6px 7px;
 }
 
 .agentExplanation {
@@ -649,8 +654,7 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .resultHeader {
-  grid-column: 2;
-  grid-row: 1;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -665,8 +669,7 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .preview {
-  grid-column: 2;
-  grid-row: 3;
+  flex: 1 1 auto;
   min-height: 0;
   margin: 0;
   padding: 9px;
@@ -692,8 +695,7 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .previewNotice {
-  grid-column: 2;
-  grid-row: 2;
+  flex: 0 0 auto;
   padding: 5px 10px;
   border-left: 3px solid rgb(240, 173, 78);
   background: rgba(240, 173, 78, 0.08);
@@ -701,33 +703,40 @@ function buildPreview(result?: DataQueryResult): {
   font-size: 11px;
 }
 
-@media (max-width: 820px) {
-  .root {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(260px, auto) auto auto minmax(300px, 1fr);
-  }
-
+@media (max-width: 760px) {
   .controls {
-    grid-row: 1;
-    max-height: 50vh;
+    max-height: 58%;
   }
 
-  .resultHeader,
-  .previewNotice,
-  .preview {
-    grid-column: 1;
+  .settingsGrid {
+    grid-template-columns: 1fr;
   }
 
-  .resultHeader {
-    grid-row: 2;
+  .filterRow {
+    grid-template-columns: 62px minmax(100px, 1fr) minmax(110px, 1fr) auto;
+    grid-template-areas:
+      'label path operator remove'
+      '. value value remove';
   }
 
-  .previewNotice {
-    grid-row: 3;
+  .filterLabel {
+    grid-area: label;
   }
 
-  .preview {
-    grid-row: 4;
+  .pathInput {
+    grid-area: path;
+  }
+
+  .operatorSelect {
+    grid-area: operator;
+  }
+
+  .valueInput {
+    grid-area: value;
+  }
+
+  .filterRow > :last-child {
+    grid-area: remove;
   }
 }
 </style>

--- a/src/features/XIT/DATA/DATA.vue
+++ b/src/features/XIT/DATA/DATA.vue
@@ -1,0 +1,733 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import Active from '@src/components/forms/Active.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import {
+  dataCatalog,
+  DataQuery,
+  DataQueryFilter,
+  DataQueryResult,
+  DataSourceSummary,
+  parseFilterValue,
+} from '@src/infrastructure/data-catalog';
+import { isRequestTransportAvailable } from '@src/infrastructure/prun-api/data/request-hooks';
+import { agentQueryConnection } from '@src/infrastructure/data-catalog/agent-query';
+import { downloadJson } from '@src/utils/json-file';
+
+interface FilterInput {
+  id: number;
+  path: string;
+  operator: DataQueryFilter['operator'];
+  value: string;
+}
+
+const maxPreviewCharacters = 750_000;
+const maxPreviewRows = 100;
+
+const operatorOptions: Array<{ label: string; value: DataQueryFilter['operator'] }> = [
+  { label: 'EQUALS', value: 'eq' },
+  { label: 'NOT EQUAL', value: 'neq' },
+  { label: 'CONTAINS', value: 'contains' },
+  { label: 'STARTS WITH', value: 'startsWith' },
+  { label: 'GREATER THAN', value: 'gt' },
+  { label: 'GREATER OR EQUAL', value: 'gte' },
+  { label: 'LESS THAN', value: 'lt' },
+  { label: 'LESS OR EQUAL', value: 'lte' },
+  { label: 'EXISTS', value: 'exists' },
+];
+
+const directionOptions = [
+  { label: 'ASCENDING', value: 'asc' },
+  { label: 'DESCENDING', value: 'desc' },
+];
+
+const sources = computed(() => dataCatalog.list());
+const selectedSourceId = ref('balances');
+const search = ref('');
+const filters = ref<FilterInput[]>([]);
+const sortPath = ref('');
+const sortDirection = ref<'asc' | 'desc'>('asc');
+const limit = ref<number | undefined>(250);
+const siteId = ref('');
+const loadMessage = ref('');
+const agentEndpoint = ref('ws://127.0.0.1:47800');
+const agentToken = ref('');
+const agentStatus = agentQueryConnection.status;
+const agentError = agentQueryConnection.lastError;
+let nextFilterId = 1;
+
+const source = computed(
+  () => sources.value.find(x => x.id === selectedSourceId.value) ?? sources.value[0],
+);
+
+const sourceOptions = computed(() =>
+  sources.value.map(x => ({
+    label: x.label,
+    value: x.id,
+  })),
+);
+
+const provenanceLabel = computed(() => {
+  switch (source.value?.provenance) {
+    case 'prun-live':
+      return 'PRUN LIVE';
+    case 'prun-live-with-defaults':
+      return 'PRUN LIVE + BUNDLED DEFAULTS';
+    case 'fio-reference-with-prun-overrides':
+      return 'FIO REFERENCE + PRUN OVERRIDES';
+    default:
+      return '';
+  }
+});
+
+const completenessLabel = computed(() => source.value?.completeness.replace('-', ' ') ?? '');
+const requestAvailable = computed(() => isRequestTransportAvailable());
+const canLoad = computed(
+  () =>
+    requestAvailable.value &&
+    source.value?.load !== undefined &&
+    (source.value.load.parameter !== 'siteId' || siteId.value.trim() !== ''),
+);
+
+const queryState = computed<{ result?: DataQueryResult; error?: string }>(() => {
+  try {
+    return { result: dataCatalog.query(buildQuery()) };
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+});
+
+const result = computed(() => queryState.value.result);
+const queryError = computed(() => queryState.value.error);
+const preview = computed(() => buildPreview(result.value));
+const prettyResult = computed(() => preview.value.text ?? queryError.value);
+const agentStatusLabel = computed(() => agentStatus.value.replace('-', ' ').toUpperCase());
+
+watch(selectedSourceId, () => {
+  loadMessage.value = '';
+});
+
+function addFilter() {
+  filters.value.push({
+    id: nextFilterId++,
+    path: '',
+    operator: 'eq',
+    value: '',
+  });
+}
+
+function removeFilter(id: number) {
+  filters.value = filters.value.filter(x => x.id !== id);
+}
+
+function resetQuery() {
+  search.value = '';
+  filters.value = [];
+  sortPath.value = '';
+  sortDirection.value = 'asc';
+  limit.value = 250;
+}
+
+function buildQuery(): DataQuery {
+  const appliedFilters = filters.value
+    .filter(x => x.path.trim() !== '')
+    .map<DataQueryFilter>(x => ({
+      path: x.path.trim(),
+      operator: x.operator,
+      ...(x.operator === 'exists' && x.value.trim() === ''
+        ? {}
+        : { value: parseFilterValue(x.value) }),
+    }));
+
+  return {
+    sourceId: source.value?.id ?? selectedSourceId.value,
+    ...(search.value ? { search: search.value } : {}),
+    ...(appliedFilters.length > 0 ? { filters: appliedFilters } : {}),
+    ...(sortPath.value.trim()
+      ? { sort: { path: sortPath.value.trim(), direction: sortDirection.value } }
+      : {}),
+    ...(limit.value !== undefined ? { limit: limit.value } : {}),
+  };
+}
+
+function exportResult() {
+  try {
+    const exported = dataCatalog.export(buildQuery());
+    downloadJson(exported, `rprun-data-${exported.source.id}-${Date.now()}.json`, { pretty: true });
+  } catch (error) {
+    loadMessage.value = getErrorMessage(error);
+  }
+}
+
+function loadSource() {
+  loadMessage.value = '';
+  if (!requestAvailable.value) {
+    loadMessage.value = 'PrUn request transport is unavailable.';
+    return;
+  }
+  try {
+    dataCatalog.load(source.value!.id, siteId.value);
+    loadMessage.value = 'Load requested from PrUn.';
+  } catch (error) {
+    loadMessage.value = getErrorMessage(error);
+  }
+}
+
+function generateAgentToken() {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  agentToken.value = btoa(String.fromCharCode(...bytes))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+async function copyAgentToken() {
+  if (agentToken.value) {
+    await navigator.clipboard.writeText(agentToken.value);
+  }
+}
+
+function connectAgent() {
+  agentQueryConnection.connect(agentEndpoint.value, agentToken.value);
+}
+
+function disconnectAgent() {
+  agentQueryConnection.disconnect();
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sourceNeedsSiteId(source?: DataSourceSummary) {
+  return source?.load?.parameter === 'siteId';
+}
+
+function buildPreview(result?: DataQueryResult): {
+  text?: string;
+  shownRows: number;
+  truncated: boolean;
+} {
+  if (!result) {
+    return { shownRows: 0, truncated: false };
+  }
+
+  let shownRows = Math.min(result.rows.length, maxPreviewRows);
+  while (shownRows > 0) {
+    const text = JSON.stringify({ ...result, rows: result.rows.slice(0, shownRows) }, null, 2);
+    if (text.length <= maxPreviewCharacters) {
+      return { text, shownRows, truncated: shownRows < result.rows.length };
+    }
+    shownRows = Math.floor(shownRows / 2);
+  }
+
+  return {
+    text: JSON.stringify({ ...result, rows: [] }, null, 2),
+    shownRows: 0,
+    truncated: result.rows.length > 0,
+  };
+}
+</script>
+
+<template>
+  <div :class="$style.root">
+    <div :class="$style.controls">
+      <SectionHeader>Dataset</SectionHeader>
+      <form>
+        <Active label="Source">
+          <SelectInput
+            v-model="selectedSourceId"
+            :class="$style.sourceSelect"
+            :options="sourceOptions" />
+        </Active>
+      </form>
+
+      <div v-if="source" :class="$style.sourceInfo">
+        <div :class="$style.sourceDescription">{{ source.description }}</div>
+        <div :class="$style.badges">
+          <span :class="$style.badge">{{ provenanceLabel }}</span>
+          <span :class="[$style.badge, $style[source.completeness]]">
+            {{ completenessLabel.toUpperCase() }}
+          </span>
+        </div>
+        <div v-if="source.warning" :class="$style.warning">{{ source.warning }}</div>
+      </div>
+
+      <SectionHeader>Query</SectionHeader>
+      <form>
+        <Active label="Text search">
+          <TextInput v-model="search" />
+        </Active>
+        <Active label="Sort path">
+          <div :class="$style.inlineInputs">
+            <TextInput v-model="sortPath" />
+            <SelectInput v-model="sortDirection" :options="directionOptions" />
+          </div>
+        </Active>
+        <Active label="Result limit" :error="limit !== undefined && limit <= 0">
+          <NumberInput v-model="limit" />
+        </Active>
+      </form>
+
+      <div v-if="filters.length > 0" :class="$style.filters">
+        <div v-for="filter in filters" :key="filter.id" :class="$style.filterRow">
+          <span :class="$style.filterLabel">FILTER {{ filter.id }}</span>
+          <input
+            v-model="filter.path"
+            :class="$style.pathInput"
+            placeholder="property.path"
+            type="text" />
+          <select v-model="filter.operator" :class="$style.operatorSelect">
+            <option v-for="option in operatorOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
+          <input
+            v-model="filter.value"
+            :class="$style.valueInput"
+            :placeholder="
+              filter.operator === 'exists' ? 'true/false; blank = true' : 'JSON or text'
+            "
+            type="text" />
+          <PrunButton danger inline @click="removeFilter(filter.id)">REMOVE</PrunButton>
+        </div>
+      </div>
+
+      <div :class="$style.commands">
+        <PrunButton primary inline @click="addFilter">ADD FILTER</PrunButton>
+        <PrunButton neutral inline @click="resetQuery">RESET QUERY</PrunButton>
+        <PrunButton primary inline :disabled="!result" @click="exportResult">
+          DOWNLOAD JSON
+        </PrunButton>
+      </div>
+
+      <template v-if="source?.load">
+        <SectionHeader>Explicit Load</SectionHeader>
+        <div :class="$style.loadControls">
+          <input
+            v-if="sourceNeedsSiteId(source)"
+            v-model="siteId"
+            :class="$style.siteInput"
+            placeholder="Required site ID"
+            type="text" />
+          <PrunButton primary :disabled="!canLoad" @click="loadSource">LOAD FROM PRUN</PrunButton>
+          <span v-if="!requestAvailable" :class="$style.error">
+            PrUn request transport is unavailable.
+          </span>
+          <span v-else-if="sourceNeedsSiteId(source) && !siteId.trim()" :class="$style.hint">
+            Enter a site ID before loading.
+          </span>
+          <span v-if="loadMessage" :class="$style.hint">{{ loadMessage }}</span>
+        </div>
+      </template>
+
+      <details :class="$style.agentPanel">
+        <summary :class="$style.agentSummary">
+          <span>Agent Query Connection</span>
+          <span :class="[$style.badge, $style.agentStatus, $style[agentStatus]]">
+            {{ agentStatusLabel }}
+          </span>
+        </summary>
+        <div :class="$style.agentExplanation">
+          Opt-in, authenticated, read-only, and loopback-only. The token stays in memory. Agent
+          requests cannot load data or perform PrUn actions.
+        </div>
+        <form>
+          <Active label="Loopback endpoint">
+            <TextInput v-model="agentEndpoint" />
+          </Active>
+          <Active
+            label="Session token"
+            tooltip="Use a 32+ character shared token configured in the local agent server.">
+            <div :class="$style.agentToken">
+              <input
+                v-model="agentToken"
+                autocomplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true"
+                placeholder="32+ character token"
+                type="password" />
+              <PrunButton primary inline @click="generateAgentToken">GENERATE</PrunButton>
+              <PrunButton primary inline :disabled="!agentToken" @click="copyAgentToken">
+                COPY
+              </PrunButton>
+            </div>
+          </Active>
+        </form>
+        <div :class="$style.commands">
+          <PrunButton
+            v-if="agentStatus === 'disconnected' || agentStatus === 'error'"
+            primary
+            inline
+            :disabled="!agentEndpoint.trim() || agentToken.length < 32"
+            @click="connectAgent">
+            CONNECT
+          </PrunButton>
+          <PrunButton v-else danger inline @click="disconnectAgent">DISCONNECT</PrunButton>
+          <span v-if="agentError" :class="$style.error">{{ agentError }}</span>
+        </div>
+      </details>
+    </div>
+
+    <div :class="$style.resultHeader">
+      <SectionHeader>Result</SectionHeader>
+      <span v-if="result">
+        {{ result.matchedRows }} matched / {{ result.totalRows }} total · showing
+        {{ result.rows.length }}
+      </span>
+      <span v-else :class="$style.error">{{ queryError }}</span>
+    </div>
+    <div v-if="result && preview.truncated" :class="$style.previewNotice">
+      Preview limited to {{ preview.shownRows }} rows for performance. Download includes all
+      {{ result.rows.length }} query rows.
+    </div>
+    <pre :class="$style.preview">{{ prettyResult }}</pre>
+  </div>
+</template>
+
+<style module>
+.root {
+  display: grid;
+  grid-template-columns: minmax(360px, 42%) minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 7px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  padding: 6px;
+  color: rgb(204, 204, 204);
+}
+
+.controls {
+  grid-row: 1 / -1;
+  min-height: 0;
+  border: 1px solid rgb(51, 51, 51);
+  background: rgb(31, 31, 31);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(51, 51, 51) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgb(51, 51, 51);
+    border-radius: 5px;
+  }
+}
+
+.sourceSelect {
+  width: 100%;
+}
+
+.sourceSelect > div,
+.sourceSelect select {
+  width: 100%;
+}
+
+.sourceInfo {
+  padding: 7px 10px 9px;
+}
+
+.sourceDescription {
+  margin-bottom: 6px;
+  color: rgb(179, 179, 179);
+  line-height: 1.35;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge {
+  padding: 1px 5px;
+  border: 1px solid rgb(87, 87, 87);
+  color: rgb(185, 185, 185);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+.not-loaded {
+  color: rgb(160, 160, 160);
+}
+
+.partial {
+  color: rgb(240, 173, 78);
+}
+
+.complete {
+  color: rgb(92, 184, 92);
+}
+
+.warning {
+  margin-top: 8px;
+  padding: 6px 8px;
+  border-left: 3px solid rgb(240, 173, 78);
+  background: rgba(240, 173, 78, 0.08);
+  color: rgb(240, 173, 78);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.inlineInputs {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  width: 100%;
+}
+
+.inlineInputs > :first-child {
+  flex: 1;
+}
+
+.inlineInputs input {
+  width: 100%;
+}
+
+.filters {
+  padding: 5px 8px 0;
+}
+
+.filterRow {
+  display: grid;
+  grid-template-columns: 62px minmax(90px, 1fr) minmax(110px, 1fr) auto;
+  grid-template-areas:
+    'label path operator remove'
+    '. value value remove';
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 5px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid rgb(51, 51, 51);
+}
+
+.filterLabel {
+  grid-area: label;
+  color: rgb(153, 153, 153);
+  font-size: 10px;
+}
+
+.pathInput {
+  grid-area: path;
+}
+
+.operatorSelect {
+  grid-area: operator;
+}
+
+.valueInput {
+  grid-area: value;
+}
+
+.filterRow > :last-child {
+  grid-area: remove;
+}
+
+.pathInput,
+.operatorSelect,
+.valueInput,
+.siteInput {
+  box-sizing: border-box;
+  min-width: 0;
+  height: 25px;
+  border: 1px solid rgb(51, 51, 51);
+  background: rgb(21, 21, 21);
+  color: rgb(204, 204, 204);
+  font: 12px monospace;
+}
+
+.pathInput,
+.valueInput,
+.siteInput {
+  padding: 3px 6px;
+}
+
+.pathInput:focus,
+.operatorSelect:focus,
+.valueInput:focus,
+.siteInput:focus {
+  border-color: rgb(240, 173, 78);
+  outline: none;
+}
+
+.commands,
+.loadControls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 10px 9px;
+}
+
+.agentExplanation {
+  padding: 8px 10px 5px;
+  color: rgb(153, 153, 153);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.agentToken {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  width: 100%;
+}
+
+.agentToken input {
+  box-sizing: border-box;
+  flex: 1;
+  min-width: 0;
+  height: 25px;
+  border: 1px solid rgb(51, 51, 51);
+  background: rgb(21, 21, 21);
+  color: rgb(204, 204, 204);
+  padding: 3px 6px;
+  font: 12px monospace;
+}
+
+.agentToken input:focus {
+  border-color: rgb(240, 173, 78);
+  outline: none;
+}
+
+.agentStatus {
+  min-width: 82px;
+  text-align: center;
+}
+
+.agentPanel {
+  border-top: 1px solid rgb(51, 51, 51);
+}
+
+.agentSummary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 8px;
+  background: rgb(35, 55, 64);
+  color: rgb(204, 204, 204);
+  cursor: pointer;
+  font-weight: bold;
+  list-style-position: inside;
+  user-select: none;
+}
+
+.agentSummary::marker {
+  color: rgb(153, 153, 153);
+}
+
+.connected {
+  border-color: rgb(92, 184, 92);
+  color: rgb(92, 184, 92);
+}
+
+.connecting,
+.authenticating {
+  border-color: rgb(240, 173, 78);
+  color: rgb(240, 173, 78);
+}
+
+.siteInput {
+  width: 260px;
+}
+
+.hint {
+  color: rgb(153, 153, 153);
+  font-size: 11px;
+}
+
+.error {
+  color: rgb(217, 83, 79);
+}
+
+.resultHeader {
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid rgb(51, 51, 51);
+  background: rgb(31, 31, 31);
+  font-size: 11px;
+}
+
+.resultHeader > :first-child {
+  flex: 1;
+}
+
+.preview {
+  grid-column: 2;
+  grid-row: 3;
+  min-height: 0;
+  margin: 0;
+  padding: 9px;
+  border: 1px solid rgb(51, 51, 51);
+  overflow: auto;
+  background: rgb(13, 13, 13);
+  color: rgb(204, 204, 204);
+  font: 12px/1.4 monospace;
+  white-space: pre;
+  tab-size: 2;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(51, 51, 51) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgb(51, 51, 51);
+    border-radius: 5px;
+  }
+}
+
+.previewNotice {
+  grid-column: 2;
+  grid-row: 2;
+  padding: 5px 10px;
+  border-left: 3px solid rgb(240, 173, 78);
+  background: rgba(240, 173, 78, 0.08);
+  color: rgb(240, 173, 78);
+  font-size: 11px;
+}
+
+@media (max-width: 820px) {
+  .root {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(260px, auto) auto auto minmax(300px, 1fr);
+  }
+
+  .controls {
+    grid-row: 1;
+    max-height: 50vh;
+  }
+
+  .resultHeader,
+  .previewNotice,
+  .preview {
+    grid-column: 1;
+  }
+
+  .resultHeader {
+    grid-row: 2;
+  }
+
+  .previewNotice {
+    grid-row: 3;
+  }
+
+  .preview {
+    grid-row: 4;
+  }
+}
+</style>

--- a/src/infrastructure/data-catalog/agent-query-connection.test.ts
+++ b/src/infrastructure/data-catalog/agent-query-connection.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCollectionSource, DataCatalog } from '@src/core/data-query/catalog';
+import {
+  AgentQueryConnection,
+  validateAgentEndpoint,
+  validateAgentToken,
+} from '@src/infrastructure/data-catalog/agent-query-connection';
+
+class FakeSocket {
+  readyState: number = WebSocket.CONNECTING;
+  sent: string[] = [];
+  closed?: { code?: number; reason?: string };
+  private readonly listeners = new Map<string, Array<(event: { data?: unknown }) => void>>();
+
+  addEventListener(type: string, listener: (event: { data?: unknown }) => void) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string) {
+    this.closed = { code, reason };
+    this.readyState = WebSocket.CLOSED;
+  }
+
+  emit(type: string, data?: unknown) {
+    if (type === 'open') {
+      this.readyState = WebSocket.OPEN;
+    }
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ data });
+    }
+  }
+
+  messages() {
+    return this.sent.map(x => JSON.parse(x));
+  }
+}
+
+function createTestCatalog() {
+  return new DataCatalog([
+    createCollectionSource({
+      id: 'test',
+      label: 'Test',
+      description: 'Test source.',
+      provenance: 'prun-live',
+      completeness: () => 'partial',
+      snapshot: () => [{ id: 1 }, { id: 2 }],
+      load: { execute: vi.fn() },
+    }),
+  ]);
+}
+
+const token = 'a'.repeat(32);
+
+describe('agent endpoint and token validation', () => {
+  it.each([
+    ['ws://127.0.0.1:47800', 'ws://127.0.0.1:47800/'],
+    ['ws://[::1]:47800/query', 'ws://[::1]:47800/query'],
+  ])('accepts literal loopback endpoint %s', (endpoint, normalized) => {
+    expect(validateAgentEndpoint(endpoint)).toBe(normalized);
+  });
+
+  it.each([
+    'ws://localhost:47800',
+    'ws://192.168.1.10:47800',
+    'https://127.0.0.1:47800',
+    'ws://user:secret@127.0.0.1:47800',
+    'ws://127.0.0.1:47800?token=secret',
+  ])('rejects unsafe endpoint %s', endpoint => {
+    expect(() => validateAgentEndpoint(endpoint)).toThrow();
+  });
+
+  it('requires a substantial token without control characters', () => {
+    expect(() => validateAgentToken('short')).toThrow();
+    expect(() => validateAgentToken(`${token}\n`)).toThrow();
+    expect(validateAgentToken(token)).toBeUndefined();
+  });
+});
+
+describe('AgentQueryConnection', () => {
+  it('is disabled until explicitly connected and authenticates before querying', () => {
+    const socket = new FakeSocket();
+    const factory = vi.fn(() => socket);
+    const connection = new AgentQueryConnection(createTestCatalog(), factory);
+
+    expect(connection.status.value).toBe('disconnected');
+    expect(factory).not.toHaveBeenCalled();
+
+    connection.connect('ws://127.0.0.1:47800', token);
+    expect(connection.status.value).toBe('connecting');
+    socket.emit('open');
+    expect(connection.status.value).toBe('authenticating');
+    expect(socket.messages()[0]).toEqual({
+      type: 'authenticate',
+      version: 1,
+      token,
+    });
+
+    socket.emit('message', JSON.stringify({ type: 'authenticated' }));
+    expect(connection.status.value).toBe('connected');
+
+    socket.emit(
+      'message',
+      JSON.stringify({ type: 'query', id: 'q1', query: { sourceId: 'test' } }),
+    );
+    const response = socket.messages()[1];
+    expect(response.type).toBe('result');
+    expect(response.id).toBe('q1');
+    expect(response.result.source).toEqual({
+      id: 'test',
+      label: 'Test',
+      provenance: 'prun-live',
+      completeness: 'partial',
+    });
+    expect(response.result.rows).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('lists metadata but rejects loader and unknown request methods', () => {
+    const socket = new FakeSocket();
+    const connection = new AgentQueryConnection(createTestCatalog(), () => socket);
+    connection.connect('ws://127.0.0.1:47800', token);
+    socket.emit('open');
+    socket.emit('message', JSON.stringify({ type: 'authenticated' }));
+
+    socket.emit('message', JSON.stringify({ type: 'list-sources', id: 'list' }));
+    expect(socket.messages()[1]).toMatchObject({
+      type: 'sources',
+      id: 'list',
+      sources: [{ id: 'test', completeness: 'partial' }],
+    });
+
+    socket.emit('message', JSON.stringify({ type: 'load', id: 'load', sourceId: 'test' }));
+    expect(socket.messages()[2]).toEqual({
+      type: 'error',
+      id: 'load',
+      error: 'Unknown or unauthorized agent request type.',
+    });
+  });
+
+  it('rejects requests before authentication and oversized messages', () => {
+    const unauthenticatedSocket = new FakeSocket();
+    const connection = new AgentQueryConnection(createTestCatalog(), () => unauthenticatedSocket);
+    connection.connect('ws://127.0.0.1:47800', token);
+    unauthenticatedSocket.emit('open');
+    unauthenticatedSocket.emit(
+      'message',
+      JSON.stringify({ type: 'query', id: 'q1', query: { sourceId: 'test' } }),
+    );
+    expect(connection.status.value).toBe('error');
+    expect(unauthenticatedSocket.closed?.code).toBe(1008);
+
+    const oversizedSocket = new FakeSocket();
+    const secondConnection = new AgentQueryConnection(createTestCatalog(), () => oversizedSocket);
+    secondConnection.connect('ws://127.0.0.1:47800', token);
+    oversizedSocket.emit('open');
+    oversizedSocket.emit('message', 'x'.repeat(64 * 1024 + 1));
+    expect(secondConnection.status.value).toBe('error');
+    expect(oversizedSocket.closed?.code).toBe(1009);
+  });
+
+  it('shows validation failures without opening a socket and disconnects cleanly', () => {
+    const socket = new FakeSocket();
+    const factory = vi.fn(() => socket);
+    const connection = new AgentQueryConnection(createTestCatalog(), factory);
+    connection.connect('ws://example.com:47800', token);
+    expect(connection.status.value).toBe('error');
+    expect(factory).not.toHaveBeenCalled();
+
+    connection.connect('ws://127.0.0.1:47800', token);
+    socket.emit('open');
+    socket.emit('message', JSON.stringify({ type: 'authenticated' }));
+    connection.disconnect();
+    expect(connection.status.value).toBe('disconnected');
+    expect(socket.closed?.code).toBe(1000);
+  });
+});

--- a/src/infrastructure/data-catalog/agent-query-connection.ts
+++ b/src/infrastructure/data-catalog/agent-query-connection.ts
@@ -1,0 +1,282 @@
+import { DataCatalog } from '@src/core/data-query/catalog';
+import { DataQuery } from '@src/core/data-query/types';
+import { ref } from 'vue';
+
+export type AgentConnectionStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'authenticating'
+  | 'connected'
+  | 'error';
+
+interface AgentSocketEvent {
+  data?: unknown;
+}
+
+interface AgentSocket {
+  readonly readyState: number;
+  addEventListener(type: string, listener: (event: AgentSocketEvent) => void): void;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+type AgentSocketFactory = (endpoint: string) => AgentSocket;
+
+interface AgentRequest {
+  id?: unknown;
+  type?: unknown;
+  query?: unknown;
+}
+
+const maxIncomingMessageSize = 64 * 1024;
+const maxOutgoingMessageSize = 4 * 1024 * 1024;
+const authenticationTimeoutMs = 10_000;
+const protocolVersion = 1;
+
+export class AgentQueryConnection {
+  readonly status = ref<AgentConnectionStatus>('disconnected');
+  readonly lastError = ref('');
+  readonly connectedEndpoint = ref('');
+
+  private socket?: AgentSocket;
+  private authenticated = false;
+  private disconnecting = false;
+  private authenticationTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly catalog: DataCatalog,
+    private readonly socketFactory: AgentSocketFactory = endpoint =>
+      new WebSocket(endpoint) as unknown as AgentSocket,
+  ) {}
+
+  connect(endpoint: string, token: string) {
+    this.disconnect();
+    this.lastError.value = '';
+
+    let validatedEndpoint: string;
+    try {
+      validatedEndpoint = validateAgentEndpoint(endpoint);
+      validateAgentToken(token);
+    } catch (error) {
+      this.fail(getErrorMessage(error));
+      return;
+    }
+
+    this.status.value = 'connecting';
+    this.connectedEndpoint.value = validatedEndpoint;
+    let authenticationToken = token;
+
+    try {
+      const socket = this.socketFactory(validatedEndpoint);
+      this.socket = socket;
+      socket.addEventListener('open', () => {
+        if (socket !== this.socket) {
+          return;
+        }
+        this.status.value = 'authenticating';
+        this.sendRaw({
+          type: 'authenticate',
+          version: protocolVersion,
+          token: authenticationToken,
+        });
+        authenticationToken = '';
+        this.authenticationTimer = setTimeout(() => {
+          if (!this.authenticated) {
+            this.failAndClose('Agent authentication timed out.');
+          }
+        }, authenticationTimeoutMs);
+      });
+      socket.addEventListener('message', event => {
+        if (socket === this.socket) {
+          this.handleMessage(event.data);
+        }
+      });
+      socket.addEventListener('error', () => {
+        if (socket === this.socket) {
+          this.failAndClose('Agent connection failed.', 1011);
+        }
+      });
+      socket.addEventListener('close', () => {
+        if (socket !== this.socket) {
+          return;
+        }
+        this.clearAuthenticationTimer();
+        this.socket = undefined;
+        this.authenticated = false;
+        this.connectedEndpoint.value = '';
+        if (this.disconnecting) {
+          this.status.value = 'disconnected';
+          this.lastError.value = '';
+        } else if (this.status.value !== 'error') {
+          this.status.value = 'disconnected';
+        }
+        this.disconnecting = false;
+      });
+    } catch (error) {
+      authenticationToken = '';
+      this.fail(getErrorMessage(error));
+    }
+  }
+
+  disconnect() {
+    this.clearAuthenticationTimer();
+    this.authenticated = false;
+    this.connectedEndpoint.value = '';
+    const socket = this.socket;
+    this.socket = undefined;
+    if (socket) {
+      this.disconnecting = true;
+      socket.close(1000, 'Disconnected by user');
+    } else {
+      this.disconnecting = false;
+    }
+    this.status.value = 'disconnected';
+    this.lastError.value = '';
+  }
+
+  private handleMessage(data: unknown) {
+    if (typeof data !== 'string') {
+      this.failAndClose('Only text agent messages are supported.', 1003);
+      return;
+    }
+    if (data.length > maxIncomingMessageSize) {
+      this.failAndClose('Agent message exceeds the size limit.', 1009);
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data) as unknown;
+    } catch {
+      this.sendError(undefined, 'Malformed JSON message.');
+      return;
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      this.sendError(undefined, 'Message must be an object.');
+      return;
+    }
+    const message = parsed as AgentRequest;
+
+    if (!this.authenticated) {
+      if (message.type !== 'authenticated') {
+        this.failAndClose('Agent sent a request before authentication.', 1008);
+        return;
+      }
+      this.clearAuthenticationTimer();
+      this.authenticated = true;
+      this.status.value = 'connected';
+      this.lastError.value = '';
+      return;
+    }
+
+    if (typeof message.id !== 'string' || message.id.length === 0 || message.id.length > 128) {
+      this.sendError(undefined, 'Request id must be a string between 1 and 128 characters.');
+      return;
+    }
+
+    switch (message.type) {
+      case 'list-sources':
+        this.sendRaw({
+          type: 'sources',
+          id: message.id,
+          sources: this.catalog.list(),
+        });
+        break;
+      case 'query':
+        this.handleQuery(message.id, message.query);
+        break;
+      default:
+        this.sendError(message.id, 'Unknown or unauthorized agent request type.');
+        break;
+    }
+  }
+
+  private handleQuery(id: string, query: unknown) {
+    try {
+      const result = this.catalog.query(query as DataQuery);
+      this.sendRaw({ type: 'result', id, result }, id);
+    } catch (error) {
+      this.sendError(id, getErrorMessage(error));
+    }
+  }
+
+  private sendError(id: string | undefined, message: string) {
+    this.sendRaw({
+      type: 'error',
+      ...(id ? { id } : {}),
+      error: message,
+    });
+  }
+
+  private sendRaw(message: object, requestId?: string) {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const serialized = JSON.stringify(message);
+    if (serialized.length > maxOutgoingMessageSize) {
+      const fallback = JSON.stringify({
+        type: 'error',
+        ...(requestId ? { id: requestId } : {}),
+        error: 'Agent response exceeds the size limit. Narrow the query or reduce its limit.',
+      });
+      socket.send(fallback);
+      return;
+    }
+    socket.send(serialized);
+  }
+
+  private failAndClose(message: string, code = 1008) {
+    this.fail(message);
+    const socket = this.socket;
+    this.socket = undefined;
+    socket?.close(code, 'Agent protocol error');
+  }
+
+  private fail(message: string) {
+    this.clearAuthenticationTimer();
+    this.authenticated = false;
+    this.status.value = 'error';
+    this.lastError.value = message;
+    this.connectedEndpoint.value = '';
+  }
+
+  private clearAuthenticationTimer() {
+    if (this.authenticationTimer !== undefined) {
+      clearTimeout(this.authenticationTimer);
+      this.authenticationTimer = undefined;
+    }
+  }
+}
+
+export function validateAgentEndpoint(endpoint: string) {
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw Error('Agent endpoint must be a valid WebSocket URL.');
+  }
+  if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+    throw Error('Agent endpoint must use ws:// or wss://.');
+  }
+  if (url.hostname !== '127.0.0.1' && url.hostname !== '[::1]') {
+    throw Error('Agent endpoint must use the literal loopback address 127.0.0.1 or [::1].');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw Error('Agent endpoint must not contain credentials, query parameters, or a fragment.');
+  }
+  return url.toString();
+}
+
+export function validateAgentToken(token: string) {
+  if (typeof token !== 'string' || token.length < 32 || token.length > 256) {
+    throw Error('Agent token must contain between 32 and 256 characters.');
+  }
+  if ([...token].some(x => x.charCodeAt(0) <= 31 || x.charCodeAt(0) === 127)) {
+    throw Error('Agent token must not contain control characters.');
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/infrastructure/data-catalog/agent-query.ts
+++ b/src/infrastructure/data-catalog/agent-query.ts
@@ -1,0 +1,4 @@
+import { dataCatalog } from '@src/infrastructure/data-catalog';
+import { AgentQueryConnection } from '@src/infrastructure/data-catalog/agent-query-connection';
+
+export const agentQueryConnection = new AgentQueryConnection(dataCatalog);

--- a/src/infrastructure/data-catalog/game-sources.test.ts
+++ b/src/infrastructure/data-catalog/game-sources.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DataCatalog } from '@src/core/data-query/catalog';
+import { gameDataSources } from '@src/infrastructure/data-catalog/game-sources';
+import { request } from '@src/infrastructure/prun-api/data/request-hooks';
+
+const expectedSourceIds = [
+  'alerts',
+  'balances',
+  'blueprints',
+  'company',
+  'contract-drafts',
+  'contracts',
+  'corporation-holdings',
+  'cx-order-books',
+  'cx-orders',
+  'cx-prices',
+  'exchanges',
+  'experts',
+  'flight-plans',
+  'flights',
+  'fx-order-books',
+  'fx-orders',
+  'local-ads',
+  'material-categories',
+  'materials',
+  'planets',
+  'production',
+  'sectors',
+  'ships',
+  'shipyard-projects',
+  'shipyards',
+  'sites',
+  'stars',
+  'stations',
+  'storages',
+  'users',
+  'warehouses',
+  'workforces',
+];
+
+describe('game data sources', () => {
+  it('catalogs the explicit gameplay source set with declared provenance and loaders', () => {
+    expect(gameDataSources.map(x => x.id)).toEqual(expectedSourceIds);
+
+    const byId = new Map(gameDataSources.map(x => [x.id, x]));
+    expect(byId.get('planets')).toMatchObject({
+      provenance: 'fio-reference-with-prun-overrides',
+      warning: expect.stringContaining('stale'),
+    });
+    expect(byId.get('exchanges')?.provenance).toBe('prun-live-with-defaults');
+    expect(byId.get('stations')?.provenance).toBe('prun-live-with-defaults');
+    expect(byId.get('production')?.load?.parameter).toBe('siteId');
+    expect(byId.get('workforces')?.load?.parameter).toBe('siteId');
+    for (const id of ['blueprints', 'cx-orders', 'fx-orders', 'shipyards', 'shipyard-projects']) {
+      expect(byId.get(id)?.load).toBeDefined();
+    }
+  });
+
+  it('lists, snapshots, queries, and exports every real source without requesting data', () => {
+    const requestSpies = Object.keys(request).map(key =>
+      vi.spyOn(request, key as keyof typeof request),
+    );
+    const catalog = new DataCatalog(gameDataSources);
+
+    expect(catalog.list()).toHaveLength(expectedSourceIds.length);
+    for (const sourceId of expectedSourceIds) {
+      catalog.snapshot(sourceId);
+      catalog.query({ sourceId });
+      catalog.export({ sourceId });
+    }
+    for (const spy of requestSpies) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/infrastructure/data-catalog/game-sources.ts
+++ b/src/infrastructure/data-catalog/game-sources.ts
@@ -1,0 +1,324 @@
+import { createCollectionSource, createRecordSource } from '@src/core/data-query/catalog';
+import { DataCompleteness, DataSourceDescriptor, DataProvenance } from '@src/core/data-query/types';
+import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
+import { balancesStore } from '@src/infrastructure/prun-api/data/balances';
+import { blueprintsStore } from '@src/infrastructure/prun-api/data/blueprints';
+import { companyStore } from '@src/infrastructure/prun-api/data/company';
+import { contractDraftsStore } from '@src/infrastructure/prun-api/data/contract-drafts';
+import { contractsStore } from '@src/infrastructure/prun-api/data/contracts';
+import { corporationHoldingsStore } from '@src/infrastructure/prun-api/data/corporation-holdings';
+import { cxobStore } from '@src/infrastructure/prun-api/data/cxob';
+import { cxosStore } from '@src/infrastructure/prun-api/data/cxos';
+import { cxpcStore } from '@src/infrastructure/prun-api/data/cxpc';
+import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
+import { expertsStore } from '@src/infrastructure/prun-api/data/experts';
+import { flightPlansStore } from '@src/infrastructure/prun-api/data/flight-plans';
+import { flightsStore } from '@src/infrastructure/prun-api/data/flights';
+import { fxobStore } from '@src/infrastructure/prun-api/data/fxob';
+import { fxosStore } from '@src/infrastructure/prun-api/data/fxos';
+import { localAdsStore } from '@src/infrastructure/prun-api/data/local-ads';
+import { materialCategoriesStore } from '@src/infrastructure/prun-api/data/material-categories';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { planetsStore } from '@src/infrastructure/prun-api/data/planets';
+import { productionStore } from '@src/infrastructure/prun-api/data/production';
+import { request } from '@src/infrastructure/prun-api/data/request-hooks';
+import { sectorsStore } from '@src/infrastructure/prun-api/data/sectors';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { shipyardProjectsStore } from '@src/infrastructure/prun-api/data/shipyard-projects';
+import { shipyardsStore } from '@src/infrastructure/prun-api/data/shipyards';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { starsStore } from '@src/infrastructure/prun-api/data/stars';
+import { stationsStore } from '@src/infrastructure/prun-api/data/stations';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { usersStore } from '@src/infrastructure/prun-api/data/users';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { workforcesStore } from '@src/infrastructure/prun-api/data/workforces';
+
+const fioWarning =
+  'Reference only: planet data originates from FIO fallback data and may be stale. Live PrUn messages only patch selected fields.';
+
+interface EntitySourceOptions {
+  id: string;
+  label: string;
+  description: string;
+  provenance?: DataProvenance;
+  partial?: boolean;
+  warning?: string;
+  store: {
+    all: Ref<unknown[] | undefined>;
+    fetched: Ref<boolean>;
+  };
+  load?: DataSourceDescriptor['load'];
+}
+
+function entitySource(options: EntitySourceOptions) {
+  const {
+    description,
+    id,
+    label,
+    load,
+    partial = false,
+    provenance = 'prun-live',
+    store,
+    warning,
+  } = options;
+  return createCollectionSource({
+    id,
+    label,
+    description,
+    provenance,
+    completeness: fetchedCompleteness(store.fetched, partial),
+    snapshot: () => store.all.value,
+    ...(warning ? { warning } : {}),
+    ...(load ? { load } : {}),
+  });
+}
+
+function fetchedCompleteness(fetched: Ref<boolean>, partial = false) {
+  return (): DataCompleteness => {
+    if (!fetched.value) {
+      return 'not-loaded';
+    }
+    return partial ? 'partial' : 'complete';
+  };
+}
+
+const blueprintsState = blueprintsStore.peek();
+const shipyardProjectsState = shipyardProjectsStore.peek();
+
+export const gameDataSources: DataSourceDescriptor[] = [
+  entitySource({
+    id: 'alerts',
+    label: 'Alerts',
+    description: 'Current company alerts observed from PrUn.',
+    store: alertsStore,
+  }),
+  entitySource({
+    id: 'balances',
+    label: 'Balances',
+    description: 'Current company currency balances observed from PrUn.',
+    store: balancesStore,
+  }),
+  entitySource({
+    id: 'blueprints',
+    label: 'Blueprints',
+    description: 'Ship blueprints loaded from PrUn.',
+    store: blueprintsState,
+    load: { execute: () => request.blueprints() },
+  }),
+  createRecordSource({
+    id: 'company',
+    label: 'Company',
+    description: 'The current company record observed from PrUn.',
+    provenance: 'prun-live',
+    completeness: () => (companyStore.value === undefined ? 'not-loaded' : 'complete'),
+    snapshotRecord: () => companyStore.value,
+  }),
+  entitySource({
+    id: 'contract-drafts',
+    label: 'Contract Drafts',
+    description: 'Contract drafts observed from PrUn.',
+    store: contractDraftsStore,
+  }),
+  entitySource({
+    id: 'contracts',
+    label: 'Contracts',
+    description: 'Company contracts observed from PrUn.',
+    store: contractsStore,
+  }),
+  entitySource({
+    id: 'corporation-holdings',
+    label: 'Corporation Holdings',
+    description: 'Corporation shareholder holdings observed from PrUn.',
+    store: corporationHoldingsStore,
+  }),
+  entitySource({
+    id: 'cx-order-books',
+    label: 'CX Order Books',
+    description: 'Commodity Exchange broker views observed for individual market tickers.',
+    store: cxobStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'cx-orders',
+    label: 'CX Orders',
+    description: 'The company’s Commodity Exchange orders.',
+    store: { all: cxosStore.passiveAll, fetched: cxosStore.fetched },
+    load: { execute: () => request.cxos() },
+  }),
+  entitySource({
+    id: 'cx-prices',
+    label: 'CX Prices',
+    description: 'Commodity Exchange price histories observed for individual brokers.',
+    store: cxpcStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'exchanges',
+    label: 'Exchanges',
+    description: 'Bundled Commodity Exchange defaults patched by live PrUn data.',
+    provenance: 'prun-live-with-defaults',
+    store: exchangesStore,
+  }),
+  entitySource({
+    id: 'experts',
+    label: 'Experts',
+    description: 'Site expert records observed while visiting expert views.',
+    store: expertsStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'flight-plans',
+    label: 'Flight Plans',
+    description: 'Ship flight plans observed while visiting flight controls.',
+    store: flightPlansStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'flights',
+    label: 'Flights',
+    description: 'Current company flights observed from PrUn.',
+    store: flightsStore,
+  }),
+  entitySource({
+    id: 'fx-order-books',
+    label: 'FX Order Books',
+    description: 'Foreign Exchange broker views observed for individual currency pairs.',
+    store: fxobStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'fx-orders',
+    label: 'FX Orders',
+    description: 'The company’s Foreign Exchange orders.',
+    store: { all: fxosStore.passiveAll, fetched: fxosStore.fetched },
+    load: { execute: () => request.fxos() },
+  }),
+  entitySource({
+    id: 'local-ads',
+    label: 'Local Ads',
+    description: 'Local Market ads observed for individual locations.',
+    store: localAdsStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'material-categories',
+    label: 'Material Categories',
+    description: 'PrUn material categories and their material definitions.',
+    store: materialCategoriesStore,
+  }),
+  entitySource({
+    id: 'materials',
+    label: 'Materials',
+    description: 'PrUn material definitions.',
+    store: materialsStore,
+  }),
+  entitySource({
+    id: 'planets',
+    label: 'Planets',
+    description: 'FIO fallback planet reference data patched with selected live PrUn fields.',
+    provenance: 'fio-reference-with-prun-overrides',
+    warning: fioWarning,
+    store: planetsStore,
+  }),
+  createCollectionSource({
+    id: 'production',
+    label: 'Production',
+    description: 'Production lines observed globally or for explicitly loaded sites.',
+    provenance: 'prun-live',
+    completeness: () => {
+      if (!productionStore.fetched.value) {
+        return 'not-loaded';
+      }
+      return productionStore.fetchedAll.value ? 'complete' : 'partial';
+    },
+    snapshot: () => productionStore.all.value,
+    load: {
+      parameter: 'siteId',
+      execute: siteId => loadSiteData(siteId, request.production),
+    },
+  }),
+  entitySource({
+    id: 'sectors',
+    label: 'Sectors',
+    description: 'Universe sectors observed from PrUn.',
+    store: sectorsStore,
+  }),
+  entitySource({
+    id: 'ships',
+    label: 'Ships',
+    description: 'Current company ships observed from PrUn.',
+    store: shipsStore,
+  }),
+  entitySource({
+    id: 'shipyard-projects',
+    label: 'Shipyard Projects',
+    description: 'Shipyard projects loaded from PrUn.',
+    store: shipyardProjectsState,
+    load: { execute: () => request.shipyardProjects() },
+  }),
+  entitySource({
+    id: 'shipyards',
+    label: 'Shipyards',
+    description: 'Shipyards loaded from PrUn.',
+    store: shipyardsStore,
+    load: { execute: () => request.shipyards() },
+  }),
+  entitySource({
+    id: 'sites',
+    label: 'Sites',
+    description: 'The company’s sites, platforms, and base data observed from PrUn.',
+    store: sitesStore,
+  }),
+  entitySource({
+    id: 'stars',
+    label: 'Stars',
+    description: 'Universe star systems observed from PrUn.',
+    store: starsStore,
+  }),
+  entitySource({
+    id: 'stations',
+    label: 'Stations',
+    description: 'Bundled station defaults patched by live PrUn data.',
+    provenance: 'prun-live-with-defaults',
+    store: stationsStore,
+  }),
+  entitySource({
+    id: 'storages',
+    label: 'Storages',
+    description: 'Company inventories and storage contents observed from PrUn.',
+    store: storagesStore,
+  }),
+  entitySource({
+    id: 'users',
+    label: 'Users',
+    description: 'User records observed while browsing PrUn.',
+    store: usersStore,
+    partial: true,
+  }),
+  entitySource({
+    id: 'warehouses',
+    label: 'Warehouses',
+    description: 'The company’s warehouse records observed from PrUn.',
+    store: warehousesStore,
+  }),
+  entitySource({
+    id: 'workforces',
+    label: 'Workforces',
+    description: 'Workforce data observed for explicitly visited or loaded sites.',
+    store: workforcesStore,
+    partial: true,
+    load: {
+      parameter: 'siteId',
+      execute: siteId => loadSiteData(siteId, request.workforce),
+    },
+  }),
+];
+
+function loadSiteData(siteId: string | undefined, load: (siteId: string) => void) {
+  const site = sitesStore.getById(siteId);
+  if (!site) {
+    throw Error(`Unknown site ID "${siteId ?? ''}".`);
+  }
+  load(site.siteId);
+}

--- a/src/infrastructure/data-catalog/index.ts
+++ b/src/infrastructure/data-catalog/index.ts
@@ -1,0 +1,8 @@
+import { DataCatalog } from '@src/core/data-query/catalog';
+import { gameDataSources } from '@src/infrastructure/data-catalog/game-sources';
+import { tileDataSources } from '@src/infrastructure/data-catalog/tile-sources';
+
+export const dataCatalog = new DataCatalog([...gameDataSources, ...tileDataSources]);
+
+export * from '@src/core/data-query/types';
+export { DataQueryError, parseFilterValue } from '@src/core/data-query/query';

--- a/src/infrastructure/data-catalog/tile-export-providers.test.ts
+++ b/src/infrastructure/data-catalog/tile-export-providers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCollectionSource, DataCatalog } from '@src/core/data-query/catalog';
+import {
+  exportTileDataFromCatalog,
+  listTileDataProviders,
+  registerTileDataProvider,
+} from '@src/infrastructure/data-catalog/tile-export-providers';
+
+function createCatalog() {
+  return new DataCatalog([
+    createCollectionSource({
+      id: 'ships',
+      label: 'Ships',
+      description: 'Ships.',
+      provenance: 'prun-live',
+      completeness: () => 'complete',
+      snapshot: () => [{ registration: 'ABC-123' }],
+    }),
+    createCollectionSource({
+      id: 'flights',
+      label: 'Flights',
+      description: 'Flights.',
+      provenance: 'prun-live',
+      completeness: () => 'partial',
+      snapshot: () => [{ id: 'flight-1' }],
+    }),
+  ]);
+}
+
+describe('tile export providers', () => {
+  it('exports provider datasets with consistent result envelopes and timestamps', () => {
+    const generatedAt = new Date('2026-07-19T12:00:00.000Z');
+    const result = exportTileDataFromCatalog(
+      createCatalog(),
+      {
+        id: 'tile-1',
+        fullCommand: 'FLT',
+        command: 'FLT',
+      },
+      generatedAt,
+      () => ({
+        id: 'tile-1',
+        docked: true,
+        fullCommand: 'FLT',
+        command: 'FLT',
+        gameState: [],
+        extensionState: {},
+      }),
+    );
+
+    expect(result.providerId).toBe('fleet');
+    expect(result.generatedAt).toBe(generatedAt.toISOString());
+    expect(result.tile).toMatchObject({ id: 'tile-1', docked: true });
+    expect(result.datasets).toHaveLength(2);
+    expect(result.datasets.map(x => x.source.id)).toEqual(['ships', 'flights']);
+    expect(result.datasets.every(x => x.generatedAt === result.generatedAt)).toBe(true);
+    expect(result.datasets[0].rows).toEqual([{ registration: 'ABC-123' }]);
+  });
+
+  it('does not invoke loaders when exporting a tile', () => {
+    const loader = vi.fn();
+    const catalog = new DataCatalog([
+      createCollectionSource({
+        id: 'ships',
+        label: 'Ships',
+        description: 'Ships.',
+        provenance: 'prun-live',
+        completeness: () => 'not-loaded',
+        snapshot: () => undefined,
+        load: { execute: loader },
+      }),
+      createCollectionSource({
+        id: 'flights',
+        label: 'Flights',
+        description: 'Flights.',
+        provenance: 'prun-live',
+        completeness: () => 'not-loaded',
+        snapshot: () => undefined,
+      }),
+    ]);
+
+    exportTileDataFromCatalog(
+      catalog,
+      { id: 'tile-1', fullCommand: 'FLT', command: 'FLT' },
+      new Date(),
+      () => undefined,
+    );
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('supports explicit provider registration and rejects duplicates', () => {
+    const id = `test-${Date.now()}`;
+    registerTileDataProvider({
+      id,
+      matches: () => false,
+      queries: () => [],
+    });
+    expect(listTileDataProviders().some(x => x.id === id)).toBe(true);
+    expect(() =>
+      registerTileDataProvider({
+        id,
+        matches: () => false,
+        queries: () => [],
+      }),
+    ).toThrow();
+  });
+});

--- a/src/infrastructure/data-catalog/tile-export-providers.ts
+++ b/src/infrastructure/data-catalog/tile-export-providers.ts
@@ -1,0 +1,159 @@
+import { DataCatalog } from '@src/core/data-query/catalog';
+import { DataQuery, DataQueryResult } from '@src/core/data-query/types';
+import type { RenderedTileMetadata } from '@src/infrastructure/data-catalog/tile-sources';
+
+export interface TileExportContext {
+  id: string;
+  fullCommand: string;
+  command: string;
+  parameter?: string;
+}
+
+export interface TileDataProvider {
+  id: string;
+  matches(context: TileExportContext): boolean;
+  queries(context: TileExportContext): DataQuery[];
+}
+
+export interface TileDataExportResult {
+  generatedAt: string;
+  tile: RenderedTileMetadata | TileExportContext;
+  providerId?: string;
+  datasets: DataQueryResult[];
+}
+
+const providers: TileDataProvider[] = [
+  provider('buildings', ['BBL'], context =>
+    context.parameter
+      ? [query('sites', filter('siteId', 'startsWith', context.parameter))]
+      : [query('sites')],
+  ),
+  provider('blueprints', ['BLU'], context =>
+    context.parameter
+      ? [query('blueprints', filter('naturalId', 'eq', context.parameter))]
+      : [query('blueprints')],
+  ),
+  provider('base', ['BS'], context => {
+    if (!context.parameter) {
+      return [query('sites'), query('workforces'), query('production')];
+    }
+    return [
+      query('sites', undefined, context.parameter),
+      query('workforces', undefined, context.parameter),
+      query('production', undefined, context.parameter),
+    ];
+  }),
+  provider('contract-drafts', ['CONTD'], context =>
+    context.parameter
+      ? [query('contract-drafts', filter('naturalId', 'eq', context.parameter))]
+      : [query('contract-drafts')],
+  ),
+  provider('contracts', ['CONTS'], () => [query('contracts')]),
+  provider('contract', ['CONT'], context => [
+    query('contracts', filter('localId', 'eq', context.parameter)),
+  ]),
+  provider('cx-order-book', ['CXOB', 'CXPO'], context => [
+    query('cx-order-books', filter('ticker', 'eq', context.parameter)),
+  ]),
+  provider('cx-orders', ['CXOS'], () => [query('cx-orders')]),
+  provider('fx-orders', ['FXOS'], () => [query('fx-orders')]),
+  provider('fleet', ['FLT'], () => [query('ships'), query('flights')]),
+  provider('inventory', ['INV'], context =>
+    context.parameter
+      ? [query('storages', filter('id', 'startsWith', context.parameter))]
+      : [query('storages')],
+  ),
+  provider('alerts', ['NOTS'], () => [query('alerts')]),
+  provider('production', ['PROD'], context =>
+    context.parameter
+      ? [query('production', filter('siteId', 'startsWith', context.parameter))]
+      : [query('production')],
+  ),
+  provider('ship', ['SHP'], context => [
+    query('ships', filter('registration', 'eq', context.parameter)),
+  ]),
+  provider('shipyard-project', ['SHYP'], context =>
+    context.parameter
+      ? [query('shipyard-projects', filter('id', 'startsWith', context.parameter))]
+      : [query('shipyard-projects')],
+  ),
+  provider('workforce', ['WF'], context => [
+    query('workforces', filter('siteId', 'startsWith', context.parameter)),
+  ]),
+  {
+    id: 'xit-contracts',
+    matches: context => context.fullCommand.toUpperCase().startsWith('XIT CONTS'),
+    queries: () => [query('contracts')],
+  },
+  {
+    id: 'xit-cx-orders',
+    matches: context => context.fullCommand.toUpperCase().startsWith('XIT CXTS'),
+    queries: () => [query('cx-orders')],
+  },
+  {
+    id: 'xit-fx-orders',
+    matches: context => context.fullCommand.toUpperCase().startsWith('XIT FXTS'),
+    queries: () => [query('fx-orders')],
+  },
+];
+
+export function registerTileDataProvider(provider: TileDataProvider) {
+  if (providers.some(x => x.id === provider.id)) {
+    throw Error(`Duplicate tile data provider ID "${provider.id}".`);
+  }
+  providers.push(provider);
+}
+
+export function listTileDataProviders() {
+  return [...providers];
+}
+
+export function exportTileDataFromCatalog(
+  catalog: DataCatalog,
+  context: TileExportContext,
+  generatedAt = new Date(),
+  resolveTileMetadata: (id: string) => RenderedTileMetadata | undefined = () => undefined,
+): TileDataExportResult {
+  const provider = providers.find(x => x.matches(context));
+  const datasets =
+    provider?.queries(context).map(query => catalog.export(query, generatedAt)) ?? [];
+  return {
+    generatedAt: generatedAt.toISOString(),
+    tile: resolveTileMetadata(context.id) ?? context,
+    ...(provider ? { providerId: provider.id } : {}),
+    datasets,
+  };
+}
+
+function provider(
+  id: string,
+  commands: string[],
+  queries: (context: TileExportContext) => DataQuery[],
+): TileDataProvider {
+  const commandSet = new Set(commands);
+  return {
+    id,
+    matches: context => commandSet.has(context.command),
+    queries,
+  };
+}
+
+function query(sourceId: string, dataFilter?: DataQuery['filters'], search?: string): DataQuery {
+  return {
+    sourceId,
+    ...(search ? { search } : {}),
+    ...(dataFilter ? { filters: dataFilter } : {}),
+    limit: 5000,
+  };
+}
+
+function filter(
+  path: string,
+  operator: NonNullable<DataQuery['filters']>[number]['operator'],
+  value: unknown,
+): DataQuery['filters'] {
+  if (value === undefined) {
+    return [];
+  }
+  return [{ path, operator, value }];
+}

--- a/src/infrastructure/data-catalog/tile-sources.ts
+++ b/src/infrastructure/data-catalog/tile-sources.ts
@@ -1,0 +1,131 @@
+import { createCollectionSource } from '@src/core/data-query/catalog';
+import { DataSourceDescriptor } from '@src/core/data-query/types';
+import { screensStore } from '@src/infrastructure/prun-api/data/screens';
+import { tilesStore } from '@src/infrastructure/prun-api/data/tiles';
+import { uiDataStore } from '@src/infrastructure/prun-api/data/ui-data';
+import tiles from '@src/infrastructure/prun-ui/tiles';
+import { userData } from '@src/store/user-data';
+import { deepToRaw } from '@src/utils/deep-to-raw';
+
+export interface StoredLayoutTileMetadata {
+  id: string;
+  parentId: string | null;
+  screenId?: string;
+  screenName?: string;
+  content: string | null;
+  command?: string;
+  parameter?: string;
+  container: PrunApi.TileContainer | null;
+  gameState: Array<{ key: string; value: string }>;
+  extensionState: Record<string, unknown>;
+}
+
+export interface RenderedTileMetadata {
+  id: string;
+  docked: boolean;
+  fullCommand: string;
+  command: string;
+  parameter?: string;
+  gameState: Array<{ key: string; value: string }>;
+  extensionState: Record<string, unknown>;
+}
+
+export const tileDataSources: DataSourceDescriptor[] = [
+  createCollectionSource({
+    id: 'stored-layout-tiles',
+    label: 'Stored Layout Tiles',
+    description:
+      'Serializable tile nodes from saved PrUn layouts, with narrowly scoped tile state.',
+    provenance: 'prun-live',
+    completeness: () => (tilesStore.fetched.value ? 'complete' : 'not-loaded'),
+    snapshot: snapshotStoredLayoutTiles,
+  }),
+  createCollectionSource({
+    id: 'active-rendered-tiles',
+    label: 'Active Rendered Tiles',
+    description:
+      'Serializable metadata for tiles currently rendered in APEX. DOM and framework objects are excluded.',
+    provenance: 'prun-live',
+    completeness: () => 'complete',
+    snapshot: snapshotRenderedTiles,
+  }),
+];
+
+export function snapshotStoredLayoutTiles(): StoredLayoutTileMetadata[] | undefined {
+  const storedTiles = tilesStore.all.value;
+  if (!storedTiles) {
+    return undefined;
+  }
+
+  const screens = screensStore.all.value ?? [];
+  const screensById = new Map(screens.map(x => [x.id, x]));
+  const tilesById = new Map(storedTiles.map(x => [x.id, x]));
+
+  return storedTiles.map(tile => {
+    const screen = findScreen(tile, screensById, tilesById);
+    const command = parseCommand(tile.content);
+    return {
+      id: tile.id,
+      parentId: tile.parentId,
+      ...(screen ? { screenId: screen.id, screenName: screen.name } : {}),
+      content: tile.content,
+      ...(command?.command ? { command: command.command } : {}),
+      ...(command?.parameter ? { parameter: command.parameter } : {}),
+      container: tile.container ? { ...tile.container } : null,
+      gameState: getGameState(tile.id),
+      extensionState: getExtensionState(tile.id),
+    };
+  });
+}
+
+export function snapshotRenderedTiles(): RenderedTileMetadata[] {
+  return tiles.snapshotMetadata().map(tile => ({
+    ...tile,
+    gameState: getGameState(tile.id),
+    extensionState: getExtensionState(tile.id),
+  }));
+}
+
+export function getRenderedTileMetadata(id: string) {
+  return snapshotRenderedTiles().find(x => x.id === id);
+}
+
+function findScreen(
+  tile: PrunApi.Tile,
+  screens: Map<string, PrunApi.Screen>,
+  storedTiles: Map<string, PrunApi.Tile>,
+) {
+  let parentId = tile.parentId;
+  const visited = new Set<string>();
+  while (parentId && !visited.has(parentId)) {
+    visited.add(parentId);
+    const screen = screens.get(parentId);
+    if (screen) {
+      return screen;
+    }
+    parentId = storedTiles.get(parentId)?.parentId ?? null;
+  }
+  return undefined;
+}
+
+function parseCommand(content: string | null) {
+  if (!content) {
+    return undefined;
+  }
+  const trimmed = content.trim();
+  const space = trimmed.indexOf(' ');
+  return {
+    command: (space === -1 ? trimmed : trimmed.slice(0, space)).toUpperCase(),
+    ...(space === -1 ? {} : { parameter: trimmed.slice(space + 1) }),
+  };
+}
+
+function getGameState(id: string) {
+  return (uiDataStore.tileStates ?? [])
+    .filter(x => x.containerId === id)
+    .map(x => ({ key: x.key, value: x.value }));
+}
+
+function getExtensionState(id: string) {
+  return deepToRaw((userData.tileState[id] ?? {}) as Record<string, unknown>);
+}

--- a/src/infrastructure/prun-api/data/cxos.ts
+++ b/src/infrastructure/prun-api/data/cxos.ts
@@ -38,4 +38,5 @@ export const cxosStore = {
   ...state,
   all,
   active,
+  passiveAll: state.all,
 };

--- a/src/infrastructure/prun-api/data/fxos.ts
+++ b/src/infrastructure/prun-api/data/fxos.ts
@@ -38,4 +38,5 @@ export const fxosStore = {
   ...state,
   all,
   active,
+  passiveAll: state.all,
 };

--- a/src/infrastructure/prun-api/data/production.ts
+++ b/src/infrastructure/prun-api/data/production.ts
@@ -94,5 +94,6 @@ const getBySiteId = (value?: string | null) => {
 
 export const productionStore = {
   ...state,
+  fetchedAll,
   getBySiteId,
 };

--- a/src/infrastructure/prun-api/data/request-hooks.test.ts
+++ b/src/infrastructure/prun-api/data/request-hooks.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRequestStore } from '@src/infrastructure/prun-api/data/request-hooks';
+
+describe('createRequestStore passive access', () => {
+  it('requests through wrapped properties but never through peek', () => {
+    const request = vi.fn();
+    const source = { value: { current: 1 } };
+    const wrapped = createRequestStore(request, source);
+
+    expect(wrapped.peek()).toBe(source);
+    expect(wrapped.peek().value).toEqual({ current: 1 });
+    expect(request).not.toHaveBeenCalled();
+
+    expect(wrapped.value).toEqual({ current: 1 });
+    expect(request).toHaveBeenCalledOnce();
+  });
+});

--- a/src/infrastructure/prun-api/data/request-hooks.ts
+++ b/src/infrastructure/prun-api/data/request-hooks.ts
@@ -15,9 +15,15 @@ interface RequestHooks {
 }
 
 let hooks: RequestHooks | undefined = undefined;
+const requestTransportAvailable = ref(false);
 
 export function implementRequestHooks(newHooks: RequestHooks) {
   hooks = newHooks;
+  requestTransportAvailable.value = true;
+}
+
+export function isRequestTransportAvailable() {
+  return requestTransportAvailable.value;
 }
 
 export const request = {
@@ -65,7 +71,7 @@ export function createRequestGetter<T, K>(
   };
 }
 
-type RequestStore<T> = T & { request(): void };
+type RequestStore<T> = T & { request(): void; peek(): T };
 
 export function createRequestStore<T>(request: () => void, store: T): RequestStore<T> {
   const wrapped = {} as RequestStore<T>;
@@ -78,5 +84,6 @@ export function createRequestStore<T>(request: () => void, store: T): RequestSto
     });
   }
   wrapped.request = request;
+  wrapped.peek = () => store;
   return wrapped;
 }

--- a/src/infrastructure/prun-ui/tile-data-export.ts
+++ b/src/infrastructure/prun-ui/tile-data-export.ts
@@ -1,29 +1,15 @@
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { downloadJson } from '@src/utils/json-file';
-import { userData } from '@src/store/user-data';
-import { uiDataStore } from '@src/infrastructure/prun-api/data/ui-data';
-import { deepToRaw } from '@src/utils/deep-to-raw';
-import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
-import { flightsStore } from '@src/infrastructure/prun-api/data/flights';
-import { contractsStore } from '@src/infrastructure/prun-api/data/contracts';
-import { contractDraftsStore } from '@src/infrastructure/prun-api/data/contract-drafts';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { blueprintsStore } from '@src/infrastructure/prun-api/data/blueprints';
-import { workforcesStore } from '@src/infrastructure/prun-api/data/workforces';
-import { productionStore } from '@src/infrastructure/prun-api/data/production';
-import { cxobStore } from '@src/infrastructure/prun-api/data/cxob';
-import { cxosStore } from '@src/infrastructure/prun-api/data/cxos';
-import { getInvStore } from '@src/core/store-id';
-import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
-import { shipyardProjectsStore } from '@src/infrastructure/prun-api/data/shipyard-projects';
+import { dataCatalog } from '@src/infrastructure/data-catalog';
+import { exportTileDataFromCatalog } from '@src/infrastructure/data-catalog/tile-export-providers';
+import { getRenderedTileMetadata } from '@src/infrastructure/data-catalog/tile-sources';
 
 export function initTileDataExport() {
   subscribe($$(document, C.TileFrame.cmd), cmd => {
     cmd.addEventListener('click', e => {
       if (e.altKey) {
         const tile = cmd.closest(`.${C.Tile.tile}`) as HTMLElement;
-        exportTileData(tile, cmd.textContent!.trim());
+        downloadTileData(tile, cmd.textContent!.trim());
         e.preventDefault();
         e.stopPropagation();
         return false;
@@ -33,185 +19,22 @@ export function initTileDataExport() {
   });
 }
 
-function exportTileData(el: HTMLElement, command: string) {
+function downloadTileData(el: HTMLElement, fullCommand: string) {
   const id = getPrunId(el);
   if (!id) {
     return;
   }
-  const data = {
-    id,
-    command,
-    state: {
-      game: uiDataStore.tileStates.find(x => x.containerId === id) ?? {},
-      rprun: userData.tileState[id] ?? {},
+  const space = fullCommand.indexOf(' ');
+  const data = exportTileDataFromCatalog(
+    dataCatalog,
+    {
+      id,
+      fullCommand,
+      command: (space === -1 ? fullCommand : fullCommand.slice(0, space)).toUpperCase(),
+      ...(space === -1 ? {} : { parameter: fullCommand.slice(space + 1) }),
     },
-    data: deepToRaw(getTileData(command)),
-  };
-  downloadJson(data, `${data.command} ${id}.json`);
-}
-
-function getTileData(command: string): object {
-  command = command.toUpperCase();
-
-  if (command.startsWith('BBL ')) {
-    const id = command.replace('BBL ', '').trim();
-    return {
-      buildings: sitesStore.getById(id)?.platforms,
-    };
-  }
-
-  if (command.startsWith('BLU ')) {
-    const id = command.replace('BLU ', '').trim();
-    if (id) {
-      return {
-        blueprint: blueprintsStore.getByNaturalId(id),
-      };
-    }
-    return {
-      blueprints: blueprintsStore.all.value,
-    };
-  }
-
-  if (command.startsWith('BS ')) {
-    const naturalId = command.replace('BS ', '').trim();
-    if (naturalId) {
-      const site = sitesStore.getByPlanetNaturalId(naturalId);
-      return {
-        site,
-        workforce: workforcesStore.getById(site?.siteId),
-        production: productionStore.getBySiteId(site?.siteId),
-      };
-    }
-    return {
-      sites: sitesStore.all.value,
-      workforce: workforcesStore.all.value,
-      production: productionStore.all.value,
-    };
-  }
-
-  if (command.startsWith('CONTD ')) {
-    const id = command.replace('CONTD ', '').trim();
-    if (id) {
-      return {
-        draft: contractDraftsStore.getByNaturalId(id),
-      };
-    }
-    return {
-      drafts: contractDraftsStore.all.value,
-    };
-  }
-
-  if (command.startsWith('CONTS')) {
-    return {
-      contracts: contractsStore.all.value,
-    };
-  }
-
-  if (command.startsWith('XIT CONTS')) {
-    let contracts = contractsStore.all.value;
-    if (contracts) {
-      contracts = contracts.filter(
-        x =>
-          x.status === 'OPEN' ||
-          x.status === 'CLOSED' ||
-          x.status === 'PARTIALLY_FULFILLED' ||
-          x.status === 'DEADLINE_EXCEEDED',
-      );
-    }
-    return {
-      contracts: contracts,
-    };
-  }
-
-  if (command.startsWith('CONT ')) {
-    const id = command.replace('CONT ', '').trim();
-    return {
-      contract: contractsStore.getByLocalId(id),
-    };
-  }
-
-  if (command.startsWith('CXOB ')) {
-    const ticker = command.replace('CXOB ', '').trim();
-    return {
-      orderBook: cxobStore.getByTicker(ticker),
-    };
-  }
-
-  if (command.startsWith('CXOS')) {
-    return {
-      orders: cxosStore.all.value,
-    };
-  }
-
-  if (command.startsWith('CXPO ')) {
-    const ticker = command.replace('CXPO ', '').trim();
-    return {
-      orderBook: cxobStore.getByTicker(ticker),
-    };
-  }
-
-  if (command.startsWith('FLT')) {
-    return {
-      ships: shipsStore.all.value,
-      flights: flightsStore.all.value,
-    };
-  }
-
-  if (command.startsWith('INV ')) {
-    const parameter = command.replace('INV ', '').trim();
-    if (parameter) {
-      return {
-        store: getInvStore(parameter),
-      };
-    }
-    return {
-      stores: storagesStore.all.value,
-    };
-  }
-
-  if (command.startsWith('NOTS')) {
-    return {
-      alerts: alertsStore.all.value,
-    };
-  }
-
-  if (command.startsWith('PROD ')) {
-    const id = command.replace('PROD ', '').trim();
-    if (id) {
-      return {
-        production: productionStore.getBySiteId(id),
-      };
-    }
-    return {
-      production: productionStore.all.value,
-    };
-  }
-
-  if (command.startsWith('SHP ')) {
-    const id = command.replace('SHP ', '').trim();
-    return {
-      ship: shipsStore.getByRegistration(id),
-    };
-  }
-
-  if (command.startsWith('SHYP ')) {
-    const id = command.replace('SHYP ', '').trim();
-    if (id) {
-      return {
-        project: shipyardProjectsStore.getById(id),
-      };
-    }
-    return {
-      projects: shipyardProjectsStore.all.value,
-    };
-  }
-
-  if (command.startsWith('WF ')) {
-    const id = command.replace('WF ', '').trim();
-    return {
-      workforce: workforcesStore.getById(id),
-    };
-  }
-
-  return {};
+    new Date(),
+    getRenderedTileMetadata,
+  );
+  downloadJson(data, `${data.tile.command} ${id}.json`, { pretty: true });
 }

--- a/src/infrastructure/prun-ui/tiles.ts
+++ b/src/infrastructure/prun-ui/tiles.ts
@@ -32,6 +32,10 @@ function reconciliate(mutations: MutationRecord[]) {
     return;
   }
 
+  activateExistingFrames();
+}
+
+function activateExistingFrames() {
   const frameElements = document.getElementsByClassName(C.TileFrame.frame);
   if (frameElements.length === activeTiles.length) {
     let sameTiles = true;
@@ -159,11 +163,45 @@ function findByContainer(container?: HTMLElement | null) {
   return activeTiles.filter(tile => tile.container === container);
 }
 
+export interface ActiveTileMetadata {
+  id: string;
+  docked: boolean;
+  fullCommand: string;
+  command: string;
+  parameter?: string;
+}
+
+function snapshotActiveTileMetadata(): ActiveTileMetadata[] {
+  const metadata: ActiveTileMetadata[] = [];
+  const frameElements = document.getElementsByClassName(C.TileFrame.frame);
+  for (let i = 0; i < frameElements.length; i++) {
+    const frame = frameElements[i];
+    const tileElement = frame.parentElement;
+    const container = tileElement?.parentElement;
+    const commandElement = _$(frame, C.TileFrame.cmd);
+    const id = tileElement ? getPrunId(tileElement) : undefined;
+    if (!container || !commandElement || !id) {
+      continue;
+    }
+    const fullCommand = commandElement.textContent?.trim() ?? '';
+    const indexOfSpace = fullCommand.indexOf(' ');
+    metadata.push({
+      id,
+      docked: !container.classList.contains(C.Window.body),
+      fullCommand,
+      command: (indexOfSpace > 0 ? fullCommand.slice(0, indexOfSpace) : fullCommand).toUpperCase(),
+      ...(indexOfSpace > 0 ? { parameter: fullCommand.slice(indexOfSpace + 1) } : {}),
+    });
+  }
+  return metadata;
+}
+
 const tiles = {
   observe: observeTiles,
   observeAll: observeAllTiles,
   find: findTiles,
   findByContainer,
+  snapshotMetadata: snapshotActiveTileMetadata,
 };
 
 export default tiles;


### PR DESCRIPTION
## Summary

- add an explicit passive catalog for gameplay/domain stores with provenance and completeness metadata
- add a transport-independent query engine with typed filters, nested paths, sorting, limits, and stable result envelopes
- add `XIT DATA` for interactive querying, JSON export, explicit source loading, and an opt-in authenticated loopback agent connection
- catalog stored/rendered tile metadata and move Alt-click tile exports onto the same passive provider system

This branch is based directly on the current target `main`, so the diff contains the feature only and no unrelated branch history.

## Safety and data semantics

- selecting, previewing, querying, exporting, and agent querying are passive reads
- lazy/request-wrapped stores expose inert snapshots and are covered by tests proving reads do not trigger requests
- data loading remains an explicit UI action; site-scoped loaders require a site ID
- the agent connection is disabled by default, authenticated with an in-memory token, read-only, and loopback-only
- reference/default/partial datasets are labeled rather than presented as globally complete live data
- no data is automatically transmitted outside the extension

## Validation

- `pnpm run compile`
- `pnpm run lint`
- `pnpm run test` — 6 files, 51 tests
- `pnpm run build`

Manual in-game verification is intentionally pending so the currently enabled local feature build is not switched during this isolated port.