### PR TITLE
SFC: commodity exchange shortcut buttons on the destination field

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,11 @@ Browser extension for Prosperous Universe. Intercepts the game's WebSocket and D
 
 Stack: TypeScript, Vue 3, Vite (content scripts), CSS Modules. Package manager: pnpm.
 
+A fresh clone has no `node_modules` — run `pnpm install --frozen-lockfile` before
+`pnpm run compile` / `pnpm run lint`, or `tsc` reports missing `chrome`/`node`/`vite/client`
+type libraries, which reads like a broken tsconfig rather than a missing install. Cloud
+sessions (Claude Code on the web) always start from a fresh clone.
+
 ## Path Aliases
 
 | Alias | Resolves to |

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -398,7 +398,32 @@ sitesStore.fetched.value  // boolean
 Map getters are keyed by API values, which don't always match what the game UI shows:
 
 - `materialsStore.getByName` is keyed by the API's camelCase internal name (`basicRations`). UI text holds the i18n **display** name ("Basic Rations") — resolve that with `getMaterialByName` from `@src/infrastructure/prun-ui/i18n` instead (reverse direction: `getMaterialName`).
-- `stationsStore.getByNaturalId` is keyed by the station's **own** natural id (`MOR`), but game address fields canonicalize stations to their **system** id (`OT-580`). To resolve a system id to its station, search `stationsStore.all.value` by `getSystemLineFromAddress(x.address)?.entity.naturalId`.
+- `stationsStore.getByNaturalId` is keyed by the station's **own** natural id (`MOR`), but game address fields canonicalize stations to their **system** id (`OT-580`). To resolve a system id to its station, search `stationsStore.all.value` by `getSystemLineFromAddress(x.address)?.entity.naturalId` (exported as `findStationBySystemId` from `@src/infrastructure/prun-ui/utils/select-address`).
+- `ship.address` is `null` while the ship is in flight. Docked, `getEntityNaturalIdFromAddress(ship.address)` gives the station's **own** natural id (`ANT`) — not the system id — so it compares directly against `stationsStore.getByNaturalId` keys.
+
+---
+
+## Filling an AddressSelector
+
+`selectAddress(container, locationName)` from `@src/infrastructure/prun-ui/utils/select-address`
+fills any game address field (`C.AddressSelector.container`): it translates a station/system
+id to the station name, types it, waits for the suggestion list, and clicks the entry.
+
+```ts
+subscribe($$(tile.anchor, C.AddressSelector.container), container => {
+  // "ANT", "OT-580b", "Moria Station" — all resolve.
+  button.onclick = () => selectAddress(container, 'ANT');
+});
+```
+
+Don't hand-roll this. Suggestions render in `#autosuggest-portal` **outside** the tile DOM,
+the first list shown is a stale default (own bases, warehouses, CX stations) that arrives
+before the typed query's server round-trip, and bare station ids never appear as suggestion
+text — every one of those is a trap the helper already handles. Typing fires a read-only
+`NOMENCLATURE_QUERY_ADDRESSES` lookup, so the call must stay behind a user click.
+
+> ACT's `action-steps/cont-utils.ts` still carries its own weaker `selectLocation`. Migrate
+> it if you touch those code paths.
 
 ---
 

--- a/docs/game/game-concepts.md
+++ b/docs/game/game-concepts.md
@@ -138,6 +138,7 @@ Experts provide fixed bonus multipliers to production line efficiency in their i
 
 ### Commodity Exchange (CX)
 - Located on space stations. 4 major: Benten (CI1), Moria (NC1), Hortus (IC1), Antares (AI1). 2 factionless: Arclight (CI2), Hubur (NC2).
+- The exchange MIC is not the station id. Station natural ids are `BEN`, `MOR`, `HRT`, `ANT`, `ARC`, `HUB` (see `stations.default.ts`); their system ids are `UV-351`, `OT-580`, `VH-331`, `ZV-307`, `AM-783`, `TD-203`.
 - The trading is done via trade books. Each material has its own trade book.
 - Buy/Sell orders placed within Price Band (3-day average).
 - Orders match: lowest ask filled first on buys, highest bid first on sells.

--- a/src/features/basic/contd-paste-import/contd-paste-import.tsx
+++ b/src/features/basic/contd-paste-import/contd-paste-import.tsx
@@ -19,13 +19,13 @@ import {
   importMaterials,
   isLoanTemplate,
   readDraftSpec,
-  selectLocation,
   selectTemplateType,
   setAutoProvision,
   setCurrency,
   setDeadline,
   setShipPrice,
 } from './draft-form';
+import { selectAddress } from '@src/infrastructure/prun-ui/utils/select-address';
 import $style from './contd-paste-import.module.css';
 
 // Fills the template panel from the spec, in dependency order: the template
@@ -59,7 +59,7 @@ async function importSpec(anchor: Element, spec: ContractDraftSpec): Promise<str
   const addresses = _$$(anchor, C.AddressSelector.container);
   const fillAddress = async (index: number, name: string, label: string) => {
     const address = addresses.at(index);
-    if (!address || !(await selectLocation(address, name))) {
+    if (!address || !(await selectAddress(address, name))) {
       issues.push(`${label} ${name}`);
     }
   };

--- a/src/features/basic/contd-paste-import/draft-form.ts
+++ b/src/features/basic/contd-paste-import/draft-form.ts
@@ -5,12 +5,12 @@ import {
   focusElement,
   selectMaterialInMaterialSelector,
 } from '@src/util';
-import { sleep } from '@src/utils/sleep';
+import { waitFor } from '@src/utils/wait-for';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 import { planetsStore } from '@src/infrastructure/prun-api/data/planets';
 import { stationsStore } from '@src/infrastructure/prun-api/data/stations';
-import { getSystemLineFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { getMaterialByName } from '@src/infrastructure/prun-ui/i18n';
+import { findStationBySystemId } from '@src/infrastructure/prun-ui/utils/select-address';
 import { ContractDraftSpec, MaterialEntry, TemplateType } from './parsers';
 
 // DOM fillers for the CONTD template panel. Adapted from the helpers in
@@ -19,17 +19,6 @@ import { ContractDraftSpec, MaterialEntry, TemplateType } from './parsers';
 // fills one form field, and reports success. Nothing here clicks "apply
 // template", "cancel", or any save button — those are server actions and stay
 // with the user.
-
-async function waitFor(condition: () => boolean, timeout = 5000, interval = 100): Promise<boolean> {
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    if (condition()) {
-      return true;
-    }
-    await sleep(interval);
-  }
-  return false;
-}
 
 function findTemplateSelect(anchor: Element) {
   const container = _$(anchor, C.TemplateSelection.templateTypeSelect);
@@ -103,69 +92,6 @@ function findAnyCurrencySelect(anchor: Element) {
       .filter(value => value !== '');
     return values.length > 0 && values.every(value => /^[A-Z]{3}$/.test(value));
   });
-}
-
-// The station store keys getByNaturalId by the station's OWN natural id
-// ("MOR" for Moria Station), but the AddressSelector canonicalizes a picked
-// station to its SYSTEM id ("OT-580") — resolving the form value needs a
-// search by the address's system line instead.
-function findStationBySystemId(id: string) {
-  const needle = id.toUpperCase();
-  return stationsStore.all.value?.find(
-    x => getSystemLineFromAddress(x.address)?.entity.naturalId.toUpperCase() === needle,
-  );
-}
-
-// AddressSelector suggestions are rendered in #autosuggest-portal outside the
-// tile DOM. Only one portal can be open at a time, so we search it directly.
-// Typing fires a read-only NOMENCLATURE_QUERY_ADDRESSES lookup to the game
-// server; selecting a suggestion is pure local form state.
-export async function selectLocation(container: Element, locationName: string): Promise<boolean> {
-  const input = _$(container, C.AddressSelector.input) as HTMLInputElement | undefined;
-  const portal = document.getElementById('autosuggest-portal');
-  if (!input || !portal) {
-    return false;
-  }
-
-  // Bare station/system ids are un-typeable: a station suggestion renders as
-  // "Moria Station (Moria)" — its id never appears as suggestion text, so a
-  // pasted "OT-580" would only ever substring-match a moon like OT-580e.
-  // Translate the id to the station name up front, looking up by system id
-  // (what the form and exports hold) and by station id (a hand-written
-  // "MOR"). Planet ids (OT-580b) do render in suggestions and pass through
-  // untouched.
-  const query =
-    findStationBySystemId(locationName)?.name ??
-    stationsStore.getByNaturalId(locationName)?.name ??
-    locationName;
-
-  focusElement(input);
-  changeInputValue(input, query);
-
-  // The portal first renders a default list (own bases, warehouses, CX
-  // stations) for the empty focus query, and the typed query's search results
-  // only arrive after a server round-trip — so wait for an entry that actually
-  // matches the name instead of clicking into the stale default list. Matching
-  // requires a word boundary around the query, because natural ids prefix each
-  // other ("OT-580b" is a prefix of nothing, but "OT-580" prefixes every moon
-  // in the system, and the default list can hold several) — a boundary match
-  // hits "Montem (OT-580b)" but not "OT-580br". Only when no boundary match
-  // arrives within the timeout does a plain substring match get one shot,
-  // keeping tolerance for odd human-entered fragments. No match at all leaves
-  // the field for the user rather than guessing.
-  const boundary = new RegExp(`(^|\\W)${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\W|$)`, 'i');
-  const suggestions = () => _$$(portal, C.AddressSelector.suggestionContent) as HTMLElement[];
-  const findBoundaryMatch = () => suggestions().find(s => boundary.test(s.textContent ?? ''));
-  await waitFor(() => !!findBoundaryMatch(), 5000);
-  const match =
-    findBoundaryMatch() ??
-    suggestions().find(s => s.textContent?.trim().toLowerCase().includes(query.toLowerCase()));
-  if (!match) {
-    return false;
-  }
-
-  await clickElement(match);
-  return true;
 }
 
 // The SHIP template has a single price field the game charges once per

--- a/src/features/basic/sfc-exchange-destinations.module.css
+++ b/src/features/basic/sfc-exchange-destinations.module.css
@@ -1,0 +1,25 @@
+/* The address selector is the input's own react-autosuggest wrapper — the
+   suggestion list lives in #autosuggest-portal, so laying it out as a row only
+   affects the input and the appended buttons. */
+.container {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.buttons {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 3px;
+}
+
+.button {
+  margin: 0;
+  padding-left: 5px;
+  padding-right: 5px;
+}

--- a/src/features/basic/sfc-exchange-destinations.tsx
+++ b/src/features/basic/sfc-exchange-destinations.tsx
@@ -1,6 +1,5 @@
 import PrunButton from '@src/components/PrunButton.vue';
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
-import { stationsStore } from '@src/infrastructure/prun-api/data/stations';
 import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { selectAddress } from '@src/infrastructure/prun-ui/utils/select-address';
 import $style from './sfc-exchange-destinations.module.css';
@@ -28,7 +27,6 @@ function onTileReady(tile: PrunTile) {
             inline
             disabled={location.value === naturalId}
             class={$style.button}
-            data-tooltip={stationsStore.getByNaturalId(naturalId)?.name ?? naturalId}
             onClick={() => selectAddress(container, naturalId)}>
             {naturalId}
           </PrunButton>

--- a/src/features/basic/sfc-exchange-destinations.tsx
+++ b/src/features/basic/sfc-exchange-destinations.tsx
@@ -1,5 +1,7 @@
 import PrunButton from '@src/components/PrunButton.vue';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { stationsStore } from '@src/infrastructure/prun-api/data/stations';
+import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { selectAddress } from '@src/infrastructure/prun-ui/utils/select-address';
 import $style from './sfc-exchange-destinations.module.css';
 
@@ -8,6 +10,14 @@ import $style from './sfc-exchange-destinations.module.css';
 const exchangeStationIds = ['ANT', 'BEN', 'HRT', 'MOR'];
 
 function onTileReady(tile: PrunTile) {
+  // A docked ship's address resolves to the station's own natural id ("ANT");
+  // in flight it has no address, so no button is grayed out.
+  const location = computed(() =>
+    getEntityNaturalIdFromAddress(
+      shipsStore.getByRegistration(tile.parameter)?.address ?? undefined,
+    ),
+  );
+
   subscribe($$(tile.anchor, C.AddressSelector.container), container => {
     createFragmentApp(() => (
       <div class={$style.buttons}>
@@ -16,6 +26,7 @@ function onTileReady(tile: PrunTile) {
             key={naturalId}
             dark
             inline
+            disabled={location.value === naturalId}
             class={$style.button}
             data-tooltip={stationsStore.getByNaturalId(naturalId)?.name ?? naturalId}
             onClick={() => selectAddress(container, naturalId)}>

--- a/src/features/basic/sfc-exchange-destinations.tsx
+++ b/src/features/basic/sfc-exchange-destinations.tsx
@@ -1,0 +1,40 @@
+import PrunButton from '@src/components/PrunButton.vue';
+import { stationsStore } from '@src/infrastructure/prun-api/data/stations';
+import { selectAddress } from '@src/infrastructure/prun-ui/utils/select-address';
+import $style from './sfc-exchange-destinations.module.css';
+
+// Commodity exchange stations, by their own natural ids. Ordered the way the
+// game lists their exchange codes (AI1, CI1, IC1, NC1).
+const exchangeStationIds = ['ANT', 'BEN', 'HRT', 'MOR'];
+
+function onTileReady(tile: PrunTile) {
+  subscribe($$(tile.anchor, C.AddressSelector.container), container => {
+    createFragmentApp(() => (
+      <div class={$style.buttons}>
+        {exchangeStationIds.map(naturalId => (
+          <PrunButton
+            key={naturalId}
+            dark
+            inline
+            class={$style.button}
+            data-tooltip={stationsStore.getByNaturalId(naturalId)?.name ?? naturalId}
+            onClick={() => selectAddress(container, naturalId)}>
+            {naturalId}
+          </PrunButton>
+        ))}
+      </div>
+    )).appendTo(container);
+  });
+}
+
+function init() {
+  tiles.observe('SFC', onTileReady);
+  applyCssRule('SFC', `.${C.AddressSelector.container}`, $style.container);
+  applyCssRule('SFC', `.${C.AddressSelector.input}`, $style.input);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'SFC: Adds commodity exchange shortcut buttons to the destination field.',
+);

--- a/src/infrastructure/prun-ui/utils/select-address.ts
+++ b/src/infrastructure/prun-ui/utils/select-address.ts
@@ -1,0 +1,67 @@
+import { changeInputValue, clickElement, focusElement } from '@src/util';
+import { stationsStore } from '@src/infrastructure/prun-api/data/stations';
+import { getSystemLineFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { waitFor } from '@src/utils/wait-for';
+
+// The station store keys getByNaturalId by the station's OWN natural id
+// ("MOR" for Moria Station), but the AddressSelector canonicalizes a picked
+// station to its SYSTEM id ("OT-580") — resolving the form value needs a
+// search by the address's system line instead.
+export function findStationBySystemId(id: string) {
+  const needle = id.toUpperCase();
+  return stationsStore.all.value?.find(
+    x => getSystemLineFromAddress(x.address)?.entity.naturalId.toUpperCase() === needle,
+  );
+}
+
+// AddressSelector suggestions are rendered in #autosuggest-portal outside the
+// tile DOM. Only one portal can be open at a time, so we search it directly.
+// Typing fires a read-only NOMENCLATURE_QUERY_ADDRESSES lookup to the game
+// server; selecting a suggestion is pure local form state.
+export async function selectAddress(container: Element, locationName: string): Promise<boolean> {
+  const input = _$(container, C.AddressSelector.input) as HTMLInputElement | undefined;
+  const portal = document.getElementById('autosuggest-portal');
+  if (!input || !portal) {
+    return false;
+  }
+
+  // Bare station/system ids are un-typeable: a station suggestion renders as
+  // "Moria Station (Moria)" — its id never appears as suggestion text, so a
+  // pasted "OT-580" would only ever substring-match a moon like OT-580e.
+  // Translate the id to the station name up front, looking up by system id
+  // (what the form and exports hold) and by station id (a hand-written
+  // "MOR"). Planet ids (OT-580b) do render in suggestions and pass through
+  // untouched.
+  const query =
+    findStationBySystemId(locationName)?.name ??
+    stationsStore.getByNaturalId(locationName)?.name ??
+    locationName;
+
+  focusElement(input);
+  changeInputValue(input, query);
+
+  // The portal first renders a default list (own bases, warehouses, CX
+  // stations) for the empty focus query, and the typed query's search results
+  // only arrive after a server round-trip — so wait for an entry that actually
+  // matches the name instead of clicking into the stale default list. Matching
+  // requires a word boundary around the query, because natural ids prefix each
+  // other ("OT-580b" is a prefix of nothing, but "OT-580" prefixes every moon
+  // in the system, and the default list can hold several) — a boundary match
+  // hits "Montem (OT-580b)" but not "OT-580br". Only when no boundary match
+  // arrives within the timeout does a plain substring match get one shot,
+  // keeping tolerance for odd human-entered fragments. No match at all leaves
+  // the field for the user rather than guessing.
+  const boundary = new RegExp(`(^|\\W)${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\W|$)`, 'i');
+  const suggestions = () => _$$(portal, C.AddressSelector.suggestionContent) as HTMLElement[];
+  const findBoundaryMatch = () => suggestions().find(s => boundary.test(s.textContent ?? ''));
+  await waitFor(() => !!findBoundaryMatch(), 5000);
+  const match =
+    findBoundaryMatch() ??
+    suggestions().find(s => s.textContent?.trim().toLowerCase().includes(query.toLowerCase()));
+  if (!match) {
+    return false;
+  }
+
+  await clickElement(match);
+  return true;
+}

--- a/src/utils/wait-for.ts
+++ b/src/utils/wait-for.ts
@@ -1,0 +1,18 @@
+import { sleep } from '@src/utils/sleep';
+
+// Polls a condition until it holds or the timeout elapses. Returns whether the
+// condition held.
+export async function waitFor(
+  condition: () => boolean,
+  timeout = 5000,
+  interval = 100,
+): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return true;
+    }
+    await sleep(interval);
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Adds `ANT` / `BEN` / `HRT` / `MOR` buttons inline at the right of the SFC destination address input, so a ship can be sent to a commodity exchange without typing the station name. The input flexes to make room; nothing else in the buffer layout moves. The button matching the ship's current station is grayed out.

New feature: `src/features/basic/sfc-exchange-destinations.tsx` + `.module.css`.

- Each button types the station name into the `AddressSelector` and clicks the matching autosuggest entry — the same flow a player performs by hand. Typing fires the read-only `NOMENCLATURE_QUERY_ADDRESSES` lookup and stays behind an explicit click, so no server request is automated.
- Disabled state comes from `PrunButton`'s `disabled` prop, driven by a `computed` over `shipsStore`: a docked ship's `address` resolves to the station's own natural id (`ANT`), so it updates live on arrival/departure. A ship in flight has no address, leaving every button active.

Supporting refactor, to avoid a third copy of the address-picking logic:

- `selectAddress` + `findStationBySystemId` moved out of `contd-paste-import/draft-form.ts` into `src/infrastructure/prun-ui/utils/select-address.ts`.
- `waitFor` extracted to `src/utils/wait-for.ts`.
- Both are pure moves — CONTD paste-import behavior is unchanged. ACT's `action-steps/cont-utils.ts` still has its own weaker `selectLocation`; left alone as out of scope.

Docs updated: exchange MIC vs. station natural id (`game-concepts.md`), the `selectAddress` helper and the `ship.address` key shape (`feature-patterns.md`), fresh-clone `pnpm install` (`architecture.md`).

**Not yet verified against the live game** — developed in a cloud session where the browser harness is unavailable. Two things to eyeball before merging: whether `C.AddressSelector.container` is purely the input's react-autosuggest wrapper (so the flex row can't disturb the suggestion list, which renders in `#autosuggest-portal`), and whether SFC has exactly one address selector — if origin is one too, the buttons need scoping to the destination.

## Standards Checklist

- [x] No upward imports across layers (features -> core -> infrastructure -> utils)
- [x] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [x] CSS rules scoped to commands where applicable
- [x] Numbers use formatters from `@src/utils/format` — n/a, no numbers rendered
- [x] No `title=` attributes (use `data-tooltip`)
- [x] No `onApiMessage` in features (use `computed` from stores)
- [x] Feature has single responsibility, no cross-feature deps — the shared helper lives in `infrastructure`, not another feature
- [x] CSS class names describe WHERE, not WHAT
- [x] Uses `C.Component.className` not hardcoded hashed classes
- [x] CHANGELOG.md not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQeAt8NDDWU1M2tmpLHztX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQeAt8NDDWU1M2tmpLHztX)_