### PR TITLE
Fix CI/prettier config gaps + simplify tiles.snapshotMetadata

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm compile && pnpm lint
+      - run: pnpm compile && pnpm lint && pnpm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ LICENSE
 *.md
 pnpm-lock.yaml
 src/types/unimport.d.ts
+.claude/worktrees
+.local

--- a/src/infrastructure/prun-ui/tiles.ts
+++ b/src/infrastructure/prun-ui/tiles.ts
@@ -172,28 +172,13 @@ export interface ActiveTileMetadata {
 }
 
 function snapshotActiveTileMetadata(): ActiveTileMetadata[] {
-  const metadata: ActiveTileMetadata[] = [];
-  const frameElements = document.getElementsByClassName(C.TileFrame.frame);
-  for (let i = 0; i < frameElements.length; i++) {
-    const frame = frameElements[i];
-    const tileElement = frame.parentElement;
-    const container = tileElement?.parentElement;
-    const commandElement = _$(frame, C.TileFrame.cmd);
-    const id = tileElement ? getPrunId(tileElement) : undefined;
-    if (!container || !commandElement || !id) {
-      continue;
-    }
-    const fullCommand = commandElement.textContent?.trim() ?? '';
-    const indexOfSpace = fullCommand.indexOf(' ');
-    metadata.push({
-      id,
-      docked: !container.classList.contains(C.Window.body),
-      fullCommand,
-      command: (indexOfSpace > 0 ? fullCommand.slice(0, indexOfSpace) : fullCommand).toUpperCase(),
-      ...(indexOfSpace > 0 ? { parameter: fullCommand.slice(indexOfSpace + 1) } : {}),
-    });
-  }
-  return metadata;
+  return activeTiles.map(({ id, docked, fullCommand, command, parameter }) => ({
+    id,
+    docked,
+    fullCommand,
+    command,
+    ...(parameter !== undefined ? { parameter } : {}),
+  }));
 }
 
 const tiles = {


### PR DESCRIPTION
Follow-up to #125, which merged before these two review fixes could land on its branch (the head branch lived in a fork I can't push to). Originally opened as agm-114/refined-prun#7; cherry-picked onto `main` unchanged.

1. **CI/prettier fixes** (unrelated to #125's own code, found while running the review tooling):
   - `.prettierignore` had no entry for `.claude/worktrees` or the gitignored `.local` scratch dir, so a repo-wide `pnpm prettier` recursed into other git worktrees (rewriting their files as a side effect) and crashed on stray scratch files.
   - `lint.yml` never ran `pnpm test`, so #125's 51 new tests (first use of vitest in this repo) weren't enforced by CI. A contributor could break them and CI would stay green.

2. **`tiles.ts` simplification**: `snapshotActiveTileMetadata()` re-derived `id`/`docked`/`fullCommand`/`command`/`parameter` by re-scanning the DOM, duplicating what `activateFrame()` already computes and stores on every `activeTiles` entry (same shape as `PrunTile`). Replaced with a plain map over `activeTiles` — strictly less work, and one fewer place to drift out of sync with `activateFrame`'s parsing.

## Test plan
- `pnpm run compile` — clean
- `pnpm run lint` — clean
- `pnpm run test` — 51/51 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD2kWeRYNAbN3xfjt4AvBJ
