### PR TITLE
fix(XIT DATA): stabilize agent connection and launch parameters

### DIFF
--- a/docs/data-catalog.md
+++ b/docs/data-catalog.md
@@ -100,8 +100,13 @@ completeness, the normalized query, counts, truncation metadata, timestamp, and 
 
 ## XIT DATA
 
-Open `XIT DATA` to use the human explorer. Selecting datasets, editing search/filter/sort inputs,
-previewing, and downloading are passive.
+Open `XIT DATA` to use the human explorer. Pass an optional catalog source ID to select it immediately,
+for example `XIT DATA ships`; plain `XIT DATA` opens the default source. An optional loopback endpoint
+can also prefill the agent connection field: `XIT DATA ships ws://127.0.0.1:47800` or, without a source,
+`XIT DATA ws://127.0.0.1:47800`. Add the optional `JSON` parameter to omit the agent connection feature
+for an explorer instance, for example `XIT DATA ships JSON` or
+`XIT DATA ships ws://127.0.0.1:47800 JSON`. Parameters never connect automatically. Selecting datasets,
+editing search/filter/sort inputs, previewing, and downloading are passive.
 
 Filter values are parsed as JSON when valid. For example, `true`, `42`, `null`, `["RAT"]`, and
 `{"mode":"safe"}` retain their JSON types. Other input is treated as a string.
@@ -152,6 +157,13 @@ Security requirements enforced by the client:
 
 Chrome may show its Local Network Access permission prompt on the first loopback connection. The user
 must grant that browser permission for the connection to proceed.
+
+The PrUn API middleware proxies the page's `WebSocket` constructor to observe game traffic. The agent
+client therefore captures the native constructor before that proxy is installed, and the middleware
+forwards `addEventListener` through the saved native method. Calling the overridden listener method
+recursively causes a stack overflow, while reading branded static properties such as `WebSocket.OPEN`
+through the proxy can produce an `Illegal invocation` error. These failures are interception bugs and
+do not require changing the authenticated loopback protocol.
 
 ### Protocol
 

--- a/src/features/XIT/DATA/DATA.ts
+++ b/src/features/XIT/DATA/DATA.ts
@@ -4,6 +4,7 @@ xit.add({
   command: 'DATA',
   name: 'DATA EXPLORER',
   description: 'Passively explores in-memory Refined PrUn game and tile data.',
+  optionalParameters: 'Source ID, Loopback Endpoint, JSON',
   component: () => DATA,
   bufferSize: [1080, 720],
 });

--- a/src/features/XIT/DATA/DATA.vue
+++ b/src/features/XIT/DATA/DATA.vue
@@ -16,7 +16,9 @@ import {
 } from '@src/infrastructure/data-catalog';
 import { isRequestTransportAvailable } from '@src/infrastructure/prun-api/data/request-hooks';
 import { agentQueryConnection } from '@src/infrastructure/data-catalog/agent-query';
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { downloadJson } from '@src/utils/json-file';
+import { parseDataExplorerParameters } from '@src/features/XIT/DATA/parameters';
 
 interface FilterInput {
   id: number;
@@ -45,8 +47,20 @@ const directionOptions = [
   { label: 'DESCENDING', value: 'desc' },
 ];
 
+const parameters = useXitParameters();
+const parsedParameters = parseDataExplorerParameters(parameters);
 const sources = computed(() => dataCatalog.list());
-const selectedSourceId = ref('balances');
+const requestedSourceId = parsedParameters.sourceId?.trim().toLowerCase();
+const defaultSourceId = sources.value.some(x => x.id === 'balances')
+  ? 'balances'
+  : (sources.value[0]?.id ?? '');
+const hasRequestedSource = sources.value.some(x => x.id === requestedSourceId);
+const selectedSourceId = ref(hasRequestedSource ? requestedSourceId! : defaultSourceId);
+const parameterMessage = ref(
+  requestedSourceId && !hasRequestedSource
+    ? `Unknown data source "${parsedParameters.sourceId}"; showing the default source.`
+    : '',
+);
 const search = ref('');
 const filters = ref<FilterInput[]>([]);
 const sortPath = ref('');
@@ -54,7 +68,7 @@ const sortDirection = ref<'asc' | 'desc'>('asc');
 const limit = ref<number | undefined>(250);
 const siteId = ref('');
 const loadMessage = ref('');
-const agentEndpoint = ref('ws://127.0.0.1:47800');
+const agentEndpoint = ref(parsedParameters.endpoint ?? 'ws://127.0.0.1:47800');
 const agentToken = ref('');
 const agentStatus = agentQueryConnection.status;
 const agentError = agentQueryConnection.lastError;
@@ -108,6 +122,7 @@ const prettyResult = computed(() => preview.value.text ?? queryError.value);
 const agentStatusLabel = computed(() => agentStatus.value.replace('-', ' ').toUpperCase());
 
 watch(selectedSourceId, () => {
+  parameterMessage.value = '';
   loadMessage.value = '';
 });
 
@@ -250,6 +265,9 @@ function buildPreview(result?: DataQueryResult): {
 
           <div v-if="source" :class="$style.sourceInfo">
             <div :class="$style.sourceDescription">{{ source.description }}</div>
+            <div v-if="parameterMessage" :class="$style.error">
+              {{ parameterMessage }}
+            </div>
             <div :class="$style.badges">
               <span :class="$style.badge">{{ provenanceLabel }}</span>
               <span :class="[$style.badge, $style[source.completeness]]">
@@ -332,7 +350,7 @@ function buildPreview(result?: DataQueryResult): {
         </div>
       </template>
 
-      <details :class="$style.agentPanel">
+      <details v-if="parsedParameters.connectionEnabled" :class="$style.agentPanel">
         <summary :class="$style.agentSummary">
           <span>Agent Query Connection</span>
           <span :class="[$style.badge, $style.agentStatus, $style[agentStatus]]">
@@ -410,7 +428,7 @@ function buildPreview(result?: DataQueryResult): {
 }
 
 .controls {
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   max-height: 48%;
   min-height: 0;
   border: 1px solid rgb(51, 51, 51);

--- a/src/features/XIT/DATA/parameters.test.ts
+++ b/src/features/XIT/DATA/parameters.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parseDataExplorerParameters } from '@src/features/XIT/DATA/parameters';
+
+describe('parseDataExplorerParameters', () => {
+  it.each([
+    [[], { connectionEnabled: true }],
+    [['ships'], { sourceId: 'ships', connectionEnabled: true }],
+    [
+      ['ships', 'ws://127.0.0.1:47800'],
+      { sourceId: 'ships', endpoint: 'ws://127.0.0.1:47800', connectionEnabled: true },
+    ],
+    [
+      ['ws://127.0.0.1:47800', 'JSON'],
+      { endpoint: 'ws://127.0.0.1:47800', connectionEnabled: false },
+    ],
+    [
+      ['json', 'ships', 'ws://127.0.0.1:47800'],
+      { sourceId: 'ships', endpoint: 'ws://127.0.0.1:47800', connectionEnabled: false },
+    ],
+  ])('parses optional DATA parameters %#', (parameters, expected) => {
+    expect(parseDataExplorerParameters(parameters)).toEqual(expected);
+  });
+});

--- a/src/features/XIT/DATA/parameters.ts
+++ b/src/features/XIT/DATA/parameters.ts
@@ -1,0 +1,12 @@
+export interface DataExplorerParameters {
+  sourceId?: string;
+  endpoint?: string;
+  connectionEnabled: boolean;
+}
+
+export function parseDataExplorerParameters(parameters: string[]): DataExplorerParameters {
+  const endpoint = parameters.find(x => /^wss?:\/\//i.test(x));
+  const jsonOnly = parameters.some(x => x.toUpperCase() === 'JSON');
+  const sourceId = parameters.find(x => x !== endpoint && x.toUpperCase() !== 'JSON');
+  return { sourceId, endpoint, connectionEnabled: !jsonOnly };
+}

--- a/src/infrastructure/data-catalog/agent-query-connection.test.ts
+++ b/src/infrastructure/data-catalog/agent-query-connection.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@src/infrastructure/data-catalog/agent-query-connection';
 
 class FakeSocket {
-  readyState: number = WebSocket.CONNECTING;
+  readyState = 0;
   sent: string[] = [];
   closed?: { code?: number; reason?: string };
   private readonly listeners = new Map<string, Array<(event: { data?: unknown }) => void>>();
@@ -24,12 +24,12 @@ class FakeSocket {
 
   close(code?: number, reason?: string) {
     this.closed = { code, reason };
-    this.readyState = WebSocket.CLOSED;
+    this.readyState = 3;
   }
 
   emit(type: string, data?: unknown) {
     if (type === 'open') {
-      this.readyState = WebSocket.OPEN;
+      this.readyState = 1;
     }
     for (const listener of this.listeners.get(type) ?? []) {
       listener({ data });
@@ -83,6 +83,30 @@ describe('agent endpoint and token validation', () => {
 });
 
 describe('AgentQueryConnection', () => {
+  it('authenticates when the page WebSocket constructor has branded static properties', () => {
+    const nativeWebSocket = WebSocket;
+    const proxiedWebSocket = new Proxy(nativeWebSocket, {
+      get(target, property, receiver) {
+        if (property === 'OPEN') {
+          throw new TypeError('Illegal invocation');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    vi.stubGlobal('WebSocket', proxiedWebSocket);
+
+    try {
+      const socket = new FakeSocket();
+      const connection = new AgentQueryConnection(createTestCatalog(), () => socket);
+      connection.connect('ws://127.0.0.1:47800', token);
+
+      expect(() => socket.emit('open')).not.toThrow();
+      expect(socket.messages()[0]).toMatchObject({ type: 'authenticate', token });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('is disabled until explicitly connected and authenticates before querying', () => {
     const socket = new FakeSocket();
     const factory = vi.fn(() => socket);

--- a/src/infrastructure/data-catalog/agent-query-connection.ts
+++ b/src/infrastructure/data-catalog/agent-query-connection.ts
@@ -32,6 +32,10 @@ const maxIncomingMessageSize = 64 * 1024;
 const maxOutgoingMessageSize = 4 * 1024 * 1024;
 const authenticationTimeoutMs = 10_000;
 const protocolVersion = 1;
+// Capture the constructor before the PrUn API middleware proxies window.WebSocket.
+const agentWebSocket = WebSocket;
+// Chromium brand-checks WebSocket constants when the page constructor is proxied.
+const webSocketOpen = 1;
 
 export class AgentQueryConnection {
   readonly status = ref<AgentConnectionStatus>('disconnected');
@@ -46,7 +50,7 @@ export class AgentQueryConnection {
   constructor(
     private readonly catalog: DataCatalog,
     private readonly socketFactory: AgentSocketFactory = endpoint =>
-      new WebSocket(endpoint) as unknown as AgentSocket,
+      new agentWebSocket(endpoint) as unknown as AgentSocket,
   ) {}
 
   connect(endpoint: string, token: string) {
@@ -210,7 +214,7 @@ export class AgentQueryConnection {
 
   private sendRaw(message: object, requestId?: string) {
     const socket = this.socket;
-    if (!socket || socket.readyState !== WebSocket.OPEN) {
+    if (!socket || socket.readyState !== webSocketOpen) {
       return;
     }
     const serialized = JSON.stringify(message);

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -55,7 +55,7 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
   // I don't remember what this override is for, lol. Probably some FIO compatibility issues.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   WebSocket.prototype.addEventListener = function (type: any, listener: any, options: any) {
-    return this.addEventListener(type, listener, options);
+    return addEventListener.call(this, type, listener, options);
   };
 
   window.XMLHttpRequest = new Proxy(XMLHttpRequest, {


### PR DESCRIPTION
## What changed

- fixes the loopback agent connection when the page WebSocket constructor is proxied
- forwards the native WebSocket listener correctly instead of recursively invoking the override
- adds optional source, loopback endpoint, and `JSON` launch parameters to `XIT DATA`
- keeps the explorer controls visible when the JSON preview grows
- documents the parameter forms and connection troubleshooting

## Why

The connection could fail with `Illegal invocation` or a stack overflow. The page middleware proxies WebSocket, so branded static properties cannot be read safely through that proxy, and the listener override was recursively calling itself. The agent client now captures the native constructor and uses the numeric open state while the middleware delegates to the saved native listener.

Parameters remain passive: they preselect or prefill UI state but never connect or load data automatically.

## Validation

- `pnpm run compile`
- `pnpm run lint`
- `pnpm test` — 57 tests passed
- `pnpm run build`
- live authenticated loopback connection and passive ship/storage queries