### PR TITLE
fix: capture the native WebSocket constructor in the middleware module

### DIFF
--- a/docs/data-catalog.md
+++ b/docs/data-catalog.md
@@ -158,12 +158,14 @@ Security requirements enforced by the client:
 Chrome may show its Local Network Access permission prompt on the first loopback connection. The user
 must grant that browser permission for the connection to proceed.
 
-The PrUn API middleware proxies the page's `WebSocket` constructor to observe game traffic. The agent
-client therefore captures the native constructor before that proxy is installed, and the middleware
-forwards `addEventListener` through the saved native method. Calling the overridden listener method
-recursively causes a stack overflow, while reading branded static properties such as `WebSocket.OPEN`
-through the proxy can produce an `Illegal invocation` error. These failures are interception bugs and
-do not require changing the authenticated loopback protocol.
+The PrUn API middleware proxies the page's `WebSocket` constructor to observe game traffic. The
+agent client therefore imports the native constructor that the middleware module captures before
+installing the proxy, so the loopback socket is never routed through the game's socket.io
+interception. The middleware forwards `addEventListener` through the saved native method, because
+calling the overridden listener method recursively causes a stack overflow. The agent client also
+compares `readyState` against the numeric open state instead of reading constants off the page
+constructor. These are interception concerns and do not require changing the authenticated
+loopback protocol.
 
 ### Protocol
 

--- a/src/infrastructure/data-catalog/agent-query-connection.ts
+++ b/src/infrastructure/data-catalog/agent-query-connection.ts
@@ -1,5 +1,6 @@
 import { DataCatalog } from '@src/core/data-query/catalog';
 import { DataQuery } from '@src/core/data-query/types';
+import { nativeWebSocket } from '@src/infrastructure/prun-api/socket-io-middleware';
 import { ref } from 'vue';
 
 export type AgentConnectionStatus =
@@ -32,9 +33,7 @@ const maxIncomingMessageSize = 64 * 1024;
 const maxOutgoingMessageSize = 4 * 1024 * 1024;
 const authenticationTimeoutMs = 10_000;
 const protocolVersion = 1;
-// Capture the constructor before the PrUn API middleware proxies window.WebSocket.
-const agentWebSocket = WebSocket;
-// Chromium brand-checks WebSocket constants when the page constructor is proxied.
+// WebSocket.OPEN, inlined so the page's proxied constructor is never read from.
 const webSocketOpen = 1;
 
 export class AgentQueryConnection {
@@ -50,7 +49,7 @@ export class AgentQueryConnection {
   constructor(
     private readonly catalog: DataCatalog,
     private readonly socketFactory: AgentSocketFactory = endpoint =>
-      new agentWebSocket(endpoint) as unknown as AgentSocket,
+      new nativeWebSocket(endpoint) as unknown as AgentSocket,
   ) {}
 
   connect(endpoint: string, token: string) {

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -2,6 +2,10 @@ import { decodePayload, encodePayload, Packet as EIOPacket } from 'engine.io-par
 import { Decoder, Encoder, Packet as SIOPacket, PacketType } from 'socket.io-parser';
 import { castArray } from '@src/utils/cast-array';
 
+// Captured before socketIOMiddleware() replaces window.WebSocket with a proxy.
+// Code that needs the real constructor imports this instead of reading the global.
+export const nativeWebSocket = WebSocket;
+
 export type Middleware<T> = {
   onOpen: () => void;
   onMessage: (payload: T) => Promise<boolean>;


### PR DESCRIPTION
Follow-up to #133.

## What changed

- `socket-io-middleware.ts` exports `nativeWebSocket`, captured at module scope. `agent-query-connection.ts` imports it instead of reading the global.
- Corrected the `Illegal invocation` claim in `docs/data-catalog.md` and in the comment above `webSocketOpen`.

## Why

#133 captured `WebSocket` at module scope in `agent-query-connection.ts`, which is only the native constructor if that module is evaluated before `listenPrunApi()` installs the `window.WebSocket` proxy. That holds today purely because `src/features/index.ts` eager-globs XIT DATA during `@src/features` import, while `listenPrunApi()` runs later inside `main()`. Make it lazy, or move the middleware to module init, and the agent silently connects through the game's socket.io interception with no test failing.

Capturing in the middleware module is structural: the proxy is installed by a function in that same module, so the module-scope capture always runs first.

The docs also stated that reading `WebSocket.OPEN` through our proxy can throw `Illegal invocation`. `window.WebSocket` is `new Proxy(WebSocket, { construct })` with no `get` trap, and WebIDL constants are plain data properties, so it cannot. The `webSocketOpen = 1` constant is left in place as harmless hardening against third-party constructor replacements, but the false diagnosis is removed so it does not send the next reader chasing a bug that is not there.

## Validation

- `pnpm run compile` (tsc + eslint)
- `npx vitest run` — 57 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtTvydWQ96JezQhF4vegFo
