### PR TITLE
fix(build): exclude feature tests from extension bundle

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,3 +1,5 @@
-import.meta.glob(['./basic/**/*.{ts,tsx}'], { eager: true });
-import.meta.glob(['./advanced/**/*.{ts,tsx}'], { eager: true });
-import.meta.glob(['./XIT/**/*.{ts,tsx}'], { eager: true });
+import.meta.glob(['./basic/**/*.{ts,tsx}', '!./basic/**/*.{test,spec}.{ts,tsx}'], { eager: true });
+import.meta.glob(['./advanced/**/*.{ts,tsx}', '!./advanced/**/*.{test,spec}.{ts,tsx}'], {
+  eager: true,
+});
+import.meta.glob(['./XIT/**/*.{ts,tsx}', '!./XIT/**/*.{test,spec}.{ts,tsx}'], { eager: true });


### PR DESCRIPTION
## What changed

- excludes `*.test.*` and `*.spec.*` modules from all eager feature import globs
- prevents co-located feature tests from entering the browser extension runtime

## Root cause

The feature loader eagerly imported every TypeScript file below `src/features/XIT`. The DATA parameter unit test imported Vitest, so the production extension executed the Vitest runner without its test configuration and failed with `Cannot read properties of undefined (reading 'config')`.

## Validation

- clean `pnpm dev` rebuild
- zero Vitest/test-runner artifacts in `dist`
- zero runtime references to Vitest
- `pnpm run compile`
- `pnpm test` — 57 tests passed
- ESLint passes for `src/features/index.ts`