### PR TITLE
Add a JSON plan import to XIT GOVBURN

### DIFF
--- a/.claude/harness-notes.md
+++ b/.claude/harness-notes.md
@@ -29,6 +29,31 @@ Scope that bypass to commands that actually write config, though — a plain
 allowed host, so it runs fine sandboxed. Reaching for `dangerouslyDisableSandbox` "because
 it's a push" spends a user approval for nothing.
 
+**Never `git add -A` from inside the sandbox.** The sandbox materializes its deny-mounts as
+`/dev/null` character devices at paths under the working directory — a sandboxed
+`git status` in a worktree listed `.bashrc`, `.gitconfig`, `.gitmodules`, `.zshrc` and a
+dozen more as untracked, and `git add -A` then aborted with
+`error: .bash_profile: can only add regular files, symbolic links or git-directories`,
+staging nothing. They are not real files (`git status` unsandboxed shows only your actual
+changes) and `git fetch` warning `unable to access '.gitmodules': Permission denied` is the
+same illusion. Stage explicit paths (`git add src/ CHANGELOG.md`) and the problem
+disappears — no bypass needed.
+
+A sandboxed command can also fail spuriously with
+`bwrap: Can't find source path /home/cyrus/.claude/local: No such file or directory`. That
+is a transient sandbox-setup race, not a denial: re-run the same command and it works.
+Reaching for `dangerouslyDisableSandbox` on the first sight of a `bwrap:` line spends an
+approval that a plain retry would have saved.
+
+## Bash working directory does not persist
+
+The tool description's "working directory persists between calls" does not hold here — a
+standalone `cd /some/path` returns `Shell cwd was reset to <session cwd>`. You cannot `cd`
+into the main checkout to run repo scripts by their relative path from a worktree session
+(and a compound `cd X && node scripts/...` breaks the `sandbox.excludedCommands` match,
+since only the FIRST segment is tested). Bridge the missing files into the worktree
+instead — see `docs/browser-testing.md` on symlinking `.local/`.
+
 Watch one non-obvious config write: `git branch -f <branch> origin/main`, used to reset a
 merged branch, *also* re-points that branch's upstream to `origin/main` via
 `branch.autoSetupMerge`. Restore it with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ ships and opens a fresh `Unreleased` section.
 ### Added
 
 - `XIT WHATSNEW`: Shows release notes since your last update, opened automatically after an update
+- `XIT GOVBURN`: Import a planet's POPI plan from JSON in the config pane, with a preview of what it overwrites
+
+### Changed
+
+- `XIT GOVBURNACT`: Upkeep material slot picks are saved, instead of being re-guessed every time the buffer opens
 
 ### Fixed
 

--- a/docs/browser-testing.md
+++ b/docs/browser-testing.md
@@ -61,6 +61,17 @@ before concluding anything is broken, grep `dist/` for a string unique to your c
 Re-check mid-run if a long session starts producing surprising results (this has happened
 live: another session rebuilt `dist/` from a different branch mid-test).
 
+**From a git worktree the harness needs two bridges.** `.local/` is gitignored, so a
+worktree has neither `pw-tools/` nor `browser-profile/`, and `scripts/pw-act.mjs` resolves
+them from its own repo root — every call dies with `Playwright is not installed at
+<worktree>/.local/pw-tools/node_modules/playwright`. Symlink it once
+(`ln -sfn <main-checkout>/.local <worktree>/.local`); it stays gitignored. Second, the
+running browser was launched with `--load-extension=<main-checkout>/dist`, so building in
+the worktree changes nothing it can see — copy the worktree's `dist/` over the main
+checkout's before reloading. That overwrites shared state the whole machine tests against,
+which is the hazard the worktree existed to avoid: confirm with the owner first if another
+session might be mid-run.
+
 ### 2. Launch
 
 ```

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -376,6 +376,16 @@ feature; put durable state in `userData` instead.
 
 ESLint bans `.reduce()` for summation (`no-restricted-syntax`) — use `sumBy(array, x => x.value)` instead.
 
+**Never use an auto-imported name as a local identifier in a module you want to unit-test.**
+unimport's injection is not scope-aware enough to see that a parameter or `const` already
+binds the name, so it adds the import anyway. For `config` that pulls in
+`@src/infrastructure/shell/config`, which touches `document` at module scope — the feature
+still works in the browser, but the moment a vitest file imports that module the whole test
+run dies with `document is not defined`, pointing at a module that never mentions the DOM.
+GOVBURN's `planetDays(planet, config, now)` hit exactly this and had to become
+`planetDays(planet, planetConfig, now)` before `utils.ts` could be tested. `config` is the
+sharp edge, but the rule covers every name in the table above.
+
 ---
 
 ## `C` Object

--- a/src/features/XIT/GOVBURN/GovBurnActWindow.vue
+++ b/src/features/XIT/GOVBURN/GovBurnActWindow.vue
@@ -12,7 +12,7 @@ import { stagedGovBurn } from '@src/features/XIT/GOVBURN/staged';
 import {
   cogcRefills,
   planetGovBurnBill,
-  rankSlots,
+  resolveSlots,
   type SlotPick,
 } from '@src/features/XIT/GOVBURN/utils';
 import { useMinBufferHeight } from '@src/hooks/use-min-buffer-height';
@@ -98,7 +98,7 @@ const buildingRows = computed(() => {
   return result;
 });
 
-// Keyed by building ticker; initialized once from rankSlots(building, n).
+// Keyed by building ticker; seeded from saved picks via resolveSlots.
 const slots = ref<Record<string, SlotPick[]>>({});
 
 watch(
@@ -110,6 +110,7 @@ watch(
       return;
     }
     const config = planetConfig.value;
+    const savedSlots = userData.govburn.config.slots[naturalId.value];
     const next: Record<string, SlotPick[]> = {};
     for (const building of planet.buildings) {
       if (building.level <= 0) {
@@ -119,19 +120,7 @@ watch(
       if (n <= 0 || building.upkeeps === undefined) {
         continue;
       }
-      const previous = slots.value[building.ticker];
-      if (
-        previous !== undefined &&
-        previous.length === Math.max(0, Math.min(n, building.upkeeps.length))
-      ) {
-        // Preserve user picks across data refreshes; blank tickers that are no longer upkeeps.
-        const valid = new Set(building.upkeeps.map(x => x.ticker));
-        next[building.ticker] = previous.map(x =>
-          x.ticker === '' || valid.has(x.ticker) ? x : { ticker: '', source: 'manual' },
-        );
-      } else {
-        next[building.ticker] = rankSlots(building, n);
-      }
+      next[building.ticker] = resolveSlots(building, n, savedSlots?.[building.ticker]);
     }
     slots.value = next;
   },
@@ -176,6 +165,9 @@ function setSlot(buildingTicker: string, slotIndex: number, value: string | unde
     return;
   }
   list[slotIndex] = { ticker: value ?? '', source: 'manual' };
+  const naturalIdValue = naturalId.value;
+  const stored = (userData.govburn.config.slots[naturalIdValue] ??= {});
+  stored[buildingTicker] = list.map(x => x.ticker).filter(x => x !== '');
 }
 
 const allResolved = computed(() => {

--- a/src/features/XIT/GOVBURN/GovBurnConfig.vue
+++ b/src/features/XIT/GOVBURN/GovBurnConfig.vue
@@ -6,12 +6,14 @@ import TextInput from '@src/components/forms/TextInput.vue';
 import PrunButton from '@src/components/PrunButton.vue';
 import SectionHeader from '@src/components/SectionHeader.vue';
 import { popiBuildings } from '@src/features/XIT/GOVBURN/buildings';
+import GovBurnImport from '@src/features/XIT/GOVBURN/GovBurnImport.vue';
 import { planetsStore } from '@src/infrastructure/prun-api/data/planets';
 import { userData } from '@src/store/user-data';
 import { comparePlanets } from '@src/util';
 
 const emit = defineEmits<{ (e: 'done'): void }>();
 
+const showImport = ref(false);
 const planetInput = ref('');
 const planetError = ref(false);
 
@@ -74,6 +76,7 @@ function addPlanet() {
 
 function removePlanet(naturalId: string) {
   delete userData.govburn.config.planets[naturalId];
+  delete userData.govburn.config.slots[naturalId];
 }
 
 function onInputKeydown(ev: KeyboardEvent) {
@@ -84,61 +87,65 @@ function onInputKeydown(ev: KeyboardEvent) {
 </script>
 
 <template>
-  <div :class="C.ComExOrdersPanel.filter">
-    <div :class="$style.spacer" />
-    <PrunButton primary @click="emit('done')">DONE</PrunButton>
-  </div>
+  <GovBurnImport v-if="showImport" @done="showImport = false" />
+  <template v-else>
+    <div :class="C.ComExOrdersPanel.filter">
+      <div :class="$style.spacer" />
+      <PrunButton @click="showImport = true">IMPORT</PrunButton>
+      <PrunButton primary @click="emit('done')">DONE</PrunButton>
+    </div>
 
-  <SectionHeader>Thresholds</SectionHeader>
-  <form @submit.prevent>
-    <Active label="Red (days)">
-      <NumberInput v-model="userData.govburn.config.red" />
-    </Active>
-    <Active label="Yellow (days)">
-      <NumberInput v-model="userData.govburn.config.yellow" />
-    </Active>
-  </form>
+    <SectionHeader>Thresholds</SectionHeader>
+    <form @submit.prevent>
+      <Active label="Red (days)">
+        <NumberInput v-model="userData.govburn.config.red" />
+      </Active>
+      <Active label="Yellow (days)">
+        <NumberInput v-model="userData.govburn.config.yellow" />
+      </Active>
+    </form>
 
-  <SectionHeader>Add Planet</SectionHeader>
-  <form @submit.prevent>
-    <Active label="Planet" :error="planetError">
-      <TextInput v-model="planetInput" @keydown="onInputKeydown" />
-    </Active>
-    <Commands>
-      <PrunButton primary @click="addPlanet">ADD</PrunButton>
-    </Commands>
-  </form>
-  <p v-if="planetError" :class="$style.error">Planet not found.</p>
+    <SectionHeader>Add Planet</SectionHeader>
+    <form @submit.prevent>
+      <Active label="Planet" :error="planetError">
+        <TextInput v-model="planetInput" @keydown="onInputKeydown" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="addPlanet">ADD</PrunButton>
+      </Commands>
+    </form>
+    <p v-if="planetError" :class="$style.error">Planet not found.</p>
 
-  <table v-if="configuredPlanets.length > 0">
-    <thead>
-      <tr>
-        <th>Planet</th>
-        <th v-for="building in popiBuildings" :key="building.ticker">{{ building.ticker }}</th>
-        <th />
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="naturalId in configuredPlanets" :key="naturalId">
-        <td>{{ planetName(naturalId) }}</td>
-        <td v-for="building in popiBuildings" :key="building.ticker">
-          <div
-            v-if="hasBuilding(naturalId, building.ticker)"
-            :class="[C.forms.input, $style.numberWrap]">
-            <input
-              type="number"
-              :min="-1"
-              :max="maxRequired(naturalId, building.ticker)"
-              :value="getRequired(naturalId, building.ticker)"
-              @change="onRequiredChange(naturalId, building.ticker, $event)" />
-          </div>
-        </td>
-        <td>
-          <PrunButton danger inline @click="removePlanet(naturalId)">REMOVE</PrunButton>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+    <table v-if="configuredPlanets.length > 0">
+      <thead>
+        <tr>
+          <th>Planet</th>
+          <th v-for="building in popiBuildings" :key="building.ticker">{{ building.ticker }}</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="naturalId in configuredPlanets" :key="naturalId">
+          <td>{{ planetName(naturalId) }}</td>
+          <td v-for="building in popiBuildings" :key="building.ticker">
+            <div
+              v-if="hasBuilding(naturalId, building.ticker)"
+              :class="[C.forms.input, $style.numberWrap]">
+              <input
+                type="number"
+                :min="-1"
+                :max="maxRequired(naturalId, building.ticker)"
+                :value="getRequired(naturalId, building.ticker)"
+                @change="onRequiredChange(naturalId, building.ticker, $event)" />
+            </div>
+          </td>
+          <td>
+            <PrunButton danger inline @click="removePlanet(naturalId)">REMOVE</PrunButton>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </template>
 </template>
 
 <style module>

--- a/src/features/XIT/GOVBURN/GovBurnImport.vue
+++ b/src/features/XIT/GOVBURN/GovBurnImport.vue
@@ -1,0 +1,224 @@
+<script setup lang="ts">
+import Active from '@src/components/forms/Active.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import { popiBuildings } from '@src/features/XIT/GOVBURN/buildings';
+import {
+  buildImportPlan,
+  parseGovBurnImport,
+  type GovBurnImportPlan,
+  type GovBurnImportRow,
+} from '@src/features/XIT/GOVBURN/govburn-import';
+import { planetsStore } from '@src/infrastructure/prun-api/data/planets';
+import { userData } from '@src/store/user-data';
+import { uploadJson } from '@src/utils/json-file';
+
+const emit = defineEmits<{ (e: 'done'): void }>();
+
+type ImportType = 'TEXT' | 'FILE';
+
+const typeOptions: { label: string; value: ImportType }[] = [
+  { label: 'Paste JSON', value: 'TEXT' },
+  { label: 'Upload JSON', value: 'FILE' },
+];
+
+const type = ref('TEXT' as ImportType);
+const text = ref('');
+const error = ref(false);
+const errorMessage = ref('');
+const plan = ref<GovBurnImportPlan | undefined>(undefined);
+const naturalId = ref('');
+const planetLabel = ref('');
+
+function planetName(id: string) {
+  return userData.govburn.planets[id]?.name ?? planetsStore.find(id)?.name ?? id;
+}
+
+function formatCountMaterials(count: number, materials: string[]) {
+  if (count === -1) {
+    return '--';
+  }
+  if (materials.length === 0) {
+    return String(count);
+  }
+  return `${count} (${materials.join(', ')})`;
+}
+
+function rowNote(row: GovBurnImportRow) {
+  const notes: string[] = [];
+  if (row.omitted) {
+    notes.push('not in import');
+  }
+  if (row.clamped) {
+    notes.push(`clamped to ${row.count} upkeeps`);
+  }
+  if (row.unknownMaterials.length > 0) {
+    notes.push(`not an upkeep: ${row.unknownMaterials.join(', ')}`);
+  }
+  return notes.join('; ');
+}
+
+function applyJson(json: unknown) {
+  const input = parseGovBurnImport(json);
+  if (input === undefined) {
+    error.value = true;
+    errorMessage.value = 'Invalid JSON.';
+    return;
+  }
+  const planet = planetsStore.find(input.planet);
+  if (planet === undefined) {
+    error.value = true;
+    errorMessage.value = 'Planet not found.';
+    return;
+  }
+  error.value = false;
+  errorMessage.value = '';
+  naturalId.value = planet.naturalId;
+  planetLabel.value = planetName(planet.naturalId);
+  plan.value = buildImportPlan(
+    input,
+    userData.govburn.planets[planet.naturalId],
+    userData.govburn.config.planets[planet.naturalId],
+    userData.govburn.config.slots[planet.naturalId],
+  );
+}
+
+function onPreviewClick() {
+  if (text.value.length === 0) {
+    error.value = true;
+    errorMessage.value = 'Invalid JSON.';
+    return;
+  }
+  try {
+    applyJson(JSON.parse(text.value));
+  } catch {
+    error.value = true;
+    errorMessage.value = 'Invalid JSON.';
+  }
+}
+
+function onUploadClick() {
+  uploadJson(applyJson);
+}
+
+function onBack() {
+  plan.value = undefined;
+  error.value = false;
+  errorMessage.value = '';
+}
+
+function onConfirm() {
+  const currentPlan = plan.value;
+  const id = naturalId.value;
+  if (currentPlan === undefined || id === '') {
+    return;
+  }
+  userData.govburn.config.planets[id] ??= Object.fromEntries(
+    popiBuildings.map(x => [x.ticker, -1]),
+  );
+  const planetConfig = userData.govburn.config.planets[id];
+  const slots = (userData.govburn.config.slots[id] ??= {});
+  for (const row of currentPlan.rows) {
+    planetConfig[row.ticker] = row.count;
+    if (row.materials.length === 0) {
+      delete slots[row.ticker];
+    } else {
+      slots[row.ticker] = row.materials;
+    }
+  }
+  emit('done');
+}
+</script>
+
+<template>
+  <div v-if="plan === undefined">
+    <SectionHeader>Import GovBurn Plan</SectionHeader>
+    <form @submit.prevent>
+      <Active label="Type">
+        <SelectInput v-model="type" :options="typeOptions" />
+      </Active>
+      <Active v-if="type === 'TEXT'" label="JSON" :error="error">
+        <textarea
+          v-model="text"
+          :class="$style.textarea"
+          placeholder='{"planet":"Phobos","buildings":[{"building":"SST","materials":["DW","OFF"]}]}'
+          spellcheck="false" />
+      </Active>
+      <Commands>
+        <PrunButton v-if="type === 'FILE'" primary @click="onUploadClick">UPLOAD</PrunButton>
+        <PrunButton v-if="type === 'TEXT'" primary @click="onPreviewClick">PREVIEW</PrunButton>
+        <PrunButton @click="emit('done')">CANCEL</PrunButton>
+      </Commands>
+    </form>
+    <p v-if="error" :class="$style.error">{{ errorMessage }}</p>
+  </div>
+
+  <div v-else>
+    <SectionHeader>{{ planetLabel }}</SectionHeader>
+    <p v-if="plan.hasConflicts" :class="$style.error">
+      Overwrites existing settings for the highlighted rows.
+    </p>
+    <p v-if="!plan.hasData" :class="$style.note">
+      No data captured for this planet. Materials cannot be validated — run XIT GOVBURNDATA.
+    </p>
+    <p v-if="plan.ignored.length > 0" :class="$style.note">
+      Ignored (not POPI buildings): {{ plan.ignored.join(', ') }}.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Building</th>
+          <th>Current</th>
+          <th>New</th>
+          <th>Note</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in plan.rows" :key="row.ticker" :class="{ [$style.conflict]: row.conflict }">
+          <td>{{ row.ticker }}</td>
+          <td>{{ formatCountMaterials(row.currentCount, row.currentMaterials) }}</td>
+          <td>{{ formatCountMaterials(row.count, row.materials) }}</td>
+          <td>{{ rowNote(row) }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <form @submit.prevent>
+      <Commands>
+        <PrunButton primary @click="onConfirm">CONFIRM</PrunButton>
+        <PrunButton @click="onBack">BACK</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>
+
+<style module>
+.textarea {
+  width: 100%;
+  min-height: 80px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  background: transparent;
+  border: none;
+}
+
+.textarea:focus {
+  outline: none;
+}
+
+.error {
+  margin: 0.25rem 0;
+  color: rgb(217, 83, 79);
+}
+
+.note {
+  margin: 0.25rem 0;
+}
+
+.conflict {
+  color: rgb(217, 83, 79);
+}
+</style>

--- a/src/features/XIT/GOVBURN/govburn-import.test.ts
+++ b/src/features/XIT/GOVBURN/govburn-import.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import { popiBuildings } from '@src/features/XIT/GOVBURN/buildings';
+import { buildImportPlan, parseGovBurnImport } from '@src/features/XIT/GOVBURN/govburn-import';
+import { resolveSlots } from '@src/features/XIT/GOVBURN/utils';
+
+const phobosJson = {
+  planet: 'Phobos',
+  buildings: [
+    { building: 'SST', selectedLevel: 8, maxLevel: 10, materials: ['DW', 'OFF', 'SUN'] },
+    { building: 'INF', selectedLevel: 5, maxLevel: 8, materials: ['OFF', 'STR'] },
+    { building: 'HOS', selectedLevel: 1, maxLevel: 2, materials: ['BND'] },
+    { building: 'PAR', selectedLevel: 7, maxLevel: 10, materials: ['DW', 'FOD', 'PFE'] },
+    { building: '4DA', selectedLevel: 2, maxLevel: 2, materials: ['HOG', 'EDC'] },
+    { building: 'ART', selectedLevel: 6, maxLevel: 6, materials: ['MHP', 'UTS'] },
+    { building: 'PBH', selectedLevel: 3, maxLevel: 3, materials: ['OFF', 'EDC', 'IDC'] },
+    { building: 'UNI', selectedLevel: 6, maxLevel: 7, materials: ['IDC'] },
+  ],
+};
+
+function upkeep(ticker: string): UserData.GovBurnUpkeep {
+  return { ticker, stored: 0, amount: 1, duration: 1, nextTick: 0 };
+}
+
+function building(
+  ticker: string,
+  upkeeps: UserData.GovBurnUpkeep[],
+  contribHistory?: Record<string, UserData.GovBurnContrib>,
+): UserData.GovBurnBuilding {
+  return {
+    ticker,
+    type: ticker,
+    projectId: ticker,
+    level: 1,
+    upkeeps,
+    contribHistory,
+  };
+}
+
+describe('parseGovBurnImport', () => {
+  it('parses the sample Phobos JSON', () => {
+    const input = parseGovBurnImport(phobosJson);
+    expect(input).toEqual({
+      planet: 'Phobos',
+      buildings: [
+        { ticker: 'SST', materials: ['DW', 'OFF', 'SUN'] },
+        { ticker: 'INF', materials: ['OFF', 'STR'] },
+        { ticker: 'HOS', materials: ['BND'] },
+        { ticker: 'PAR', materials: ['DW', 'FOD', 'PFE'] },
+        { ticker: '4DA', materials: ['HOG', 'EDC'] },
+        { ticker: 'ART', materials: ['MHP', 'UTS'] },
+        { ticker: 'PBH', materials: ['OFF', 'EDC', 'IDC'] },
+        { ticker: 'UNI', materials: ['IDC'] },
+      ],
+    });
+  });
+
+  it('returns undefined for malformed input', () => {
+    expect(parseGovBurnImport(null)).toBeUndefined();
+    expect(parseGovBurnImport('x')).toBeUndefined();
+    expect(parseGovBurnImport({ buildings: [] })).toBeUndefined();
+    expect(parseGovBurnImport({ planet: 'Phobos', buildings: 'nope' })).toBeUndefined();
+    expect(
+      parseGovBurnImport({
+        planet: 'Phobos',
+        buildings: [{ building: 1, materials: [] }],
+      }),
+    ).toBeUndefined();
+    expect(
+      parseGovBurnImport({
+        planet: 'Phobos',
+        buildings: [{ building: 'SST', materials: [1] }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('upper-cases tickers and lets the last duplicate win', () => {
+    const input = parseGovBurnImport({
+      planet: '  phobos  ',
+      buildings: [
+        { building: 'sst', materials: ['dw'] },
+        { building: 'SST', materials: ['off', 'sun'] },
+      ],
+    });
+    expect(input).toEqual({
+      planet: 'phobos',
+      buildings: [{ ticker: 'SST', materials: ['OFF', 'SUN'] }],
+    });
+  });
+});
+
+describe('buildImportPlan', () => {
+  const input = parseGovBurnImport(phobosJson)!;
+
+  it('derives counts from materials.length', () => {
+    const plan = buildImportPlan(input, undefined, undefined, undefined);
+    const sst = plan.rows.find(x => x.ticker === 'SST')!;
+    expect(sst.count).toBe(3);
+    expect(sst.materials).toEqual(['DW', 'OFF', 'SUN']);
+    expect(plan.hasData).toBe(false);
+  });
+
+  it('zeros configured POPI buildings omitted from the JSON', () => {
+    const plan = buildImportPlan(
+      input,
+      undefined,
+      { SST: 3, SDP: 2 },
+      { SST: ['DW', 'OFF', 'SUN'], SDP: ['OFF'] },
+    );
+    const sdp = plan.rows.find(x => x.ticker === 'SDP')!;
+    expect(sdp.count).toBe(0);
+    expect(sdp.materials).toEqual([]);
+    expect(sdp.omitted).toBe(true);
+    expect(sdp.conflict).toBe(true);
+  });
+
+  it('zeros every POPI building omitted from the JSON, configured or not', () => {
+    const plan = buildImportPlan(input, undefined, undefined, undefined);
+    expect(plan.rows).toHaveLength(popiBuildings.length);
+    const lib = plan.rows.find(x => x.ticker === 'LIB')!;
+    expect(lib.count).toBe(0);
+    expect(lib.omitted).toBe(true);
+    expect(lib.conflict).toBe(false);
+  });
+
+  it('clamps materials longer than captured upkeeps', () => {
+    const captured: UserData.GovBurnPlanet = {
+      naturalId: 'PHOBOS',
+      name: 'Phobos',
+      capturedAt: 0,
+      buildings: [building('SST', [upkeep('DW'), upkeep('OFF')])],
+    };
+    const plan = buildImportPlan(input, captured, undefined, undefined);
+    const sst = plan.rows.find(x => x.ticker === 'SST')!;
+    expect(sst.count).toBe(2);
+    expect(sst.clamped).toBe(true);
+    expect(sst.materials).toEqual(['DW', 'OFF', 'SUN']);
+    expect(sst.unknownMaterials).toEqual(['SUN']);
+    expect(plan.hasData).toBe(true);
+  });
+
+  it('keeps unknown materials and lists them', () => {
+    const captured: UserData.GovBurnPlanet = {
+      naturalId: 'PHOBOS',
+      name: 'Phobos',
+      capturedAt: 0,
+      buildings: [building('HOS', [upkeep('DW')])],
+    };
+    const plan = buildImportPlan(input, captured, undefined, undefined);
+    const hos = plan.rows.find(x => x.ticker === 'HOS')!;
+    expect(hos.materials).toEqual(['BND']);
+    expect(hos.unknownMaterials).toEqual(['BND']);
+  });
+
+  it('ignores non-POPI tickers', () => {
+    const withJunk = parseGovBurnImport({
+      planet: 'Phobos',
+      buildings: [
+        { building: 'FOO', materials: ['DW'] },
+        { building: 'SST', materials: ['DW'] },
+      ],
+    })!;
+    const plan = buildImportPlan(withJunk, undefined, undefined, undefined);
+    expect(plan.ignored).toEqual(['FOO']);
+    expect(plan.rows.every(x => x.ticker !== 'FOO')).toBe(true);
+  });
+
+  it('flags conflicts only when something was already set', () => {
+    const fresh = buildImportPlan(input, undefined, undefined, undefined);
+    expect(fresh.rows.find(x => x.ticker === 'SST')!.conflict).toBe(false);
+    expect(fresh.hasConflicts).toBe(false);
+
+    const changedCount = buildImportPlan(input, undefined, { SST: 1 }, undefined);
+    expect(changedCount.rows.find(x => x.ticker === 'SST')!.conflict).toBe(true);
+    expect(changedCount.hasConflicts).toBe(true);
+
+    const changedMaterials = buildImportPlan(
+      input,
+      undefined,
+      { SST: 3 },
+      { SST: ['DW', 'OFF', 'XXX'] },
+    );
+    expect(changedMaterials.rows.find(x => x.ticker === 'SST')!.conflict).toBe(true);
+  });
+
+  it('has no conflict when current matches the import', () => {
+    const plan = buildImportPlan(input, undefined, { SST: 3 }, { SST: ['DW', 'OFF', 'SUN'] });
+    expect(plan.rows.find(x => x.ticker === 'SST')!.conflict).toBe(false);
+  });
+});
+
+describe('resolveSlots', () => {
+  const b = building('SST', [upkeep('DW'), upkeep('OFF'), upkeep('SUN'), upkeep('STR')], {
+    OFF: { own: 100 },
+    SUN: { own: 50 },
+    STR: { any: 10 },
+  });
+
+  it('honours saved picks in order', () => {
+    expect(resolveSlots(b, 2, ['SUN', 'STR']).map(x => x.ticker)).toEqual(['SUN', 'STR']);
+  });
+
+  it('drops a saved ticker that is no longer an upkeep and backfills from rankSlots', () => {
+    const slots = resolveSlots(b, 2, ['GONE', 'STR']);
+    expect(slots[0].ticker).not.toBe('GONE');
+    expect(slots[0].ticker).not.toBe('');
+    expect(slots[1].ticker).toBe('STR');
+    expect(slots[0].ticker).not.toBe('STR');
+  });
+
+  it('does not use a duplicated saved ticker twice', () => {
+    const slots = resolveSlots(b, 2, ['OFF', 'OFF']);
+    expect(slots[0].ticker).toBe('OFF');
+    expect(slots[1].ticker).not.toBe('OFF');
+    expect(slots[1].ticker).not.toBe('');
+  });
+
+  it('backfills new indices when n grows', () => {
+    const slots = resolveSlots(b, 3, ['SUN']);
+    expect(slots[0].ticker).toBe('SUN');
+    expect(slots[1].ticker).not.toBe('');
+    expect(slots[2].ticker).not.toBe('');
+    expect(new Set(slots.map(x => x.ticker)).size).toBe(3);
+  });
+
+  it('clamps n to upkeeps.length', () => {
+    expect(resolveSlots(b, 99, ['DW', 'OFF', 'SUN', 'STR', 'EXTRA'])).toHaveLength(4);
+    expect(resolveSlots(b, 0, ['DW'])).toEqual([]);
+  });
+});

--- a/src/features/XIT/GOVBURN/govburn-import.ts
+++ b/src/features/XIT/GOVBURN/govburn-import.ts
@@ -1,0 +1,183 @@
+import { popiBuildings } from '@src/features/XIT/GOVBURN/buildings';
+
+export interface GovBurnImportBuilding {
+  ticker: string;
+  materials: string[];
+}
+
+export interface GovBurnImportInput {
+  planet: string;
+  buildings: GovBurnImportBuilding[];
+}
+
+export interface GovBurnImportRow {
+  ticker: string;
+  // Count to write: materials.length for listed buildings (clamped to the
+  // building's upkeep count when data is captured), 0 for omitted ones.
+  count: number;
+  materials: string[];
+  currentCount: number;
+  currentMaterials: string[];
+  conflict: boolean;
+  // Zeroed because the JSON does not list it.
+  omitted: boolean;
+  // The JSON listed more materials than the building has upkeeps.
+  clamped: boolean;
+  // Listed tickers that are not among the building's captured upkeeps.
+  unknownMaterials: string[];
+}
+
+export interface GovBurnImportPlan {
+  rows: GovBurnImportRow[];
+  // Tickers in the JSON that are not POPI buildings.
+  ignored: string[];
+  // False when the planet has no captured GOVBURNDATA: no clamping and no
+  // material validation are possible.
+  hasData: boolean;
+  hasConflicts: boolean;
+}
+
+const popiTickers = new Set(popiBuildings.map(x => x.ticker));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function parseGovBurnImport(json: unknown): GovBurnImportInput | undefined {
+  if (!isRecord(json)) {
+    return undefined;
+  }
+  if (typeof json.planet !== 'string' || json.planet.trim() === '') {
+    return undefined;
+  }
+  if (!Array.isArray(json.buildings)) {
+    return undefined;
+  }
+
+  // Last entry wins for duplicate building tickers.
+  const byTicker = new Map<string, string[]>();
+  for (const entry of json.buildings) {
+    if (!isRecord(entry)) {
+      return undefined;
+    }
+    if (typeof entry.building !== 'string' || entry.building.trim() === '') {
+      return undefined;
+    }
+    if (!Array.isArray(entry.materials)) {
+      return undefined;
+    }
+    const materials: string[] = [];
+    for (const material of entry.materials) {
+      if (typeof material !== 'string') {
+        return undefined;
+      }
+      materials.push(material.trim().toUpperCase());
+    }
+    byTicker.set(entry.building.trim().toUpperCase(), materials);
+  }
+
+  return {
+    planet: json.planet.trim(),
+    buildings: [...byTicker.entries()].map(([ticker, materials]) => ({ ticker, materials })),
+  };
+}
+
+function dedupePreserveOrder(tickers: string[]) {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const ticker of tickers) {
+    if (seen.has(ticker)) {
+      continue;
+    }
+    seen.add(ticker);
+    result.push(ticker);
+  }
+  return result;
+}
+
+function materialsEqual(a: string[], b: string[]) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function buildImportPlan(
+  input: GovBurnImportInput,
+  captured: UserData.GovBurnPlanet | undefined,
+  currentConfig: UserData.GovBurnPlanetConfig | undefined,
+  currentSlots: UserData.GovBurnPlanetSlots | undefined,
+): GovBurnImportPlan {
+  const listed = new Map(input.buildings.map(x => [x.ticker, x.materials]));
+  const ignored = input.buildings.map(x => x.ticker).filter(x => !popiTickers.has(x));
+
+  const capturedByTicker = new Map((captured?.buildings ?? []).map(x => [x.ticker, x] as const));
+
+  // Every POPI building gets a row: omission from the JSON means "deliberately
+  // unsupplied" (0), so unlisted buildings must be written too, not skipped.
+  const rows: GovBurnImportRow[] = [];
+  for (const { ticker } of popiBuildings) {
+    const jsonMaterials = listed.get(ticker);
+    const currentCount = currentConfig?.[ticker] ?? -1;
+    const currentMaterials = currentSlots?.[ticker] ?? [];
+
+    if (jsonMaterials === undefined) {
+      const conflict =
+        (currentCount !== -1 || currentMaterials.length > 0) &&
+        (currentCount !== 0 || currentMaterials.length > 0);
+      rows.push({
+        ticker,
+        count: 0,
+        materials: [],
+        currentCount,
+        currentMaterials,
+        conflict,
+        omitted: true,
+        clamped: false,
+        unknownMaterials: [],
+      });
+      continue;
+    }
+
+    const materials = dedupePreserveOrder(jsonMaterials);
+    const building = capturedByTicker.get(ticker);
+    const upkeeps = building?.upkeeps;
+    let count = materials.length;
+    let clamped = false;
+    if (upkeeps !== undefined && count > upkeeps.length) {
+      count = upkeeps.length;
+      clamped = true;
+    }
+    const upkeepTickers = new Set((upkeeps ?? []).map(x => x.ticker));
+    const unknownMaterials =
+      upkeeps === undefined ? [] : materials.filter(x => !upkeepTickers.has(x));
+
+    const conflict =
+      (currentCount !== -1 || currentMaterials.length > 0) &&
+      (count !== currentCount || !materialsEqual(materials, currentMaterials));
+
+    rows.push({
+      ticker,
+      count,
+      materials,
+      currentCount,
+      currentMaterials,
+      conflict,
+      omitted: false,
+      clamped,
+      unknownMaterials,
+    });
+  }
+
+  return {
+    rows,
+    ignored,
+    hasData: captured !== undefined,
+    hasConflicts: rows.some(x => x.conflict),
+  };
+}

--- a/src/features/XIT/GOVBURN/utils.ts
+++ b/src/features/XIT/GOVBURN/utils.ts
@@ -57,12 +57,13 @@ export function buildingDays(building: UserData.GovBurnBuilding, n: number, now:
   return days;
 }
 
-// Min over buildings with level > 0 of buildingDays(config[ticker] ?? -1).
+// Min over buildings with level > 0 of buildingDays(planetConfig[ticker] ?? -1).
 // hasData is true iff any level > 0 building has upkeeps captured.
 // Unconfigured buildings drag the planet to 0 (red); all-zero config is infinity (green).
+// Named planetConfig (not config) so unimport does not inject shell config.
 export function planetDays(
   planet: UserData.GovBurnPlanet,
-  config: UserData.GovBurnPlanetConfig,
+  planetConfig: UserData.GovBurnPlanetConfig,
   now: number,
 ) {
   let days = Number.POSITIVE_INFINITY;
@@ -74,7 +75,7 @@ export function planetDays(
     if (building.upkeeps !== undefined) {
       hasData = true;
     }
-    const n = config[building.ticker] ?? -1;
+    const n = planetConfig[building.ticker] ?? -1;
     days = Math.min(days, buildingDays(building, n, now));
   }
   return { days, hasData };
@@ -183,6 +184,58 @@ export function rankSlots(building: UserData.GovBurnBuilding, n: number): SlotPi
   while (result.length < slotCount) {
     result.push({ ticker: '', source: 'manual' });
   }
+  return result;
+}
+
+// Builds the slot list for a building, preferring saved picks.
+// Saved tickers that are still present in the building's current upkeeps
+// and not already used by an earlier index are kept as manual picks.
+// Remaining indices are filled from rankSlots, then left unresolved.
+// Always returns exactly slotCount entries (n clamped to upkeeps.length).
+export function resolveSlots(
+  building: UserData.GovBurnBuilding,
+  n: number,
+  saved: string[] | undefined,
+): SlotPick[] {
+  const upkeeps = building.upkeeps ?? [];
+  const slotCount = Math.max(0, Math.min(n, upkeeps.length));
+  if (slotCount === 0) {
+    return [];
+  }
+
+  const valid = new Set(upkeeps.map(x => x.ticker));
+  const used = new Set<string>();
+  const result: SlotPick[] = Array.from({ length: slotCount }, () => ({
+    ticker: '',
+    source: 'manual' as const,
+  }));
+
+  for (let i = 0; i < slotCount; i++) {
+    const ticker = saved?.[i];
+    if (ticker === undefined || ticker === '' || !valid.has(ticker) || used.has(ticker)) {
+      continue;
+    }
+    used.add(ticker);
+    result[i] = { ticker, source: 'manual' };
+  }
+
+  const ranked = rankSlots(building, slotCount);
+  let rankIndex = 0;
+  for (let i = 0; i < slotCount; i++) {
+    if (result[i].ticker !== '') {
+      continue;
+    }
+    while (rankIndex < ranked.length) {
+      const pick = ranked[rankIndex++];
+      if (pick.ticker === '' || used.has(pick.ticker)) {
+        continue;
+      }
+      used.add(pick.ticker);
+      result[i] = pick;
+      break;
+    }
+  }
+
   return result;
 }
 

--- a/src/store/user-data-migrations.ts
+++ b/src/store/user-data-migrations.ts
@@ -17,6 +17,12 @@ function isCheckpoint(entry: MigrationEntry): entry is Checkpoint {
 // The date is for reference only, and it does not affect migration order.
 const migrations: MigrationEntry[] = [
   [
+    '09.08.2026 Add govburn slot picks',
+    userData => {
+      userData.govburn.config.slots = {};
+    },
+  ],
+  [
     '13.07.2026 Add govburn thresholds',
     userData => {
       userData.govburn.config.red = 3;

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -81,6 +81,7 @@ export const initialUserData = deepFreeze({
     planets: {} as Record<string, UserData.GovBurnPlanet>,
     config: {
       planets: {} as Record<string, UserData.GovBurnPlanetConfig>,
+      slots: {} as Record<string, UserData.GovBurnPlanetSlots>,
       resupplyDays: 30,
       red: 3,
       yellow: 7,

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -230,4 +230,9 @@ declare namespace UserData {
   // 0: deliberately unsupplied — infinity days (green).
   // 1..upkeepCount: number of upkeep materials the player keeps supplied.
   type GovBurnPlanetConfig = Record<string, number>;
+
+  // Building ticker -> chosen upkeep material tickers, in slot order.
+  // Persists GOVBURNACT's slot picks; may be shorter than the configured
+  // count when some slots are still unresolved.
+  type GovBurnPlanetSlots = Record<string, string[]>;
 }


### PR DESCRIPTION
Players plan their POPI upkeep outside the game and hold the result as JSON. Getting that into `XIT GOVBURN` meant hand-editing one number per building in the config pane, and GOVBURNACT threw away the material choices every time the buffer closed.

## What this adds

**An IMPORT button on the GOVBURN config pane** that takes a plan like:

```json
{
  "planet": "Phobos",
  "buildings": [
    { "building": "SST", "selectedLevel": 8, "maxLevel": 10, "materials": ["DW", "OFF", "SUN"] },
    { "building": "INF", "selectedLevel": 5, "maxLevel": 8,  "materials": ["OFF", "STR"] }
  ]
}
```

Paste or upload, then a preview table shows every POPI building's current vs. new setting with conflicts in red, so the overwrite is always confirmed before it happens.

**Persistent slot picks.** `userData.govburn.config.slots` is a new store keyed the same way as `config.planets`. Both the import and the player's own GOVBURNACT dropdowns write to it, so a manual pick now survives closing the buffer instead of being re-guessed by `rankSlots`.

## Import semantics

- The count per building is derived from `materials.length`, clamped to the building's captured upkeep count.
- POPI buildings the JSON omits are set to `0` (deliberately unsupplied / green), not `-1` — omission is a statement, not a gap.
- `selectedLevel` / `maxLevel` are ignored: levels come from `XIT GOVBURNDATA` capture, not user config.
- Materials that aren't among the building's captured upkeeps are stored anyway and flagged in the preview; `resolveSlots` filters them against live data and backfills, so a stale JSON degrades instead of breaking.

The config pane's table is unchanged — counts only, no per-material UI.

## Incidental fix

`planetDays`'s `config` parameter is renamed to `planetConfig`. unimport auto-injects `@src/infrastructure/shell/config` for a bare `config` identifier regardless of local scope, which pulls `document` into the module and made `utils.ts` untestable under vitest. Documented in `docs/feature-patterns.md`.

## Verification

- `pnpm run compile` clean; `pnpm run test` 73 passing, including new coverage for `parseGovBurnImport`, `buildImportPlan` and `resolveSlots`.
- Driven against the live game on Phobos: preview flagged only real overwrites, CONFIRM wrote the config table exactly as previewed, GOVBURNACT pre-filled all 18 slots from the JSON, and a manual slot change survived a close/reopen. Both error paths (`Planet not found.`, `Invalid JSON.`) render without crashing the tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtTvydWQ96JezQhF4vegFo
