### PR TITLE
test(harness): add shift-click, rect and rect-gap actions to pw-act

### DIFF
--- a/.claude/harness-notes.md
+++ b/.claude/harness-notes.md
@@ -35,6 +35,18 @@ merged branch, *also* re-points that branch's upstream to `origin/main` via
 `git branch --set-upstream-to=origin/<branch> <branch>` or the next bare `git push` on it
 targets main.
 
+## `sudo` needs a real terminal
+
+Anything requiring `sudo` cannot run from this session — not from a Bash tool call, and not
+from the `!` prefix either. Both land in a non-interactive shell with no TTY, so `sudo` dies
+with `sudo: A terminal is required to authenticate` before doing anything. Suggesting `!` for
+a sudo command wastes the user's time twice: once when it fails, once when they retry it.
+
+When a task needs sudo (upgrading `gh` off the distro package, the `libnss3 libnspr4
+libasound2t64` install in `docs/browser-testing.md`), hand the user the command and say to run
+it in a real WSL terminal — Windows Terminal, or `wsl` from PowerShell — where it can prompt
+for their password. Everything after the install is normally sudo-free and runs fine in-session.
+
 ## Approvals are the scarce resource
 
 Allowlisted prefixes in `.claude/settings.json` only help when the command matches

--- a/docs/browser-testing.md
+++ b/docs/browser-testing.md
@@ -92,7 +92,7 @@ arguments — that list lives in the script and is not duplicated here. Grouped 
 | Build/session | `reload-extension`, `reload` |
 | Open a tile | `open-buffer '<CMD>'`, `open-contd-template` |
 | Interact | `click`, `click-force`, `click-nth`, `ctrl-click`, `type`, `fill-nth`, `fill-file`, `press`, `press-on`, `select-option` |
-| Read state | `list-windows`, `dump-windows`, `window-text`, `styles`, `local-storage-get`, `contd-template-fields` |
+| Read state | `list-windows`, `dump-windows`, `window-text`, `styles`, `rect`, `rect-gap`, `local-storage-get`, `contd-template-fields` |
 | Look | `screenshot`, `screenshot-window` |
 | Window layout | `move-window`, `resize-window`, `close-window` |
 | Drag & drop | `mouse-drag`, `drag-stack`, `real-drag-stack`, `drag-probe` |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -189,6 +189,21 @@ merging" policy existed to avoid: two branches both adding a bullet under `## Un
 can conflict where they land near each other. Resolution is normally trivial (keep both
 bullets) — accept it as the tradeoff for PRs writing their own entries.
 
+### Editing a PR with `gh`
+
+`gh pr edit` is broken against this repo on `gh` 2.46.0 (the Ubuntu package): it still requests
+the `repository.pullRequest.projectCards` GraphQL field, which GitHub removed with Projects
+(classic), so every invocation fails with a deprecation notice naming Projects rather than
+anything about your edit, and the PR is left unchanged. It does exit 1, so check the exit code —
+piping the output to `tail` hides it behind the pipe's status.
+
+`gh pr create` is unaffected. To change an existing PR, either upgrade `gh` past the versions that
+query that field, or go through REST:
+
+```
+gh api repos/<owner>/<repo>/pulls/<number> -X PATCH -f title="..." -F body=@body.md
+```
+
 ### Import Sorting
 
 Don't enable auto-import-sorting in your editor. It creates merge conflicts when the same file is touched in two branches. Import sorting should be project-wide (via eslint/prettier), not per-editor.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -191,18 +191,19 @@ bullets) — accept it as the tradeoff for PRs writing their own entries.
 
 ### Editing a PR with `gh`
 
-`gh pr edit` is broken against this repo on `gh` 2.46.0 (the Ubuntu package): it still requests
-the `repository.pullRequest.projectCards` GraphQL field, which GitHub removed with Projects
-(classic), so every invocation fails with a deprecation notice naming Projects rather than
-anything about your edit, and the PR is left unchanged. It does exit 1, so check the exit code —
-piping the output to `tail` hides it behind the pipe's status.
-
-`gh pr create` is unaffected. To change an existing PR, either upgrade `gh` past the versions that
-query that field, or go through REST:
+If `gh pr edit` fails with a Projects (classic) deprecation notice naming
+`repository.pullRequest.projectCards`, `gh` is too old — it is requesting a GraphQL field GitHub
+removed. The error mentions Projects, not your edit, and the PR is left unchanged; `gh pr create`
+is unaffected. Ubuntu's own package (2.46.0) has this; 2.97.0 does not, so a fresh container that
+installed `gh` from the distro repo will hit it again. Fix by installing from `cli.github.com`
+rather than the distro, or work around it with REST:
 
 ```
 gh api repos/<owner>/<repo>/pulls/<number> -X PATCH -f title="..." -F body=@body.md
 ```
+
+Either way, check the exit code rather than eyeballing output: piping to `tail` reports the pipe's
+status, which hid this failure once already.
 
 ### Import Sorting
 

--- a/scripts/pw-act.mjs
+++ b/scripts/pw-act.mjs
@@ -26,6 +26,7 @@ const ACTIONS = {
   'click-force': "click-force '<selector>' — bypass actionability checks",
   'click-nth': "click-nth '<selector>' <index|first|last>",
   'ctrl-click': "ctrl-click '<selector>' — real Control+click (inventory multi-select)",
+  'shift-click': "shift-click '<selector>' — real Shift+click (production-line companion buffers)",
   'type': "type '<selector>' <text> — page.fill",
   'fill-nth': "fill-nth '<selector>' <index|first|last> <text>",
   'fill-file': "fill-file '<selector>' <path> — fill from a file (large/multiline text)",
@@ -192,6 +193,15 @@ switch (action) {
     await page.keyboard.down('Control');
     await page.click(rest[0]);
     await page.keyboard.up('Control');
+    break;
+  }
+  case 'shift-click': {
+    // Holds Shift while clicking — production-companion-buffers.ts listens
+    // for shift-clicks on production-line tile buttons. Real keydown+click+keyup,
+    // same rationale as ctrl-click above.
+    await page.keyboard.down('Shift');
+    await page.click(rest[0]);
+    await page.keyboard.up('Shift');
     break;
   }
   case 'type': {

--- a/scripts/pw-act.mjs
+++ b/scripts/pw-act.mjs
@@ -37,6 +37,8 @@ const ACTIONS = {
   'dump-windows': 'dump-windows [index] — structured dump (cmd, context bar, columns, buttons)',
   'window-text': "window-text '<match>' [maxChars] — full innerText of one window",
   'styles': "styles '<selector>' 'prop1,prop2' — computed style values",
+  'rect': "rect '<selector>' — bounding box of every match (x/y/w/h + edges)",
+  'rect-gap': "rect-gap '<selA>' '<selB>' — signed gap between first matches",
   'local-storage-get': "local-storage-get '<key>'",
   'screenshot': 'screenshot <absolute-path> — full page',
   'screenshot-window': "screenshot-window '<match>' <absolute-path> — clip to one buffer",
@@ -482,6 +484,100 @@ switch (action) {
       return out;
     }, props);
     console.log(JSON.stringify(result, null, 2));
+    break;
+  }
+  case 'rect': {
+    // Bounding box of EVERY match for a selector (not just the first) —
+    // sessions routinely compare all rows in a column. Read-only: no click,
+    // scroll, or focus. Rounds to 2 decimals so sub-pixel diffs stay visible
+    // without dumping full float noise. Use instead of a bespoke
+    // `eval "() => getBoundingClientRect()"` snippet.
+    const [selector] = rest;
+    const locator = page.locator(selector);
+    const count = await locator.count();
+    if (count === 0) {
+      console.error(`No element matching "${selector}".`);
+      process.exit(1);
+    }
+    const rects = await locator.evaluateAll(els => {
+      const r2 = n => Math.round(n * 100) / 100;
+      return els.map(el => {
+        const r = el.getBoundingClientRect();
+        return {
+          x: r2(r.x),
+          y: r2(r.y),
+          width: r2(r.width),
+          height: r2(r.height),
+          top: r2(r.top),
+          right: r2(r.right),
+          bottom: r2(r.bottom),
+          left: r2(r.left),
+        };
+      });
+    });
+    console.log(JSON.stringify({ count, rects }, null, 2));
+    break;
+  }
+  case 'rect-gap': {
+    // Signed gap between the FIRST match of each selector. Read-only.
+    // Gap convention (same on both axes): positive = separation between the
+    // two boxes on that axis; negative = they overlap on that axis by that
+    // amount (magnitude is the overlap). Horizontal: if B is entirely to the
+    // right of A → b.left - a.right; entirely to the left → a.left - b.right;
+    // otherwise the negative overlap. Vertical: same with top/bottom.
+    // overlaps is true only when both axes have negative gaps (true 2D
+    // intersection); edge-touching (gap 0) is not overlap.
+    const [selectorA, selectorB] = rest;
+    const locA = page.locator(selectorA).first();
+    const locB = page.locator(selectorB).first();
+    if ((await locA.count()) === 0) {
+      console.error(`No element matching selector A "${selectorA}".`);
+      process.exit(1);
+    }
+    if ((await locB.count()) === 0) {
+      console.error(`No element matching selector B "${selectorB}".`);
+      process.exit(1);
+    }
+    const toRect = async loc =>
+      loc.evaluate(el => {
+        const r2 = n => Math.round(n * 100) / 100;
+        const r = el.getBoundingClientRect();
+        return {
+          x: r2(r.x),
+          y: r2(r.y),
+          width: r2(r.width),
+          height: r2(r.height),
+          top: r2(r.top),
+          right: r2(r.right),
+          bottom: r2(r.bottom),
+          left: r2(r.left),
+        };
+      });
+    const a = await toRect(locA);
+    const b = await toRect(locB);
+    // Axis gap: positive separation, negative overlap (see case comment).
+    const axisGap = (aStart, aEnd, bStart, bEnd) => {
+      if (bStart >= aEnd) return Math.round((bStart - aEnd) * 100) / 100;
+      if (aStart >= bEnd) return Math.round((aStart - bEnd) * 100) / 100;
+      return Math.round(-(Math.min(aEnd, bEnd) - Math.max(aStart, bStart)) * 100) / 100;
+    };
+    const horizontal = axisGap(a.left, a.right, b.left, b.right);
+    const vertical = axisGap(a.top, a.bottom, b.top, b.bottom);
+    console.log(
+      JSON.stringify(
+        {
+          a,
+          b,
+          gap: {
+            horizontal,
+            vertical,
+            overlaps: horizontal < 0 && vertical < 0,
+          },
+        },
+        null,
+        2,
+      ),
+    );
     break;
   }
   case 'local-storage-get': {


### PR DESCRIPTION
Adds three missing primitives to `scripts/pw-act.mjs`.

## `shift-click '<selector>'`

Verifying the production-companion-buffers feature (shift-click a production line button to open PRODCO and PRODQ as a split pair) needs a real shift-click, and the harness had only `click`, `click-force`, `click-nth` and `ctrl-click`. Mirrors `ctrl-click` exactly: real `keyboard.down('Shift')`, `page.click`, `keyboard.up('Shift')`, so the page sees genuine modifier state rather than a synthesised event with `shiftKey` patched on.

## `rect '<selector>'` and `rect-gap '<selA>' '<selB>'`

Element geometry was the last recurring reason to reach for `eval`, which ships arbitrary JS into a live logged-in session each time — one recent session used it three times for exactly this. `docs/browser-testing.md` already states the rule: *"If an `eval` pattern recurs, add it to `pw-act.mjs` as a new fixed-argument action."* This is that follow-through; both take data-only selectors with the logic fixed in the script.

- `rect` reports **every** match, not just the first — comparing all rows in a column is the common case. Rounds to 2 decimals, since sub-pixel differences matter (a real measurement here was `23.99147605895996`). Includes edges as well as x/y/w/h.
- `rect-gap` answers the recurring "how much space is between these two things" question (label→button edge, button→column divider, label→clear button). Gaps are signed: positive is separation, negative means the boxes overlap on that axis by that amount. `overlaps` is true only on a real 2D intersection; edge-touching is not overlap.

Both are read-only and exit non-zero with a clear message when a selector matches nothing, rather than printing an empty result that reads like a passing measurement.

## Verification

Driven against the live harness. `rect` on the XIT DISPATCH ship pool returned all 9 rows at `height: 23.99`, matching hand-measured values; `rect-gap` between the pool and the planet-name column returned `horizontal: 107.33`, `vertical: -24`, `overlaps: false` (correct — they overlap on one axis only). No-match paths exit 1 naming which selector failed. `node --check` and `node scripts/pw-act.mjs help` both pass; note `scripts/**/*.mjs` is excluded from eslint, so `pnpm run compile` does not cover this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD2kWeRYNAbN3xfjt4AvBJ
