### PR TITLE
XIT PLANETS: pickup ship size per base, with a ready-for-pickup badge in XIT BS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,12 @@ ships and opens a fresh `Unreleased` section.
 
 - `XIT WHATSNEW`: Shows release notes since your last update, opened automatically after an update
 - `bs-inv-base-store-link`: Makes the `INV` context link on `BS` open the base store directly
+- `XIT PLANETS`: New Pickup column picks the cargo size of the ship you collect each base's output with
+- `XIT BS`: Shows a green 🚀 next to a base's inventory bar 24 hours before its produced goods fill the ship picked in `XIT PLANETS`, and hides it while a ship is already in flight there
 
 ### Changed
 
 - `correct-commands`: `INV <planet>` opens the base store directly instead of the store list
-
-### Changed
-
 - `XIT ACT`: Auto-SFC step now sets the destination planet with the same address-select helper used by CONTD import, dropping two redundant confirmation clicks
 - `XIT ACT`: A commodity exchange short on stock no longer aborts the whole action package. The buy warns and offers whatever the order book can fill, so you can ACT on the partial amount, adjust it by hand, or SKIP it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ ships and opens a fresh `Unreleased` section.
 
 - `XIT WHATSNEW`: Shows release notes since your last update, opened automatically after an update
 - `bs-inv-base-store-link`: Makes the `INV` context link on `BS` open the base store directly
-- `XIT PLANETS`: New Pickup column picks the cargo size of the ship you collect each base's output with
+- `XIT PLANETS`: New Pickup column picks the cargo size of the ship you collect each base's output with, spelled out in tonnes and m³ so `3k/1k` can't be read backwards
 - `XIT BS`: Shows a green 🚀 next to a base's inventory bar 24 hours before its produced goods fill the ship picked in `XIT PLANETS`, and hides it while a ship is already in flight there
 
 ### Changed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,21 +13,27 @@ Stack: TypeScript, Vue 3, Vite (content scripts), CSS Modules. Package manager: 
 | `pnpm run build:fast` | clean + `vite build`, skipping the checks — for the browser-test loop |
 | `pnpm run fix` | eslint `--fix` |
 | `pnpm run dev` | watch-mode development build |
-| `pnpm run test` | `vitest run` — see the stale-`dist` trap below |
+| `pnpm run test` | `vitest run` |
 
 A fresh clone has no `node_modules` — run `pnpm install --frozen-lockfile` before
 `pnpm run compile` / `pnpm run lint`, or `tsc` reports missing `chrome`/`node`/`vite/client`
 type libraries, which reads like a broken tsconfig rather than a missing install. Cloud
 sessions (Claude Code on the web) always start from a fresh clone.
 
-**Run `pnpm run clean` before `vitest` if you have built since the last test run.** There is
-no vitest config, so vitest keeps its default include glob, which does not exclude `dist/` —
-and `vite build` emits every `*.test.ts` as its own `dist/**/*.test.js` chunk. Vitest then
-collects those compiled copies and the suite dies on `document is not defined`, thrown from
-`src/infrastructure/shell/config.ts` at import time. The failure names a source file and
-looks like a real regression; the giveaway is a `dist/` path in the failing-suite header.
-`src/features/index.ts` excluding test files from `import.meta.glob` does not help — that
-stops tests being pulled *into* the bundle, not from being emitted alongside it.
+`vite.config.mts` doubles as the vitest config (hence its `defineConfig` comes from
+`vitest/config`, not `vite`). **Don't drop its `test.exclude` entry.** Vitest 4 narrowed its
+default exclude to `node_modules` and `.git` — `dist/**` used to be in it — so any compiled
+test that reaches `dist/` gets collected on the next run and dies on `document is not
+defined`, thrown from `src/infrastructure/shell/config.ts` at import time. The failure names
+a *source* file and reads like a real regression; the giveaway is a `dist/` path in the
+failing-suite header.
+
+Builds only emit modules that are in the import graph, so a test file lands in `dist/` only
+if something imports it. The way that happened was `src/features/index.ts`'s
+`import.meta.glob` sweeping `**/*.ts` — now excluded there with `!**/*.{test,spec}.{ts,tsx}`
+patterns, which is the primary fix. `test.exclude` is the backstop that makes it structural:
+a new glob without the exclusion, or a `dist/` left over from an older checkout, can't
+resurrect the trap.
 
 Verifying UI-visible behaviour against the live game: `docs/browser-testing.md`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,11 +13,21 @@ Stack: TypeScript, Vue 3, Vite (content scripts), CSS Modules. Package manager: 
 | `pnpm run build:fast` | clean + `vite build`, skipping the checks — for the browser-test loop |
 | `pnpm run fix` | eslint `--fix` |
 | `pnpm run dev` | watch-mode development build |
+| `pnpm run test` | `vitest run` — see the stale-`dist` trap below |
 
 A fresh clone has no `node_modules` — run `pnpm install --frozen-lockfile` before
 `pnpm run compile` / `pnpm run lint`, or `tsc` reports missing `chrome`/`node`/`vite/client`
 type libraries, which reads like a broken tsconfig rather than a missing install. Cloud
 sessions (Claude Code on the web) always start from a fresh clone.
+
+**Run `pnpm run clean` before `vitest` if you have built since the last test run.** There is
+no vitest config, so vitest keeps its default include glob, which does not exclude `dist/` —
+and `vite build` emits every `*.test.ts` as its own `dist/**/*.test.js` chunk. Vitest then
+collects those compiled copies and the suite dies on `document is not defined`, thrown from
+`src/infrastructure/shell/config.ts` at import time. The failure names a source file and
+looks like a real regression; the giveaway is a `dist/` path in the failing-suite header.
+`src/features/index.ts` excluding test files from `import.meta.glob` does not help — that
+stops tests being pulled *into* the bundle, not from being emitted alongside it.
 
 Verifying UI-visible behaviour against the live game: `docs/browser-testing.md`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,20 +20,16 @@ A fresh clone has no `node_modules` — run `pnpm install --frozen-lockfile` bef
 type libraries, which reads like a broken tsconfig rather than a missing install. Cloud
 sessions (Claude Code on the web) always start from a fresh clone.
 
-`vite.config.mts` doubles as the vitest config (hence its `defineConfig` comes from
-`vitest/config`, not `vite`). **Don't drop its `test.exclude` entry.** Vitest 4 narrowed its
-default exclude to `node_modules` and `.git` — `dist/**` used to be in it — so any compiled
-test that reaches `dist/` gets collected on the next run and dies on `document is not
-defined`, thrown from `src/infrastructure/shell/config.ts` at import time. The failure names
-a *source* file and reads like a real regression; the giveaway is a `dist/` path in the
-failing-suite header.
-
-Builds only emit modules that are in the import graph, so a test file lands in `dist/` only
-if something imports it. The way that happened was `src/features/index.ts`'s
-`import.meta.glob` sweeping `**/*.ts` — now excluded there with `!**/*.{test,spec}.{ts,tsx}`
-patterns, which is the primary fix. `test.exclude` is the backstop that makes it structural:
-a new glob without the exclusion, or a `dist/` left over from an older checkout, can't
-resurrect the trap.
+**Keep test files out of `src/features/index.ts`'s `import.meta.glob` sweeps** — each one
+carries a matching `!./<dir>/**/*.{test,spec}.{ts,tsx}` pattern. That glob is the only thing
+that ever pulls a test into the import graph, and a build emits exactly what is in the graph,
+so dropping the exclusion puts compiled `*.test.js` into `dist/`. Vitest 4 no longer excludes
+`dist/**` by default (its `defaultExclude` is just `node_modules` and `.git`), so it then
+collects those copies and the suite dies on `document is not defined`, thrown from
+`src/infrastructure/shell/config.ts` at import time. That failure names a *source* file and
+reads like a real regression — the giveaway is a `dist/` path in the failing-suite header.
+The same symptom appears from a `dist/` built before this exclusion existed; `pnpm run clean`
+clears it.
 
 Verifying UI-visible behaviour against the live game: `docs/browser-testing.md`.
 

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -649,6 +649,20 @@ Map getters are keyed by API values, which don't always match what the game UI s
 - `ship.address` is `null` while the ship is in flight. Docked, `getEntityNaturalIdFromAddress(ship.address)` gives the station's **own** natural id (`ANT`) — not the system id — so it compares directly against `stationsStore.getByNaturalId` keys.
 - Getters built with `createMapGetter`/`createGroupMapGetter` upper-case both the stored key and the lookup value, so they are already case-insensitive. Don't lower-case a parameter before passing it in, and don't add a case-normalizing wrapper of your own.
 
+### Core helpers can be feature-gated (returns nothing for most users)
+
+Not every helper in `src/core/` reads live game state unconditionally. `getInboundShipStores`
+(`src/core/burn.ts`) returns `[]` unless the `oog-burn-inflight-inventory` feature is on, and
+that feature ships **disabled by default** (`initialUserData.settings.disabled`) — so for most
+users it answers `[]` regardless of what ships are actually flying. It exists to answer "does
+in-flight cargo count toward this base's inventory", a deliberately opt-in accounting choice.
+
+Anything asking the *factual* question "is a ship already on its way to this planet" must use
+the ungated `getInboundShips` instead. The distinction is invisible at the call site and fails
+silently: XIT BS's pickup badge was written against the gated helper, so its clear-once-a-ship-
+is-dispatched rule would never have fired for a default install. Before reusing a `src/core/`
+helper, check whether its body opens with a feature-flag guard.
+
 ---
 
 ## Filling an AddressSelector
@@ -749,12 +763,19 @@ watch(state, value => localStorage.setItem(key, value));
 
 ### Adding a Field to `initialUserData`
 
-A new field whose default in `initialUserData` (`src/store/user-data.ts`) already means
-"unset" (e.g. `lastSeenChangelogVersion: undefined`) needs no entry in
+A new **top-level** field whose default in `initialUserData` (`src/store/user-data.ts`)
+already means "unset" (e.g. `lastSeenChangelogVersion: undefined`) needs no entry in
 `user-data-migrations.ts`. `applyUserData`'s `Object.assign(userData, newData)` only
 overwrites keys present in the loaded blob — a key absent from an existing user's stored
 data (because it predates the field) is simply left at the `initialUserData` default.
 Migrations are only for transforming a field that already has a *different* stored value.
+
+**That exemption stops at the top level.** `Object.assign` is a shallow merge, so a loaded
+blob's `settings` object replaces the default `settings` wholesale — every *nested* new
+field (`settings.burn.planetPickup`) reads back `undefined` for existing users no matter
+what its `initialUserData` default is. Nested fields always need a migration, and reads on
+the path should stay defensive (`settings.burn.planetPickup?.[id]`, as `getResupplyDays`
+already does for `planetResupply`) to cover data written before the migration lands.
 
 ### Comparators in a Primary/Secondary Sort Chain
 

--- a/src/core/burn.ts
+++ b/src/core/burn.ts
@@ -67,19 +67,20 @@ const burnBySiteId = computed(() => {
   return bySiteId;
 });
 
-export function getInboundShipStores(planetNaturalId: string | undefined) {
-  if (!inboundShipInventoryEnabled.value) {
-    return [];
-  }
-  if (!planetNaturalId) {
+// Ships currently in flight towards the planet. A landed ship has no flightId,
+// so this is exactly "dispatched but not arrived yet". Unlike
+// getInboundShipStores this is not gated behind oog-burn-inflight-inventory —
+// it answers "is a ship already on its way", not "does its cargo count as
+// inventory".
+export function getInboundShips(planetNaturalId: string | undefined) {
+  if (planetNaturalId === undefined) {
     return [];
   }
   const ships = shipsStore.all.value;
-  const stores = storagesStore.all.value;
-  if (!ships || !stores) {
+  if (!ships) {
     return [];
   }
-  const result: PrunApi.Store[] = [];
+  const result: PrunApi.Ship[] = [];
   for (const ship of ships) {
     if (!ship.flightId) {
       continue;
@@ -91,6 +92,21 @@ export function getInboundShipStores(planetNaturalId: string | undefined) {
     if (getEntityNaturalIdFromAddress(flight.destination) !== planetNaturalId) {
       continue;
     }
+    result.push(ship);
+  }
+  return result;
+}
+
+export function getInboundShipStores(planetNaturalId: string | undefined) {
+  if (!inboundShipInventoryEnabled.value) {
+    return [];
+  }
+  const stores = storagesStore.all.value;
+  if (!stores) {
+    return [];
+  }
+  const result: PrunApi.Store[] = [];
+  for (const ship of getInboundShips(planetNaturalId)) {
     const shipStore = stores.find(x => x.id === ship.idShipStore);
     if (shipStore) {
       result.push(shipStore);

--- a/src/core/ship-sizes.ts
+++ b/src/core/ship-sizes.ts
@@ -1,23 +1,27 @@
 export interface ShipSize {
+  // Stable key persisted in userData.settings.burn.planetPickup, and the
+  // compact form shown on ACT's fit-to-ship buttons. Renaming one silently
+  // drops the planets that already point at it — change `label` instead.
+  id: string;
+  // Display text for the XIT PLANETS dropdown. Spells out the units so a
+  // 3k/1k hold can't be read as 3,000m³.
   label: string;
   weight: number;
   volume: number;
 }
 
 // Cargo hold sizes of the common freighter configurations, smallest first.
-// Labels double as the persisted key for per-planet pickup picks, so renaming
-// one silently drops the planets that already point at it.
 export const shipSizes: ShipSize[] = [
-  { label: '500/500', weight: 500, volume: 500 },
-  { label: '1k/3k', weight: 1000, volume: 3000 },
-  { label: '2k/2k', weight: 2000, volume: 2000 },
-  { label: '3k/1k', weight: 3000, volume: 1000 },
-  { label: '5k/5k', weight: 5000, volume: 5000 },
+  { id: '500/500', label: '500t / 500m³', weight: 500, volume: 500 },
+  { id: '1k/3k', label: '1kt / 3km³', weight: 1000, volume: 3000 },
+  { id: '2k/2k', label: '2kt / 2km³', weight: 2000, volume: 2000 },
+  { id: '3k/1k', label: '3kt / 1km³', weight: 3000, volume: 1000 },
+  { id: '5k/5k', label: '5kt / 5km³', weight: 5000, volume: 5000 },
 ];
 
-export function getShipSize(label: string | undefined) {
-  if (label === undefined) {
+export function getShipSize(id: string | undefined) {
+  if (id === undefined) {
     return undefined;
   }
-  return shipSizes.find(x => x.label === label);
+  return shipSizes.find(x => x.id === id);
 }

--- a/src/core/ship-sizes.ts
+++ b/src/core/ship-sizes.ts
@@ -1,0 +1,23 @@
+export interface ShipSize {
+  label: string;
+  weight: number;
+  volume: number;
+}
+
+// Cargo hold sizes of the common freighter configurations, smallest first.
+// Labels double as the persisted key for per-planet pickup picks, so renaming
+// one silently drops the planets that already point at it.
+export const shipSizes: ShipSize[] = [
+  { label: '500/500', weight: 500, volume: 500 },
+  { label: '1k/3k', weight: 1000, volume: 3000 },
+  { label: '2k/2k', weight: 2000, volume: 2000 },
+  { label: '3k/1k', weight: 3000, volume: 1000 },
+  { label: '5k/5k', weight: 5000, volume: 5000 },
+];
+
+export function getShipSize(label: string | undefined) {
+  if (label === undefined) {
+    return undefined;
+  }
+  return shipSizes.find(x => x.label === label);
+}

--- a/src/core/storage-analysis.ts
+++ b/src/core/storage-analysis.ts
@@ -326,16 +326,21 @@ export function getStorageAlarmLevel(
 export interface PickupAlarm {
   // The ship size the base is waiting for.
   shipSize: ShipSize;
-  // Short human-readable explanation of what filled the ship.
+  // Short human-readable explanation of what fills the ship.
   reason: string;
 }
 
-// Alarm for XIT BS's Inv column: a base whose accumulated produced goods would
-// already fill the pickup ship picked for it in XIT PLANETS. Returns undefined
-// when no ship size is configured, when the pile is still too small, or when a
-// ship is already in flight to the planet — a dispatched ship clears the alarm
-// so the player doesn't send a second one, while a ship that has already landed
-// does not (its cargo run isn't done until it leaves).
+// How far ahead the alarm looks. A pickup run takes time to arrange, so the
+// badge lights up a day before the produced goods actually fill the ship.
+const PICKUP_LEAD_DAYS = 1;
+
+// Alarm for XIT BS's Inv column: a base whose accumulated produced goods fill —
+// or within PICKUP_LEAD_DAYS will fill — the pickup ship picked for it in XIT
+// PLANETS. Returns undefined when no ship size is configured, when the pile is
+// still too small, or when a ship is already in flight to the planet — a
+// dispatched ship clears the alarm so the player doesn't send a second one,
+// while a ship that has already landed does not (its cargo run isn't done until
+// it leaves).
 export function getPickupAlarm(siteOrId?: PrunApi.Site | string | null): PickupAlarm | undefined {
   const analysis = getBaseStorageAnalysis(siteOrId);
   if (!analysis) {
@@ -351,18 +356,28 @@ export function getPickupAlarm(siteOrId?: PrunApi.Site | string | null): PickupA
     return undefined;
   }
 
-  const fillsWeight = analysis.producedWeight >= shipSize.weight;
-  const fillsVolume = analysis.producedVolume >= shipSize.volume;
+  // The analysis' export rates are the per-day rate at which net-produced goods
+  // pile up, so this is the stock PICKUP_LEAD_DAYS from now.
+  const projectedWeight = analysis.producedWeight + analysis.exportWeight * PICKUP_LEAD_DAYS;
+  const projectedVolume = analysis.producedVolume + analysis.exportVolume * PICKUP_LEAD_DAYS;
+
+  const fillsWeight = projectedWeight >= shipSize.weight;
+  const fillsVolume = projectedVolume >= shipSize.volume;
   if (!fillsWeight && !fillsVolume) {
     return undefined;
   }
 
+  const full =
+    analysis.producedWeight >= shipSize.weight || analysis.producedVolume >= shipSize.volume;
   const binding = fillsWeight ? 'weight' : 'volume';
+  const current = `${fixed02(analysis.producedWeight)}t / ${fixed02(analysis.producedVolume)}m³`;
+  const projected = `${fixed02(projectedWeight)}t / ${fixed02(projectedVolume)}m³`;
   return {
     shipSize,
-    reason:
-      `Pickup ready: ${fixed02(analysis.producedWeight)}t / ` +
-      `${fixed02(analysis.producedVolume)}m³ fills a ${shipSize.label} ship (${binding})`,
+    reason: full
+      ? `Pickup ready: ${current} fills a ${shipSize.label} ship (${binding})`
+      : `Pickup ready within 24h: ${current} now, ${projected} in 24h — ` +
+        `fills a ${shipSize.label} ship (${binding})`,
   };
 }
 

--- a/src/core/storage-analysis.ts
+++ b/src/core/storage-analysis.ts
@@ -1,10 +1,14 @@
 import {
   computeNeed,
+  getInboundShips,
   getInboundShipStores,
   getMinDaysLeft,
   getPlanetBurn,
   getResupplyDays,
 } from '@src/core/burn';
+import { getShipSize, ShipSize } from '@src/core/ship-sizes';
+import { userData } from '@src/store/user-data';
+import { fixed02 } from '@src/utils/format';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
@@ -29,6 +33,11 @@ export interface BaseStorageAnalysis {
   importVolume: number;
   exportWeight: number;
   exportVolume: number;
+
+  // Current inventory of strictly net-producing (dailyAmount > 0) materials —
+  // the goods a pickup run would actually carry away.
+  producedWeight: number;
+  producedVolume: number;
 
   // Current fill.
   fillPercentWeight: number;
@@ -215,6 +224,8 @@ function computeAnalysis(site: PrunApi.Site): BaseStorageAnalysis | undefined {
     importVolume,
     exportWeight,
     exportVolume,
+    producedWeight: shippedOutWeight,
+    producedVolume: shippedOutVolume,
     fillPercentWeight,
     fillPercentVolume,
     fillPercentWeightNoInf,
@@ -310,6 +321,49 @@ export function getStorageAlarmLevel(
     };
   }
   return { level: 'none' };
+}
+
+export interface PickupAlarm {
+  // The ship size the base is waiting for.
+  shipSize: ShipSize;
+  // Short human-readable explanation of what filled the ship.
+  reason: string;
+}
+
+// Alarm for XIT BS's Inv column: a base whose accumulated produced goods would
+// already fill the pickup ship picked for it in XIT PLANETS. Returns undefined
+// when no ship size is configured, when the pile is still too small, or when a
+// ship is already in flight to the planet — a dispatched ship clears the alarm
+// so the player doesn't send a second one, while a ship that has already landed
+// does not (its cargo run isn't done until it leaves).
+export function getPickupAlarm(siteOrId?: PrunApi.Site | string | null): PickupAlarm | undefined {
+  const analysis = getBaseStorageAnalysis(siteOrId);
+  if (!analysis) {
+    return undefined;
+  }
+
+  const shipSize = getShipSize(userData.settings.burn.planetPickup?.[analysis.naturalId]);
+  if (!shipSize) {
+    return undefined;
+  }
+
+  if (getInboundShips(analysis.naturalId).length > 0) {
+    return undefined;
+  }
+
+  const fillsWeight = analysis.producedWeight >= shipSize.weight;
+  const fillsVolume = analysis.producedVolume >= shipSize.volume;
+  if (!fillsWeight && !fillsVolume) {
+    return undefined;
+  }
+
+  const binding = fillsWeight ? 'weight' : 'volume';
+  return {
+    shipSize,
+    reason:
+      `Pickup ready: ${fixed02(analysis.producedWeight)}t / ` +
+      `${fixed02(analysis.producedVolume)}m³ fills a ${shipSize.label} ship (${binding})`,
+  };
 }
 
 // Returns a synthetic Store representing the base's STORE after a full resupply

--- a/src/core/storage-analysis.ts
+++ b/src/core/storage-analysis.ts
@@ -375,9 +375,9 @@ export function getPickupAlarm(siteOrId?: PrunApi.Site | string | null): PickupA
   return {
     shipSize,
     reason: full
-      ? `Pickup ready: ${current} fills a ${shipSize.label} ship (${binding})`
+      ? `Pickup ready: ${current} fills a ${shipSize.id} ship (${binding})`
       : `Pickup ready within 24h: ${current} now, ${projected} in 24h — ` +
-        `fills a ${shipSize.label} ship (${binding})`,
+        `fills a ${shipSize.id} ship (${binding})`,
   };
 }
 

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -167,11 +167,11 @@ const shipName = computed(() => {
     <span>Fit to Ship</span>
     <PrunButton
       v-for="ship in shipSizes"
-      :key="ship.label"
+      :key="ship.id"
       primary
       :disabled="!canFit"
       @click="fitToShip(ship.weight, ship.volume)">
-      {{ ship.label }}
+      {{ ship.id }}
     </PrunButton>
     <template v-if="shipName && shipFree">
       <span>Fit Selected</span>

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -16,6 +16,7 @@ import { getResupplyDays } from '@src/core/burn';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { fixed02 } from '@src/utils/format';
+import { shipSizes } from '@src/core/ship-sizes';
 
 const { data, config, shipStore } = defineProps<{
   data: UserData.MaterialGroupData;
@@ -89,12 +90,6 @@ const totals = computed(() => {
   }
   return billTotals(entries);
 });
-
-const shipSizes = [
-  { label: '2k/2k', weight: 2000, volume: 2000 },
-  { label: '3k/1k', weight: 3000, volume: 1000 },
-  { label: '5k/5k', weight: 5000, volume: 5000 },
-];
 
 // Binary search for the maximum whole-day count whose bill fits the ship.
 function fitToShip(maxWeight: number, maxVolume: number) {

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -5,7 +5,7 @@ import InvBar from '@src/features/XIT/BS/InvBar.vue';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { getPlanetBurn } from '@src/core/burn';
 import { countDays } from '@src/features/XIT/BURN/utils';
-import { getStorageAlarmLevel } from '@src/core/storage-analysis';
+import { getPickupAlarm, getStorageAlarmLevel } from '@src/core/storage-analysis';
 import { fixed1 } from '@src/utils/format';
 import { getPlanetProduction } from '@src/core/production';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
@@ -128,6 +128,9 @@ const barAlarmReason = computed(() =>
   storageAlarm.value?.level === 'red' ? storageAlarm.value.reason : undefined,
 );
 
+const pickupAlarm = computed(() => getPickupAlarm(siteId));
+const rocket = '\u{1F680}';
+
 const warehouse = computed(() => warehousesStore.getByEntityNaturalId(naturalId));
 const warehouseStore = computed(() =>
   storagesStore
@@ -194,6 +197,13 @@ const warehouseStore = computed(() =>
           :data-tooltip="storageAlarm.reason"
           data-tooltip-position="top">
           <span :class="$style.statusNum">{{ fillDaysText }}</span>
+        </div>
+        <div
+          v-if="pickupAlarm"
+          :class="[C.ProgressBar.progress, $style.pickupBox, C.Workforces.daysSupplied]"
+          :data-tooltip="pickupAlarm.reason"
+          data-tooltip-position="top">
+          <span>{{ rocket }}</span>
         </div>
       </div>
     </td>
@@ -294,5 +304,20 @@ const warehouseStore = computed(() =>
   justify-content: center;
   height: 13px;
   padding: 0 1px;
+}
+
+/* padding: 0 cancels the game's [data-tooltip] rule (`padding: 0 4px 0`), which
+   would otherwise widen the box beyond the glyph it centres. */
+.pickupBox {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 13px;
+  padding: 0;
+  margin: 0;
+  font-size: 10px;
+  line-height: 1;
 }
 </style>

--- a/src/features/XIT/PLANETS/PLANETS.ts
+++ b/src/features/XIT/PLANETS/PLANETS.ts
@@ -4,7 +4,7 @@ xit.add({
   command: ['PLANETS', 'PLNT'],
   name: 'BASE PLANETS',
   description:
-    'Per-planet overrides (resupply days, repair threshold, repair offset) for bases you own.',
+    'Per-planet settings (resupply days, pickup ship size, repair threshold, repair offset) for bases you own.',
   component: () => PLANETS,
   bufferSize: [700, 400],
 });

--- a/src/features/XIT/PLANETS/PLANETS.vue
+++ b/src/features/XIT/PLANETS/PLANETS.vue
@@ -127,7 +127,7 @@ function setRepairField(
               Pickup
               <Tooltip
                 position="bottom"
-                tooltip="Cargo size of the ship you collect this base's output with. XIT BS shows a green &#x1F680; next to the base's inventory bar once its produced goods would fill that ship — until a ship is in flight to the planet." />
+                tooltip="Cargo size of the ship you collect this base's output with. XIT BS shows a green &#x1F680; next to the base's inventory bar 24 hours before the base's produced goods fill that ship — until a ship is in flight to the planet." />
             </InlineFlex>
           </th>
           <th>

--- a/src/features/XIT/PLANETS/PLANETS.vue
+++ b/src/features/XIT/PLANETS/PLANETS.vue
@@ -57,7 +57,7 @@ function setResupplyOverride(naturalId: string, value: number | undefined) {
 // strings, so the absence of an override is spelled as ''.
 const pickupOptions = [
   { label: '—', value: '' },
-  ...shipSizes.map(x => ({ label: x.label, value: x.label })),
+  ...shipSizes.map(x => ({ label: x.label, value: x.id })),
 ];
 
 function getPickup(naturalId: string) {
@@ -127,7 +127,7 @@ function setRepairField(
               Pickup
               <Tooltip
                 position="bottom"
-                tooltip="Cargo size of the ship you collect this base's output with. XIT BS shows a green &#x1F680; next to the base's inventory bar 24 hours before the base's produced goods fill that ship — until a ship is in flight to the planet." />
+                tooltip="Cargo size (weight / volume) of the ship you collect this base's output with. XIT BS shows a green &#x1F680; next to the base's inventory bar 24 hours before the base's produced goods fill that ship — until a ship is in flight to the planet." />
             </InlineFlex>
           </th>
           <th>
@@ -218,7 +218,7 @@ function setRepairField(
 }
 
 .pickup {
-  width: 80px;
+  width: 110px;
 }
 
 .selectWrap {

--- a/src/features/XIT/PLANETS/PLANETS.vue
+++ b/src/features/XIT/PLANETS/PLANETS.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
 import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
 import Tooltip from '@src/components/Tooltip.vue';
 import InlineFlex from '@src/components/InlineFlex.vue';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
@@ -10,6 +11,7 @@ import {
 } from '@src/infrastructure/prun-api/data/addresses';
 import { userData } from '@src/store/user-data';
 import { comparePlanets } from '@src/util';
+import { shipSizes } from '@src/core/ship-sizes';
 
 interface Row {
   siteId: string;
@@ -51,6 +53,26 @@ function setResupplyOverride(naturalId: string, value: number | undefined) {
   }
 }
 
+// The empty value is the "no pickup tracking" option — SelectInput binds
+// strings, so the absence of an override is spelled as ''.
+const pickupOptions = [
+  { label: '—', value: '' },
+  ...shipSizes.map(x => ({ label: x.label, value: x.label })),
+];
+
+function getPickup(naturalId: string) {
+  return userData.settings.burn.planetPickup?.[naturalId] ?? '';
+}
+
+function setPickup(naturalId: string, value: string | undefined) {
+  const map = userData.settings.burn.planetPickup;
+  if (value === undefined || value === '') {
+    delete map[naturalId];
+  } else {
+    map[naturalId] = value;
+  }
+}
+
 function getRepairOverride(naturalId: string) {
   return userData.settings.repair.planetOverrides[naturalId];
 }
@@ -85,7 +107,8 @@ function setRepairField(
   <div v-else-if="rows.length === 0" :class="$style.empty">No bases yet</div>
   <template v-else>
     <div :class="$style.note">
-      Clear any field to remove its override and use the default value (from XIT SET / XIT REP).
+      Clear any number field to remove its override and use the default value (from XIT SET / XIT
+      REP).
     </div>
     <table :class="$style.table">
       <thead>
@@ -97,6 +120,14 @@ function setRepairField(
               <Tooltip
                 position="bottom"
                 :tooltip="`Per-planet override. Leave empty to use the default (${defaultResupply} days) from XIT SET.`" />
+            </InlineFlex>
+          </th>
+          <th>
+            <InlineFlex>
+              Pickup
+              <Tooltip
+                position="bottom"
+                tooltip="Cargo size of the ship you collect this base's output with. XIT BS shows a green &#x1F680; next to the base's inventory bar once its produced goods would fill that ship — until a ship is in flight to the planet." />
             </InlineFlex>
           </th>
           <th>
@@ -125,6 +156,14 @@ function setRepairField(
               :model-value="getResupplyOverride(row.naturalId)"
               optional
               @update:model-value="setResupplyOverride(row.naturalId, $event)" />
+          </td>
+          <td :class="$style.pickup">
+            <div :class="[C.forms.input, $style.selectWrap]">
+              <SelectInput
+                :model-value="getPickup(row.naturalId)"
+                :options="pickupOptions"
+                @update:model-value="setPickup(row.naturalId, $event)" />
+            </div>
           </td>
           <td :class="$style.input">
             <NumberInput
@@ -176,6 +215,21 @@ function setRepairField(
   &:focus {
     outline: none;
   }
+}
+
+.pickup {
+  width: 80px;
+}
+
+.selectWrap {
+  width: 100%;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.selectWrap :global(div) {
+  width: 100%;
+  margin-left: 0;
 }
 
 .empty {

--- a/src/store/user-data-migrations.ts
+++ b/src/store/user-data-migrations.ts
@@ -17,6 +17,12 @@ function isCheckpoint(entry: MigrationEntry): entry is Checkpoint {
 // The date is for reference only, and it does not affect migration order.
 const migrations: MigrationEntry[] = [
   [
+    '08.08.2026 Add per-planet pickup ship sizes',
+    userData => {
+      userData.settings.burn.planetPickup = {};
+    },
+  ],
+  [
     '13.07.2026 Add govburn thresholds',
     userData => {
       userData.govburn.config.red = 3;

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -28,6 +28,8 @@ export const initialUserData = deepFreeze({
       yellow: 7,
       resupply: 16,
       planetResupply: {} as Record<string, number>,
+      // Planet natural id -> ship-size label from core/ship-sizes.
+      planetPickup: {} as Record<string, string>,
     },
     repair: {
       threshold: 60,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,4 +1,4 @@
-import { configDefaults, defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import libAssetsPlugin from '@laynezh/vite-plugin-lib-assets';
 import vue from '@vitejs/plugin-vue';
@@ -111,13 +111,6 @@ export default defineConfig({
   define: {
     // This define is needed for vue npm packages
     'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`,
-  },
-  test: {
-    // Vitest 4 narrowed its default exclude to node_modules and .git, and the
-    // build emits every *.test.ts as its own dist chunk. Without this the
-    // suite collects those compiled copies alongside the sources and dies on
-    // `document is not defined`.
-    exclude: [...configDefaults.exclude, 'dist/**'],
   },
 });
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { configDefaults, defineConfig } from 'vitest/config';
 import { resolve } from 'path';
 import libAssetsPlugin from '@laynezh/vite-plugin-lib-assets';
 import vue from '@vitejs/plugin-vue';
@@ -111,6 +111,13 @@ export default defineConfig({
   define: {
     // This define is needed for vue npm packages
     'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`,
+  },
+  test: {
+    // Vitest 4 narrowed its default exclude to node_modules and .git, and the
+    // build emits every *.test.ts as its own dist chunk. Without this the
+    // suite collects those compiled copies alongside the sources and dies on
+    // `document is not defined`.
+    exclude: [...configDefaults.exclude, 'dist/**'],
   },
 });
 


### PR DESCRIPTION
## Summary

Adds a **Pickup** column to `XIT PLANETS` where each base picks the cargo size of the ship you collect its output with, and a green 🚀 badge in `XIT BS` that fires when that base has enough produced goods to fill it.

**The badge** sits next to the base's inventory bar, in the same slot and styling as the existing yellow fill-warning box (reusing `C.Workforces.daysSupplied`, the green already used by the Burn column). It appears when the base's accumulated produced goods — the current stock of every material with a positive net burn — reach the selected ship's weight **or** volume, projected **24 hours forward** at the base's net production rate so there's a day's notice to arrange the run. The tooltip distinguishes the two states:

- `Pickup ready: 2,140t / 980m³ fills a 3k/1k ship (weight)`
- `Pickup ready within 24h: 1,950t / 900m³ now, 2,050t / 940m³ in 24h — fills a 3k/1k ship (weight)`

It clears while a ship is in flight to the planet, so a second one doesn't get dispatched. A ship that has already **landed** does not clear it — its run isn't done until it leaves.

**Sizes are labelled in units** (`3kt / 1km³`, not `3k/1k`) because `1k/3k` and `3k/1k` sitting two rows apart made it a coin flip which was the high-mass hold. `ShipSize` carries a stable `id` next to the display `label`; the id is what's persisted, so labels stay free to change without orphaning saved picks, and since the ids are byte-identical to the previous labels no migration is needed.

### Supporting changes

- **`src/core/ship-sizes.ts`** holds the cargo presets (500/500, 1k/3k, 2k/2k, 3k/1k, 5k/5k), replacing the local list in the resupply material group's `Configure.vue`. That panel's fit-to-ship buttons render the compact `id` and are unchanged in appearance, but now offer 500/500 and 1k/3k too.
- **`getInboundShips`** split out of `core/burn.ts`. The existing `getInboundShipStores` is gated behind `oog-burn-inflight-inventory`, which ships **disabled by default** — it returns `[]` for most users. It answers "does in-flight cargo count as inventory"; the badge needs the factual "is a ship on its way", so it uses the ungated variant. Written against the gated helper, the clear-on-dispatch rule would have silently never fired.
- **`BaseStorageAnalysis`** exposes `producedWeight`/`producedVolume`, which the analysis already computed internally.

### Docs

Three findings distilled into `docs/feature-patterns.md` and `docs/architecture.md`:

- The feature-gated-core-helper rule above, so the next person doesn't reuse `getInboundShipStores` for a factual question.
- A correction to the *"Adding a Field to `initialUserData`"* section added in `e86029d`. That section's "no migration needed" exemption holds only for **top-level** fields: `applyUserData`'s `Object.assign` is shallow, so a nested field like `settings.burn.planetPickup` reads back `undefined` for existing users regardless of its default — which is exactly why this PR ships a migration for it.
- A note that test files must stay out of `src/features/index.ts`'s `import.meta.glob` sweeps. Dropping those `!` patterns puts compiled `*.test.js` into `dist/`, and vitest 4 no longer excludes `dist/**` by default, so the suite then collects them and dies on `document is not defined` while naming a *source* file.

That last note has some history worth flagging: this branch briefly carried a `test.exclude` entry in `vite.config.mts` as a backstop for it. That was **reverted** — verified against main directly, a full build of main emits zero test chunks and vitest passes against that populated `dist/`, because #135 (`a8ccce1`) already fixed it at the source. The symptom I originally hit came from a `dist/` built before that fix reached this branch. `vite.config.mts` is byte-identical to main here; only the doc note survives.

### Not covered

No CI workflow runs the test suite today (`lint.yml`, `build-extension.yml` and friends never invoke vitest), so nothing would catch a genuinely broken test in CI. Left alone as out of scope.

Browser verification against the live game hasn't been done — this was built in a cloud session, and the harness needs the local WSL2 checkout. The dropdown width and badge placement are the parts worth a look.

## Standards Checklist

- [x] No upward imports across layers (features -> core -> infrastructure -> utils)
  - `core/storage-analysis.ts` importing `@src/store/user-data` follows existing precedent — `core/burn.ts` already does it for `getResupplyDays`, and `store/` is a side node in the layer diagram, not an upward layer.
- [x] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [x] CSS rules scoped to commands where applicable — all new CSS is in `<style module>` blocks
- [x] Numbers use formatters from `@src/utils/format` (`fixed02` in the badge tooltip)
- [x] No `title=` attributes (use `data-tooltip`)
- [x] No `onApiMessage` in features (use `computed` from stores)
- [x] Feature has single responsibility, no cross-feature deps — true of the feature; the distilled docs ride along, per AGENTS.md's "distill and commit before writing a PR"
- [x] CSS class names describe WHERE, not WHAT (`.pickup`, `.pickupBox`, `.selectWrap`)
- [x] Uses `C.Component.className` not hardcoded hashed classes
- [x] CHANGELOG.md updated under `## Unreleased`

## Verification

- `pnpm run compile` clean
- `pnpm run build` succeeds, emitting no test chunks
- `pnpm exec vitest run` — 7 files / 57 tests, with `dist/` both populated and absent