### PR TITLE
XIT ACT: warn instead of failing when a CX is short on stock

### DIFF
--- a/.claude/harness-notes.md
+++ b/.claude/harness-notes.md
@@ -27,7 +27,10 @@ intentional, so never work around it by widening the allowlist.
 Scope that bypass to commands that actually write config, though — a plain
 `git push origin <branch>` (no `-u`) touches only refs, and github.com is already an
 allowed host, so it runs fine sandboxed. Reaching for `dangerouslyDisableSandbox` "because
-it's a push" spends a user approval for nothing.
+it's a push" spends a user approval for nothing. Same trap on the branch side:
+`git checkout -b <new-branch>` off current HEAD moves no files and (branching from a local
+HEAD, not a remote-tracking ref) writes no config, so it needs no bypass either — the
+checkout rule above is about *switching between* existing branches.
 
 Watch one non-obvious config write: `git branch -f <branch> origin/main`, used to reset a
 merged branch, *also* re-points that branch's upstream to `origin/main` via
@@ -53,6 +56,15 @@ literally. Things that quietly cost the user a manual approval:
   excluded command.
 - **Absolute paths.** `node /home/.../repo/scripts/pw-act.mjs` matches neither the
   allowlist nor the exclusion. Always invoke repo scripts by their relative path.
+
+## Web/cloud sessions
+
+The container is a fresh clone with **no `node_modules`**, so the first
+`pnpm run compile` fails with `Cannot find type definition file for 'chrome'` and
+`File '@vue/tsconfig/tsconfig.dom.json' not found` — that is a missing install, not a
+broken tsconfig. Run `pnpm install --frozen-lockfile` first. `grok` is not installed
+either, so implement directly per `AGENTS.md`, and the browser harness below is
+unavailable — say so once, don't try to stand it up.
 
 ## Browser harness specifics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ships and opens a fresh `Unreleased` section.
 ### Changed
 
 - `XIT ACT`: Auto-SFC step now sets the destination planet with the same address-select helper used by CONTD import, dropping two redundant confirmation clicks
+- `XIT ACT`: A commodity exchange short on stock no longer aborts the whole action package. The buy warns and offers whatever the order book can fill, so you can ACT on the partial amount, adjust it by hand, or SKIP it
 
 ### Fixed
 

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -244,10 +244,13 @@ during the pause is handled.
   frozen at generation (on) or re-checked against the live book when the step runs (off).
   `allowUnfilled` is the separate "rest the remainder as a standing bid" flag.
 - **Size follow-up steps by what the CX can fill.** An action that emits a purchase and then
-  emits steps consuming it must plan against `fillAmount()`, not the requested amount, or
-  those steps ask the game for materials that never arrived — Refuel's `emitFuelPurchase`
-  returns the fillable amount for exactly this reason. A residual gap stays: the book can
-  drop further between generation and execution, and already-emitted steps can't shrink.
+  emits steps consuming it must plan against `fillAmount()`, not the requested amount —
+  Refuel's `emitFuelPurchase` returns the fillable amount for exactly this reason. The
+  consuming steps survive either way (`MTRA_TRANSFER` clamps to the MTRA slider max and
+  warns), so what the sizing buys is *where the player finds out*: planned against the
+  request, the first ships are promised full loads and the last ones quietly get nothing,
+  one loading step at a time. Planned against the fill, the shortfall warns once, up front,
+  next to the purchase that caused it.
 - **`CXPO_BUY`'s quantity `watchEffect` reruns on every order-book tick** while the buffer
   sits open waiting for ACT. Anything with a side effect inside it (logging above all) must
   dedupe, or one slow CX fills the log with the same warning.

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -204,6 +204,12 @@ swallows — an `execute()` body never runs past a failed game action. Code afte
 await (e.g. a `watchWhile` for a storage update that will now never come) can rely on
 this; don't wrap `waitActionFeedback` in a step-local try/catch or the hang comes back.
 
+**`ctx.skip()` and `ctx.fail()` do not unwind `execute()`** — unlike `waitActionFeedback`,
+they just advance/stop the machine and return, so the caller must `return` right after one.
+The reverse also holds: a step parked in `await waitAct()` when the machine moves on (user
+SKIP, or a self-skip from a reactive watcher) never resumes, and everything after that await
+— listener cleanup included — is dropped. Do teardown before the skip, not after the await.
+
 ### Reminder Pauses in ACT Steps
 
 When a step needs the player to do something manually in a companion buffer before the
@@ -231,6 +237,24 @@ during the pause is handled.
 - **`CX Buy` with `useCXInv: true` nets out warehouse stock**, so a PREVIEW showing
   `Buy 900` against `Transfer 1,000` of the same ticker is correct (100 already in the
   warehouse), not a quantity bug.
+- **A short CX order book only warns, never aborts the package.** Both the generation-time
+  check (`cx-buy.ts`) and the live one in `CXPO_BUY` log a warning and buy what
+  `fillAmount()` says is available; a ticker with nothing available is skipped. `buyPartial`
+  no longer decides whether a shortage is fatal — it only decides whether the quantity is
+  frozen at generation (on) or re-checked against the live book when the step runs (off).
+  `allowUnfilled` is the separate "rest the remainder as a standing bid" flag.
+- **Size follow-up steps by what the CX can fill.** An action that emits a purchase and then
+  emits steps consuming it must plan against `fillAmount()`, not the requested amount, or
+  those steps ask the game for materials that never arrived — Refuel's `emitFuelPurchase`
+  returns the fillable amount for exactly this reason. A residual gap stays: the book can
+  drop further between generation and execution, and already-emitted steps can't shrink.
+- **`CXPO_BUY`'s quantity `watchEffect` reruns on every order-book tick** while the buffer
+  sits open waiting for ACT. Anything with a side effect inside it (logging above all) must
+  dedupe, or one slow CX fills the log with the same warning.
+- **Step `Data` is per-run, not persisted.** `action-steps/*` interfaces are rebuilt by
+  every generation pass, so fields can be added or dropped freely. `UserData.ActionData`
+  fields are the opposite: they persist in saved packages and are mirrored in
+  `agent-sync.ts`'s short-key map, so removing one needs a migration.
 
 ### Action-Specific Sentinel Values
 

--- a/src/features/XIT/ACT/action-steps/CXPO_BUY.ts
+++ b/src/features/XIT/ACT/action-steps/CXPO_BUY.ts
@@ -15,7 +15,6 @@ interface Data {
   ticker: string;
   amount: number;
   priceLimit: number;
-  buyPartial: boolean;
   allowUnfilled: boolean;
 }
 
@@ -98,6 +97,7 @@ export const CXPO_BUY = act.addActionStep<Data>({
     assert(priceInput !== undefined, 'Missing price input');
 
     let shouldUnwatch = false;
+    let lastShortageWarning: string | undefined;
     const unwatch = watchEffect(() => {
       if (shouldUnwatch) {
         unwatch();
@@ -113,16 +113,6 @@ export const CXPO_BUY = act.addActionStep<Data>({
       }
 
       if (filled.amount < amount && !data.allowUnfilled) {
-        if (!data.buyPartial) {
-          let message = `Not enough materials on ${exchange} to buy ${fixed0(amount)} ${ticker}`;
-          if (isFinite(priceLimit)) {
-            message += ` with price limit ${fixed02(priceLimit)}/u`;
-          }
-          shouldUnwatch = true;
-          fail(message);
-          return;
-        }
-
         const leftover = amount - filled.amount;
         let message =
           `${fixed0(leftover)} ${ticker} will not be bought on ${exchange} ` +
@@ -131,7 +121,12 @@ export const CXPO_BUY = act.addActionStep<Data>({
           message += ` with price limit ${fixed02(priceLimit)}/u`;
         }
         message += ')';
-        log.warning(message);
+        // The order book keeps updating while the buffer is open, so this effect
+        // reruns on every change. Only log a shortage when it actually changed.
+        if (message !== lastShortageWarning) {
+          lastShortageWarning = message;
+          log.warning(message);
+        }
         if (filled.amount === 0) {
           shouldUnwatch = true;
           skip();

--- a/src/features/XIT/ACT/actions/cx-buy/Edit.vue
+++ b/src/features/XIT/ACT/actions/cx-buy/Edit.vue
@@ -71,7 +71,7 @@ defineExpose({ validate, save });
   </Commands>
   <Active
     label="Buy Partial"
-    tooltip="Whether the action will be taken if there is not enough stock on the CX.">
+    tooltip="Lock the order to the stock available when the package starts. If off, the amount is re-checked when the step runs. Either way, a shortage only warns.">
     <RadioItem v-model="buyPartial">buy partial</RadioItem>
   </Active>
   <Active

--- a/src/features/XIT/ACT/actions/cx-buy/cx-buy.ts
+++ b/src/features/XIT/ACT/actions/cx-buy/cx-buy.ts
@@ -30,8 +30,7 @@ act.addAction<Config>({
     data.exchange !== configurableValue ||
     config.exchange !== undefined,
   generateSteps: async ctx => {
-    const { data, config, state, log, fail, getMaterialGroup, getMaterialGroupPrices, emitStep } =
-      ctx;
+    const { data, config, state, log, getMaterialGroup, getMaterialGroupPrices, emitStep } = ctx;
 
     if (data.skippable && config.skip) {
       return;
@@ -87,15 +86,6 @@ act.addAction<Config>({
       let bidAmount = amount;
 
       if (filled && filled.amount < amount && !allowUnfilled) {
-        if (!buyPartial) {
-          let message = `Not enough materials on ${exchange} to buy ${fixed0(amount)} ${ticker}`;
-          if (isFinite(priceLimit)) {
-            message += ` with price limit ${fixed02(priceLimit)}/u`;
-          }
-          fail(message);
-          return;
-        }
-
         const leftover = amount - filled.amount;
         let message =
           `${fixed0(leftover)} ${ticker} will not be bought on ${exchange} ` +
@@ -108,8 +98,11 @@ act.addAction<Config>({
         if (filled.amount === 0) {
           continue;
         }
-
-        bidAmount = filled.amount;
+        if (buyPartial) {
+          // Lock the order to what is available now. Otherwise the full amount is
+          // kept and the step buys whatever is available when it actually runs.
+          bidAmount = filled.amount;
+        }
       }
 
       emitStep(
@@ -118,7 +111,6 @@ act.addAction<Config>({
           ticker,
           amount: bidAmount,
           priceLimit: priceLimit,
-          buyPartial: buyPartial,
           allowUnfilled: allowUnfilled,
         }),
       );

--- a/src/features/XIT/ACT/actions/refuel/refuel.ts
+++ b/src/features/XIT/ACT/actions/refuel/refuel.ts
@@ -110,7 +110,6 @@ function refuelFromOrigin(
           ticker: stlMaterial.ticker,
           amount: totalStlRefuel - presentStlFuel,
           priceLimit: Number.POSITIVE_INFINITY,
-          buyPartial: false,
           allowUnfilled: false,
         }),
       );
@@ -132,7 +131,6 @@ function refuelFromOrigin(
           ticker: ftlMaterial.ticker,
           amount: totalFtlRefuel - presentFtlFuel,
           priceLimit: Number.POSITIVE_INFINITY,
-          buyPartial: false,
           allowUnfilled: false,
         }),
       );

--- a/src/features/XIT/ACT/actions/refuel/refuel.ts
+++ b/src/features/XIT/ACT/actions/refuel/refuel.ts
@@ -4,6 +4,7 @@ import Configure from '@src/features/XIT/ACT/actions/refuel/Configure.vue';
 import { Config } from '@src/features/XIT/ACT/actions/refuel/config';
 import { allExchangesValue, getRefuelOrigins } from '@src/features/XIT/ACT/actions/refuel/utils';
 import { CXPO_BUY } from '@src/features/XIT/ACT/action-steps/CXPO_BUY';
+import { fillAmount } from '@src/features/XIT/ACT/actions/cx-buy/utils';
 import { MTRA_TRANSFER } from '@src/features/XIT/ACT/action-steps/MTRA_TRANSFER';
 import { ActionStep, AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
 import {
@@ -104,17 +105,14 @@ function refuelFromOrigin(
 
   if (presentStlFuel < totalStlRefuel) {
     if (isCX && data.buyMissingFuel) {
-      emitStep(
-        CXPO_BUY({
-          exchange: exchangeCode,
-          ticker: stlMaterial.ticker,
-          amount: totalStlRefuel - presentStlFuel,
-          priceLimit: Number.POSITIVE_INFINITY,
-          allowUnfilled: false,
-        }),
+      presentStlFuel += emitFuelPurchase(
+        exchangeCode,
+        stlMaterial.ticker,
+        totalStlRefuel - presentStlFuel,
+        emitStep,
       );
-      presentStlFuel = totalStlRefuel;
-    } else {
+    }
+    if (presentStlFuel < totalStlRefuel) {
       log.warning(`Not enough SF at ${originName}. Some ships will not be refueled.`);
     }
   }
@@ -125,17 +123,14 @@ function refuelFromOrigin(
 
   if (presentFtlFuel < totalFtlRefuel) {
     if (isCX && data.buyMissingFuel) {
-      emitStep(
-        CXPO_BUY({
-          exchange: exchangeCode,
-          ticker: ftlMaterial.ticker,
-          amount: totalFtlRefuel - presentFtlFuel,
-          priceLimit: Number.POSITIVE_INFINITY,
-          allowUnfilled: false,
-        }),
+      presentFtlFuel += emitFuelPurchase(
+        exchangeCode,
+        ftlMaterial.ticker,
+        totalFtlRefuel - presentFtlFuel,
+        emitStep,
       );
-      presentFtlFuel = totalFtlRefuel;
-    } else {
+    }
+    if (presentFtlFuel < totalFtlRefuel) {
       log.warning(`Not enough FF at ${originName}. Some ships will not be refueled.`);
     }
   }
@@ -171,6 +166,33 @@ function refuelFromOrigin(
     );
     presentFtlFuel -= amount;
   }
+}
+
+// Emits a purchase for the missing fuel and returns how much of it the exchange
+// can actually supply. A short order book only warns, so the transfers planned
+// after this must count on the fillable amount instead of the requested one.
+function emitFuelPurchase(
+  exchange: string,
+  ticker: string,
+  amount: number,
+  emitStep: (step: ActionStep) => void,
+) {
+  const filled = fillAmount(`${ticker}.${exchange}`, amount, Number.POSITIVE_INFINITY);
+  // Without order book data there is nothing better to assume than a full fill.
+  const buyAmount = filled === undefined ? amount : filled.amount;
+  if (buyAmount === 0) {
+    return 0;
+  }
+  emitStep(
+    CXPO_BUY({
+      exchange,
+      ticker,
+      amount: buyAmount,
+      priceLimit: Number.POSITIVE_INFINITY,
+      allowUnfilled: false,
+    }),
+  );
+  return buyAmount;
 }
 
 function getExchangeCode(store: PrunApi.Store) {


### PR DESCRIPTION
## Summary

A `CX Buy` whose exchange ran short of stock aborted the entire action package. That happened in two places, and the second one is the painful one: `CXPO_BUY`'s reactive watcher re-checks the order book *while the buffer is already open waiting for ACT*, so any competing buyer could kill a run that had already done half its work — mid-execution, with the player looking right at it.

Both checks now warn and keep going:

- **`CXPO_BUY` (mid-execution)** — logs a warning and fills the buffer with whatever the order book actually offers, leaving the step parked on ACT/SKIP. ACT buys the available amount, manual input still overrides it, SKIP drops the buy. Zero available still skips the step, as before.
- **`cx-buy.ts` (step generation)** — same downgrade; the package always starts and handles shortfalls per step.

Shortage warnings are deduped by message, because that watcher reruns on every order-book tick — without it one slow CX would fill the log with the same line.

`buyPartial` no longer decides whether a shortage is fatal. What's left of it is *when* availability is measured: on = the quantity is frozen at generation time (preview totals stay honest), off = re-checked against the live book when the step runs. The tooltip said "whether the action will be taken if there is not enough stock on the CX", which is now false, so it's rewritten. The flag also stopped affecting execution, so it's dropped from `CXPO_BUY`'s step `Data` — that's per-run in-memory state, no migration involved. `UserData.ActionData.buyPartial` is untouched.

**Refuel follow-up.** Refuel emitted a purchase for the whole fuel shortfall and then assumed it landed in full, sizing every following `MTRA_TRANSFER` against fuel that might never arrive. The new `emitFuelPurchase` sizes the buy by `fillAmount()` and credits only that much to the transfers.

The transfers themselves were never in danger — `MTRA_TRANSFER` already clamps to the MTRA slider max and warns, skipping when the max is 0. What the sizing changes is **where the player finds out**. Planned against the request, the first ships are promised full loads and the last ones quietly get nothing, discovered one loading step at a time. Planned against the fill, the shortfall warns once at the purchase stage: `Not enough SF at <origin>. Some ships will not be refueled.` now fires whenever the purchase can't cover the gap, where it previously fired only when there was no purchase at all. If the book drops further between generation and the buy step, `CXPO_BUY` warns again at that step — still at the purchase, not at loading.

Not verified against the live game — this was written in a cloud session with no browser harness. The behavior worth eyeballing is a buy sitting open while its stock is drained.

## Standards Checklist

- [x] No upward imports across layers (features -> core -> infrastructure -> utils)
- [x] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [x] CSS rules scoped to commands where applicable — N/A, no CSS
- [x] Numbers use formatters from `@src/utils/format`
- [x] No `title=` attributes (use `data-tooltip`) — tooltip goes through `Active`'s `tooltip` prop
- [x] No `onApiMessage` in features (use `computed` from stores)
- [x] Feature has single responsibility, no cross-feature deps
- [x] CSS class names describe WHERE, not WHAT — N/A
- [x] Uses `C.Component.className` not hardcoded hashed classes
- [x] CHANGELOG.md updated under `## Unreleased`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFPetccYvRWtBYibgYYJ28