### PR TITLE
Give the 1.1.0 CHANGELOG entry a parseable section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,6 @@
 
 ## 1.1.0
 
-Existing features and the 1.1.0 patch additions can be found at https://chromewebstore.google.com/detail/oog-rprun-test-fork/pcakabdnefjhjdgbiapchkejbkhdeebn
+### Notes
+
+- Existing features and the 1.1.0 patch additions can be found at https://chromewebstore.google.com/detail/oog-rprun-test-fork/pcakabdnefjhjdgbiapchkejbkhdeebn


### PR DESCRIPTION
parseChangelog only picks up items under a "### " category heading, and changelog-data.ts filters out releases with zero parsed sections as boundary markers. The 1.1.0 entry was plain text with no heading, so it was silently dropped from XIT WHATSNEW instead of showing up below newer releases.

## Summary

<!-- Brief description of the changes -->

## Standards Checklist

- [ ] No upward imports across layers (features -> core -> infrastructure -> utils)
- [ ] No explicit imports of auto-imported symbols (ref, computed, $, $$, C, subscribe, etc.)
- [ ] CSS rules scoped to commands where applicable
- [ ] Numbers use formatters from `@src/utils/format`
- [ ] No `title=` attributes (use `data-tooltip`)
- [ ] No `onApiMessage` in features (use `computed` from stores)
- [ ] Feature has single responsibility, no cross-feature deps
- [ ] CSS class names describe WHERE, not WHAT
- [ ] Uses `C.Component.className` not hardcoded hashed classes
- [ ] CHANGELOG.md updated under `## Unreleased` (or N/A — no user-facing change)
