### PR TITLE
[JAC-6] Add Linear-Buzz workflow reconciler

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "pnpm exec eslint --concurrency auto",
     "prepare": "husky",
     "prettier": "prettier . --write --ignore-path .prettierignore",
+    "workflow": "node --experimental-strip-types scripts/ai-workflow/cli.ts",
     "open": "scripts\\open-local.bat",
     "test": "vitest run"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,9 @@
 # scripts/
 
+## `ai-workflow/`
+
+Manual-trigger Linear-to-Buzz task-channel reconciler. It keeps its mapping store outside the repository, provisions one channel/canvas per issue idempotently, and archives only after an explicit confirmed command. See `scripts/ai-workflow/README.md`.
+
 ## `build-dist.sh`
 
 Builds the extension and packages it as `dist.zip` at the repo root.

--- a/scripts/ai-workflow/README.md
+++ b/scripts/ai-workflow/README.md
@@ -1,0 +1,53 @@
+# Linear-Buzz workflow reconciler
+
+Manual-trigger Phase 2 bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after an explicit command.
+
+The bridge does not call Linear directly. The initiating agent reads Linear through its authenticated connector and supplies the issue snapshot on the first reconcile. Later reconciles need only the issue key and mapping store. This keeps OAuth credentials out of the repository and mapping data.
+
+## Runtime state
+
+Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 1, atomic replacement, and a local lock file.
+
+```powershell
+$env:AI_WORKFLOW_MAPPING_STORE = 'C:\Users\cyrus\.buzz\.state\ai-workflow\mappings.json'
+```
+
+## First reconcile
+
+```powershell
+pnpm workflow reconcile JAC-6 `
+  --title '[Phase 2] Build and prove the Linear-Buzz reconciler' `
+  --linear-url 'https://linear.app/example/issue/JAC-6/example' `
+  --team-id '<team-uuid>' `
+  --status-todo-id '<status-uuid>' `
+  --status-in-progress-id '<status-uuid>' `
+  --status-in-review-id '<status-uuid>' `
+  --status-done-id '<status-uuid>' `
+  --channel-name 'JAC-6-linear-buzz-reconciler' `
+  --repo 'https://github.com/jackinabox86/refined-prun' `
+  --branch 'JAC-6-linear-buzz-reconciler' `
+  --worktree 'C:\Users\cyrus\.buzz\REPOS\worktrees\JAC-6-linear-buzz-reconciler' `
+  --owner 'Codex Sol' `
+  --member '<human-pubkey>:owner'
+```
+
+If a verified channel already exists after an interrupted first run, add `--adopt-existing`. Adoption is never implicit.
+
+## Recovery and archive
+
+```powershell
+pnpm workflow reconcile JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE
+pnpm workflow inspect JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE
+pnpm workflow archive JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE --confirm
+```
+
+Archive is idempotent. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no delete operation.
+
+## Validation
+
+Run the full repository checks:
+
+```powershell
+pnpm run compile
+pnpm run test
+```

--- a/scripts/ai-workflow/buzz.ts
+++ b/scripts/ai-workflow/buzz.ts
@@ -1,0 +1,170 @@
+import { spawn } from 'node:child_process';
+import { parseMemberRole, type DesiredMember } from './model.ts';
+
+export interface ChannelSummary {
+  channelId: string;
+  name: string;
+  description: string;
+}
+
+export interface BuzzGateway {
+  listChannels(): Promise<ChannelSummary[]>;
+  createChannel(input: {
+    name: string;
+    description: string;
+    type: 'stream' | 'forum';
+    visibility: 'open' | 'private';
+  }): Promise<ChannelSummary>;
+  getChannel(channelId: string): Promise<ChannelSummary>;
+  listMembers(channelId: string): Promise<DesiredMember[]>;
+  addMember(channelId: string, member: DesiredMember): Promise<void>;
+  getCanvas(channelId: string): Promise<string | null>;
+  setCanvas(channelId: string, content: string): Promise<void>;
+  archiveChannel(channelId: string): Promise<void>;
+}
+
+export class BuzzCliGateway implements BuzzGateway {
+  readonly binary: string;
+
+  constructor(binary = 'buzz') {
+    this.binary = binary;
+  }
+
+  async listChannels() {
+    const output = await this.run(['channels', 'list']);
+    const channels = parseJsonArray(output);
+    return channels.map(parseChannel);
+  }
+
+  async createChannel(input: {
+    name: string;
+    description: string;
+    type: 'stream' | 'forum';
+    visibility: 'open' | 'private';
+  }) {
+    const output = await this.run([
+      'channels',
+      'create',
+      '--name',
+      input.name,
+      '--description',
+      input.description,
+      '--type',
+      input.type,
+      '--visibility',
+      input.visibility,
+    ]);
+    const value = parseJsonObject(output);
+    if (typeof value.channel_id !== 'string') {
+      throw new Error('Buzz channel creation did not return channel_id');
+    }
+    return {
+      channelId: value.channel_id,
+      name: input.name,
+      description: input.description,
+    };
+  }
+
+  async getChannel(channelId: string) {
+    const output = await this.run(['channels', 'get', '--channel', channelId]);
+    return parseChannel(parseJsonObject(output));
+  }
+
+  async listMembers(channelId: string) {
+    const output = await this.run(['channels', 'members', '--channel', channelId]);
+    return parseJsonArray(output).map(value => {
+      if (typeof value.pubkey !== 'string' || typeof value.role !== 'string') {
+        throw new Error('Buzz returned an invalid channel member');
+      }
+      return { pubkey: value.pubkey, role: parseMemberRole(value.role) };
+    });
+  }
+
+  async addMember(channelId: string, member: DesiredMember) {
+    await this.run([
+      'channels',
+      'add-member',
+      '--channel',
+      channelId,
+      '--pubkey',
+      member.pubkey,
+      '--role',
+      member.role,
+    ]);
+  }
+
+  async getCanvas(channelId: string) {
+    const output = await this.run(['canvas', 'get', '--channel', channelId]);
+    const normalized = output.replaceAll('\r\n', '\n').trimEnd();
+    return normalized === 'null' ? null : `${normalized}\n`;
+  }
+
+  async setCanvas(channelId: string, content: string) {
+    await this.run(['canvas', 'set', '--channel', channelId, '--content', '-'], content);
+  }
+
+  async archiveChannel(channelId: string) {
+    await this.run(['channels', 'archive', '--channel', channelId]);
+  }
+
+  private async run(arguments_: string[], input?: string) {
+    return await new Promise<string>((resolve, reject) => {
+      const child = spawn(this.binary, arguments_, {
+        shell: false,
+        windowsHide: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', chunk => {
+        stdout += String(chunk);
+      });
+      child.stderr.on('data', chunk => {
+        stderr += String(chunk);
+      });
+      child.on('error', reject);
+      child.on('close', code => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(
+          new Error(`Buzz command failed (${code ?? 'signal'}): ${stderr.trim() || stdout.trim()}`),
+        );
+      });
+      child.stdin.end(input);
+    });
+  }
+}
+
+function parseChannel(value: Record<string, unknown>) {
+  if (typeof value.channel_id !== 'string' || typeof value.name !== 'string') {
+    throw new Error('Buzz returned an invalid channel');
+  }
+  return {
+    channelId: value.channel_id,
+    name: value.name,
+    description: typeof value.description === 'string' ? value.description : '',
+  };
+}
+
+function parseJsonArray(value: string) {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed)) {
+    throw new Error('Buzz command did not return a JSON array');
+  }
+  return parsed.map(asRecord);
+}
+
+function parseJsonObject(value: string) {
+  return asRecord(JSON.parse(value));
+}
+
+function asRecord(value: unknown) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Buzz command returned invalid JSON');
+  }
+  return value as Record<string, unknown>;
+}

--- a/scripts/ai-workflow/cli.ts
+++ b/scripts/ai-workflow/cli.ts
@@ -1,0 +1,221 @@
+import { resolve } from 'node:path';
+import { BuzzCliGateway } from './buzz.ts';
+import {
+  parseMemberRole,
+  normalizePubkey,
+  type DesiredMember,
+  type LinearStatusIds,
+  type ReconcileRequest,
+} from './model.ts';
+import { WorkflowReconciler } from './reconcile.ts';
+import { JsonMappingStore } from './store.ts';
+
+const SWITCHES = new Set(['adopt-existing', 'confirm', 'help']);
+
+async function main() {
+  const rawArguments = process.argv.slice(2);
+  const arguments_ = rawArguments[0] === '--' ? rawArguments.slice(1) : rawArguments;
+  if (arguments_[0] === '--help') {
+    process.stdout.write(helpText());
+    return;
+  }
+  const parsed = parseArguments(arguments_);
+  if (parsed.switches.has('help') || parsed.command === undefined) {
+    process.stdout.write(helpText());
+    return;
+  }
+  const storePath = option(parsed, 'store') ?? process.env.AI_WORKFLOW_MAPPING_STORE;
+  if (storePath === undefined || storePath === '') {
+    throw new Error(
+      'Provide --store or AI_WORKFLOW_MAPPING_STORE; runtime state must stay outside the repo',
+    );
+  }
+  const issueKey = parsed.issueKey;
+  if (issueKey === undefined) {
+    throw new Error('A Linear issue key is required');
+  }
+
+  const store = new JsonMappingStore(resolve(storePath));
+  const buzz = new BuzzCliGateway(option(parsed, 'buzz-bin') ?? process.env.BUZZ_CLI ?? 'buzz');
+  const reconciler = new WorkflowReconciler(store, buzz);
+
+  if (parsed.command === 'inspect') {
+    printJson(await reconciler.inspect(issueKey));
+    return;
+  }
+  if (parsed.command === 'archive') {
+    printJson(await reconciler.archive(issueKey, parsed.switches.has('confirm')));
+    return;
+  }
+  if (parsed.command !== 'reconcile') {
+    throw new Error(`Unknown command: ${parsed.command}`);
+  }
+
+  const result = await reconciler.reconcile(buildRequest(parsed, issueKey));
+  printJson(result);
+}
+
+interface ParsedArguments {
+  command?: string;
+  issueKey?: string;
+  options: Map<string, string[]>;
+  switches: Set<string>;
+}
+
+function parseArguments(arguments_: string[]) {
+  const parsed: ParsedArguments = {
+    command: arguments_[0],
+    issueKey: arguments_[1],
+    options: new Map(),
+    switches: new Set(),
+  };
+  let index = 2;
+  while (index < arguments_.length) {
+    const token = arguments_[index];
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+    const name = token.slice(2);
+    if (SWITCHES.has(name)) {
+      parsed.switches.add(name);
+      index += 1;
+      continue;
+    }
+    const value = arguments_[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for --${name}`);
+    }
+    const values = parsed.options.get(name) ?? [];
+    values.push(value);
+    parsed.options.set(name, values);
+    index += 2;
+  }
+  return parsed;
+}
+
+function buildRequest(parsed: ParsedArguments, key: string) {
+  const request: ReconcileRequest = {
+    key,
+    title: option(parsed, 'title'),
+    linearUrl: option(parsed, 'linear-url'),
+    linearIssueId: option(parsed, 'linear-issue-id'),
+    teamId: option(parsed, 'team-id'),
+    statusIds: statusIds(parsed),
+    channelName: option(parsed, 'channel-name'),
+    channelDescription: option(parsed, 'channel-description'),
+    channelType: channelType(option(parsed, 'channel-type')),
+    channelVisibility: channelVisibility(option(parsed, 'channel-visibility')),
+    members: members(parsed.options.get('member')),
+    repository: option(parsed, 'repo'),
+    branch: option(parsed, 'branch'),
+    worktree: option(parsed, 'worktree'),
+    owner: option(parsed, 'owner'),
+    adoptExisting: parsed.switches.has('adopt-existing'),
+  };
+  return request;
+}
+
+function statusIds(parsed: ParsedArguments): LinearStatusIds | undefined {
+  const values = {
+    todo: option(parsed, 'status-todo-id'),
+    inProgress: option(parsed, 'status-in-progress-id'),
+    inReview: option(parsed, 'status-in-review-id'),
+    done: option(parsed, 'status-done-id'),
+  };
+  if (Object.values(values).every(x => x === undefined)) {
+    return undefined;
+  }
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) {
+      throw new Error(`--status-${toKebabCase(name)}-id is required with other status IDs`);
+    }
+  }
+  return values as LinearStatusIds;
+}
+
+function members(values: string[] | undefined): DesiredMember[] | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+  return values.map(value => {
+    const [pubkey, role = 'member', ...extra] = value.split(':');
+    if (extra.length > 0) {
+      throw new Error(`Invalid --member value: ${value}`);
+    }
+    return { pubkey: normalizePubkey(pubkey), role: parseMemberRole(role) };
+  });
+}
+
+function channelType(value: string | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== 'stream' && value !== 'forum') {
+    throw new Error(`Invalid --channel-type: ${value}`);
+  }
+  return value;
+}
+
+function channelVisibility(value: string | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== 'open' && value !== 'private') {
+    throw new Error(`Invalid --channel-visibility: ${value}`);
+  }
+  return value;
+}
+
+function option(parsed: ParsedArguments, name: string) {
+  const values = parsed.options.get(name);
+  if (values === undefined) {
+    return undefined;
+  }
+  if (values.length !== 1) {
+    throw new Error(`--${name} may be provided only once`);
+  }
+  return values[0];
+}
+
+function printJson(value: unknown) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function toKebabCase(value: string) {
+  return value.replaceAll(/[A-Z]/g, x => `-${x.toLowerCase()}`);
+}
+
+function helpText() {
+  return `Linear-Buzz workflow reconciler
+
+Usage:
+  pnpm workflow reconcile ISSUE-ID --store PATH [metadata options]
+  pnpm workflow inspect ISSUE-ID --store PATH
+  pnpm workflow archive ISSUE-ID --store PATH --confirm
+
+First reconcile requires:
+  --title --linear-url --team-id
+  --status-todo-id --status-in-progress-id --status-in-review-id --status-done-id
+  --channel-name --repo --branch --worktree --owner
+
+Optional:
+  --linear-issue-id UUID
+  --channel-description TEXT
+  --channel-type stream|forum
+  --channel-visibility open|private
+  --member PUBKEY:owner|admin|member|guest|bot (repeatable)
+  --adopt-existing
+  --buzz-bin PATH
+`;
+}
+
+async function run() {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+void run();

--- a/scripts/ai-workflow/model.ts
+++ b/scripts/ai-workflow/model.ts
@@ -1,0 +1,355 @@
+export const STORE_SCHEMA_VERSION = 1;
+
+export const MEMBER_ROLES = ['owner', 'admin', 'member', 'guest', 'bot'] as const;
+export type MemberRole = (typeof MEMBER_ROLES)[number];
+
+export interface DesiredMember {
+  pubkey: string;
+  role: MemberRole;
+}
+
+export interface LinearStatusIds {
+  todo: string;
+  inProgress: string;
+  inReview: string;
+  done: string;
+}
+
+export interface ReconcileRequest {
+  key: string;
+  title?: string;
+  linearUrl?: string;
+  linearIssueId?: string | null;
+  teamId?: string;
+  statusIds?: LinearStatusIds;
+  channelName?: string;
+  channelDescription?: string;
+  channelType?: 'stream' | 'forum';
+  channelVisibility?: 'open' | 'private';
+  members?: DesiredMember[];
+  repository?: string;
+  branch?: string;
+  worktree?: string;
+  owner?: string;
+  adoptExisting?: boolean;
+}
+
+export interface TaskMapping {
+  schemaVersion: 1;
+  linear: {
+    key: string;
+    title: string;
+    url: string;
+    issueId: string | null;
+    teamId: string;
+    statusIds: LinearStatusIds;
+  };
+  buzz: {
+    channelId: string;
+    channelName: string;
+    description: string;
+    type: 'stream' | 'forum';
+    visibility: 'open' | 'private';
+    members: DesiredMember[];
+  };
+  git: {
+    repository: string;
+    branch: string;
+    worktree: string;
+  };
+  execution: {
+    owner: string;
+    desiredState: 'active' | 'archived';
+    observedState: 'provisioning' | 'active' | 'archived' | 'error';
+    createdAt: string;
+    updatedAt: string;
+    archivedAt: string | null;
+    lastError: string | null;
+  };
+}
+
+export interface MappingStoreData {
+  schemaVersion: 1;
+  mappings: Record<string, TaskMapping>;
+}
+
+type CreationRequest = ReconcileRequest &
+  Required<
+    Pick<
+      ReconcileRequest,
+      | 'title'
+      | 'linearUrl'
+      | 'teamId'
+      | 'statusIds'
+      | 'channelName'
+      | 'repository'
+      | 'branch'
+      | 'worktree'
+      | 'owner'
+    >
+  >;
+
+export function emptyStore(): MappingStoreData {
+  return { schemaVersion: STORE_SCHEMA_VERSION, mappings: {} };
+}
+
+export function normalizeIssueKey(value: string) {
+  const key = value.trim().toUpperCase();
+  if (!/^[A-Z][A-Z0-9]*-[1-9][0-9]*$/.test(key)) {
+    throw new Error(`Invalid Linear issue key: ${value}`);
+  }
+  return key;
+}
+
+export function normalizePubkey(value: string) {
+  const pubkey = value.trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(pubkey)) {
+    throw new Error(`Invalid Nostr pubkey: ${value}`);
+  }
+  return pubkey;
+}
+
+export function parseMemberRole(value: string): MemberRole {
+  if (!MEMBER_ROLES.includes(value as MemberRole)) {
+    throw new Error(`Invalid channel member role: ${value}`);
+  }
+  return value as MemberRole;
+}
+
+export function createMapping(request: ReconcileRequest, channelId: string, now: string) {
+  assertCreationRequest(request);
+  const key = normalizeIssueKey(request.key);
+  return {
+    schemaVersion: STORE_SCHEMA_VERSION,
+    linear: {
+      key,
+      title: request.title,
+      url: request.linearUrl,
+      issueId: request.linearIssueId ?? null,
+      teamId: request.teamId,
+      statusIds: request.statusIds,
+    },
+    buzz: {
+      channelId,
+      channelName: request.channelName,
+      description: request.channelDescription ?? `Linear ${key}: ${request.title}`,
+      type: request.channelType ?? 'stream',
+      visibility: request.channelVisibility ?? 'open',
+      members: dedupeMembers(request.members ?? []),
+    },
+    git: {
+      repository: request.repository,
+      branch: request.branch,
+      worktree: request.worktree,
+    },
+    execution: {
+      owner: request.owner,
+      desiredState: 'active',
+      observedState: 'provisioning',
+      createdAt: now,
+      updatedAt: now,
+      archivedAt: null,
+      lastError: null,
+    },
+  } satisfies TaskMapping;
+}
+
+export function assertCreationRequest(
+  request: ReconcileRequest,
+): asserts request is CreationRequest {
+  normalizeIssueKey(request.key);
+  const required = {
+    title: request.title,
+    linearUrl: request.linearUrl,
+    teamId: request.teamId,
+    statusIds: request.statusIds,
+    channelName: request.channelName,
+    repository: request.repository,
+    branch: request.branch,
+    worktree: request.worktree,
+    owner: request.owner,
+  };
+  for (const [name, value] of Object.entries(required)) {
+    if (value === undefined || value === '') {
+      throw new Error(`--${toKebabCase(name)} is required when creating a mapping`);
+    }
+  }
+}
+
+export function assertRequestCompatible(mapping: TaskMapping, request: ReconcileRequest) {
+  const comparisons: Array<[string, unknown, unknown]> = [
+    ['title', request.title, mapping.linear.title],
+    ['linear-url', request.linearUrl, mapping.linear.url],
+    ['linear-issue-id', request.linearIssueId, mapping.linear.issueId],
+    ['team-id', request.teamId, mapping.linear.teamId],
+    ['channel-name', request.channelName, mapping.buzz.channelName],
+    ['channel-description', request.channelDescription, mapping.buzz.description],
+    ['channel-type', request.channelType, mapping.buzz.type],
+    ['channel-visibility', request.channelVisibility, mapping.buzz.visibility],
+    ['repo', request.repository, mapping.git.repository],
+    ['branch', request.branch, mapping.git.branch],
+    ['worktree', request.worktree, mapping.git.worktree],
+    ['owner', request.owner, mapping.execution.owner],
+  ];
+  for (const [name, requested, stored] of comparisons) {
+    if (requested !== undefined && requested !== stored) {
+      throw new Error(`Stored mapping conflicts with --${name}`);
+    }
+  }
+  if (request.statusIds !== undefined) {
+    const names = Object.keys(request.statusIds) as Array<keyof LinearStatusIds>;
+    for (const name of names) {
+      if (request.statusIds[name] !== mapping.linear.statusIds[name]) {
+        throw new Error(`Stored mapping conflicts with --status-${toKebabCase(name)}-id`);
+      }
+    }
+  }
+}
+
+export function mergeDesiredMembers(mapping: TaskMapping, members: DesiredMember[] | undefined) {
+  if (members === undefined) {
+    return;
+  }
+  const merged = new Map(mapping.buzz.members.map(x => [x.pubkey, x]));
+  for (const member of dedupeMembers(members)) {
+    merged.set(member.pubkey, member);
+  }
+  mapping.buzz.members = [...merged.values()].sort((a, b) => a.pubkey.localeCompare(b.pubkey));
+}
+
+export function assertValidStore(value: unknown): asserts value is MappingStoreData {
+  if (!isRecord(value) || value.schemaVersion !== STORE_SCHEMA_VERSION) {
+    throw new Error(`Unsupported mapping store schema; expected ${STORE_SCHEMA_VERSION}`);
+  }
+  if (!isRecord(value.mappings)) {
+    throw new Error('Mapping store must contain a mappings object');
+  }
+
+  const channelIds = new Set<string>();
+  const issueIds = new Set<string>();
+  for (const [key, candidate] of Object.entries(value.mappings)) {
+    if (!isTaskMapping(candidate) || candidate.linear.key !== key) {
+      throw new Error(`Invalid mapping record: ${key}`);
+    }
+    if (channelIds.has(candidate.buzz.channelId)) {
+      throw new Error(`Duplicate Buzz channel mapping: ${candidate.buzz.channelId}`);
+    }
+    channelIds.add(candidate.buzz.channelId);
+    if (candidate.linear.issueId !== null) {
+      if (issueIds.has(candidate.linear.issueId)) {
+        throw new Error(`Duplicate Linear issue UUID mapping: ${candidate.linear.issueId}`);
+      }
+      issueIds.add(candidate.linear.issueId);
+    }
+  }
+}
+
+export function renderCanvas(mapping: TaskMapping) {
+  const statusIds = mapping.linear.statusIds;
+  return `# ${mapping.linear.key} - ${mapping.linear.title}
+
+## Task truth
+
+- Linear: <${mapping.linear.url}>
+- Linear issue UUID: ${mapping.linear.issueId ?? 'unavailable through current adapter'}
+- Team ID: \`${mapping.linear.teamId}\`
+- Status IDs: Todo \`${statusIds.todo}\`; In Progress \`${statusIds.inProgress}\`; In Review \`${statusIds.inReview}\`; Done \`${statusIds.done}\`
+
+## Execution truth
+
+- Buzz channel UUID: \`${mapping.buzz.channelId}\`
+- Current owner: \`${mapping.execution.owner}\`
+- Desired state: \`${mapping.execution.desiredState}\`
+- Observed state: \`${mapping.execution.observedState}\`
+- Repository: <${mapping.git.repository}>
+- Branch: \`${mapping.git.branch}\`
+- Worktree: \`${mapping.git.worktree}\`
+
+## Recovery check
+
+1. Read this canvas and the mapping store.
+2. Verify \`git worktree list\` contains the recorded worktree and branch.
+3. Verify \`HEAD\`, \`git status\`, and the current Linear lifecycle state before editing.
+4. Only the recorded owner writes in the worktree; handoffs transfer these same pointers.
+
+## Guardrails
+
+- Never synchronize chat into Linear or GitHub.
+- Reconcile creates or updates structured pointers; it never deletes.
+- Archive the channel only after completion is verified.
+- Never remove the worktree or branch without clean-status and unique-commit checks.
+`;
+}
+
+function dedupeMembers(members: DesiredMember[]) {
+  const byPubkey = new Map<string, DesiredMember>();
+  for (const member of members) {
+    const pubkey = normalizePubkey(member.pubkey);
+    byPubkey.set(pubkey, { pubkey, role: parseMemberRole(member.role) });
+  }
+  return [...byPubkey.values()].sort((a, b) => a.pubkey.localeCompare(b.pubkey));
+}
+
+function isTaskMapping(value: unknown): value is TaskMapping {
+  if (!isRecord(value) || value.schemaVersion !== STORE_SCHEMA_VERSION) {
+    return false;
+  }
+  if (
+    !isRecord(value.linear) ||
+    !isRecord(value.buzz) ||
+    !isRecord(value.git) ||
+    !isRecord(value.execution) ||
+    !isRecord(value.linear.statusIds) ||
+    !Array.isArray(value.buzz.members)
+  ) {
+    return false;
+  }
+  return (
+    typeof value.linear.key === 'string' &&
+    typeof value.linear.title === 'string' &&
+    typeof value.linear.url === 'string' &&
+    (value.linear.issueId === null || typeof value.linear.issueId === 'string') &&
+    typeof value.linear.teamId === 'string' &&
+    typeof value.linear.statusIds.todo === 'string' &&
+    typeof value.linear.statusIds.inProgress === 'string' &&
+    typeof value.linear.statusIds.inReview === 'string' &&
+    typeof value.linear.statusIds.done === 'string' &&
+    typeof value.buzz.channelId === 'string' &&
+    typeof value.buzz.channelName === 'string' &&
+    typeof value.buzz.description === 'string' &&
+    (value.buzz.type === 'stream' || value.buzz.type === 'forum') &&
+    (value.buzz.visibility === 'open' || value.buzz.visibility === 'private') &&
+    value.buzz.members.every(isDesiredMember) &&
+    typeof value.git.repository === 'string' &&
+    typeof value.git.branch === 'string' &&
+    typeof value.git.worktree === 'string' &&
+    typeof value.execution.owner === 'string' &&
+    (value.execution.desiredState === 'active' || value.execution.desiredState === 'archived') &&
+    (value.execution.observedState === 'provisioning' ||
+      value.execution.observedState === 'active' ||
+      value.execution.observedState === 'archived' ||
+      value.execution.observedState === 'error') &&
+    typeof value.execution.createdAt === 'string' &&
+    typeof value.execution.updatedAt === 'string' &&
+    (value.execution.archivedAt === null || typeof value.execution.archivedAt === 'string') &&
+    (value.execution.lastError === null || typeof value.execution.lastError === 'string')
+  );
+}
+
+function isDesiredMember(value: unknown): value is DesiredMember {
+  return (
+    isRecord(value) &&
+    typeof value.pubkey === 'string' &&
+    /^[a-f0-9]{64}$/.test(value.pubkey) &&
+    typeof value.role === 'string' &&
+    MEMBER_ROLES.includes(value.role as MemberRole)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toKebabCase(value: string) {
+  return value.replaceAll(/[A-Z]/g, x => `-${x.toLowerCase()}`);
+}

--- a/scripts/ai-workflow/reconcile.test.ts
+++ b/scripts/ai-workflow/reconcile.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { BuzzGateway, ChannelSummary } from './buzz.ts';
+import { emptyStore, renderCanvas, type DesiredMember, type ReconcileRequest } from './model.ts';
+import { WorkflowReconciler } from './reconcile.ts';
+import { JsonMappingStore } from './store.ts';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe('WorkflowReconciler', () => {
+  it('creates one channel, mapping, member set, and canvas', async () => {
+    const { reconciler, buzz } = await harness();
+    const result = await reconciler.reconcile(seed());
+
+    expect(result.actions).toEqual([
+      'created-channel',
+      'reused-channel',
+      `set-member:${HUMAN_PUBKEY}:owner`,
+      'updated-canvas',
+    ]);
+    expect(buzz.createCount).toBe(1);
+    expect(buzz.channels).toHaveLength(1);
+    expect(buzz.canvas.get(result.mapping.buzz.channelId)).toBe(renderCanvas(result.mapping));
+    expect(result.mapping.execution.observedState).toBe('active');
+  });
+
+  it('reconciles the same issue without duplicate writes', async () => {
+    const { reconciler, buzz } = await harness();
+    await reconciler.reconcile(seed());
+    const result = await reconciler.reconcile({ key: 'JAC-6' });
+
+    expect(result.actions).toEqual(['reused-channel', 'canvas-current']);
+    expect(buzz.createCount).toBe(1);
+    expect(buzz.setCanvasCount).toBe(1);
+    expect(buzz.addMemberCount).toBe(1);
+  });
+
+  it('adds a new desired member without removing existing members', async () => {
+    const { reconciler, buzz } = await harness();
+    await reconciler.reconcile(seed());
+    const secondPubkey = 'b'.repeat(64);
+    const result = await reconciler.reconcile({
+      key: 'JAC-6',
+      members: [{ pubkey: secondPubkey, role: 'bot' }],
+    });
+
+    expect(result.mapping.buzz.members).toEqual([
+      { pubkey: HUMAN_PUBKEY, role: 'owner' },
+      { pubkey: secondPubkey, role: 'bot' },
+    ]);
+    expect(buzz.members.get(result.mapping.buzz.channelId)).toEqual([
+      { pubkey: HUMAN_PUBKEY, role: 'owner' },
+      { pubkey: secondPubkey, role: 'bot' },
+    ]);
+  });
+
+  it('rejects conflicting immutable metadata', async () => {
+    const { reconciler } = await harness();
+    await reconciler.reconcile(seed());
+
+    await expect(reconciler.reconcile({ key: 'JAC-6', branch: 'wrong-branch' })).rejects.toThrow(
+      'Stored mapping conflicts with --branch',
+    );
+  });
+
+  it('rejects conflicting channel policy metadata', async () => {
+    const { reconciler } = await harness();
+    await reconciler.reconcile(seed());
+
+    await expect(
+      reconciler.reconcile({ key: 'JAC-6', channelVisibility: 'private' }),
+    ).rejects.toThrow('Stored mapping conflicts with --channel-visibility');
+  });
+
+  it('refuses to adopt an existing channel implicitly', async () => {
+    const { reconciler, buzz } = await harness();
+    buzz.channels.push({ channelId: 'existing', name: CHANNEL_NAME, description: '' });
+
+    await expect(reconciler.reconcile(seed())).rejects.toThrow('rerun with --adopt-existing');
+    expect(buzz.createCount).toBe(0);
+  });
+
+  it('adopts one explicitly verified existing channel', async () => {
+    const { reconciler, buzz } = await harness();
+    buzz.channels.push({ channelId: 'existing', name: CHANNEL_NAME, description: '' });
+    const result = await reconciler.reconcile({ ...seed(), adoptExisting: true });
+
+    expect(result.mapping.buzz.channelId).toBe('existing');
+    expect(result.actions[0]).toBe('adopted-channel');
+    expect(buzz.createCount).toBe(0);
+  });
+
+  it('rejects ambiguous existing channel names', async () => {
+    const { reconciler, buzz } = await harness();
+    buzz.channels.push(
+      { channelId: 'one', name: CHANNEL_NAME, description: '' },
+      { channelId: 'two', name: CHANNEL_NAME, description: '' },
+    );
+
+    await expect(reconciler.reconcile({ ...seed(), adoptExisting: true })).rejects.toThrow(
+      'Multiple visible Buzz channels',
+    );
+  });
+
+  it('records a recoverable external error and resumes on retry', async () => {
+    const { reconciler, buzz } = await harness();
+    buzz.failNextCanvasWrite = true;
+
+    await expect(reconciler.reconcile(seed())).rejects.toThrow('canvas write failed');
+    const failed = await reconciler.inspect('JAC-6');
+    expect(failed.execution.observedState).toBe('error');
+    expect(failed.execution.lastError).toBe('canvas write failed');
+
+    const recovered = await reconciler.reconcile({ key: 'JAC-6' });
+    expect(recovered.mapping.execution.observedState).toBe('active');
+    expect(recovered.mapping.execution.lastError).toBeNull();
+    expect(buzz.createCount).toBe(1);
+  });
+
+  it('requires explicit confirmation before archiving', async () => {
+    const { reconciler, buzz } = await harness();
+    await reconciler.reconcile(seed());
+
+    await expect(reconciler.archive('JAC-6', false)).rejects.toThrow('Archive requires --confirm');
+    expect(buzz.archiveCount).toBe(0);
+  });
+
+  it('archives once and preserves the archived mapping on later reconcile', async () => {
+    const { reconciler, buzz } = await harness();
+    await reconciler.reconcile(seed());
+    const first = await reconciler.archive('JAC-6', true);
+    const second = await reconciler.archive('JAC-6', true);
+    const recovered = await reconciler.reconcile({ key: 'JAC-6' });
+
+    expect(first.actions).toEqual(['archived-channel']);
+    expect(second.actions).toEqual(['already-archived']);
+    expect(recovered.actions).toEqual(['preserved-archived-channel']);
+    expect(buzz.archiveCount).toBe(1);
+    expect(buzz.createCount).toBe(1);
+  });
+});
+
+describe('JsonMappingStore', () => {
+  it('rejects a duplicate Buzz channel invariant', async () => {
+    const directory = await temporaryDirectory();
+    const path = join(directory, 'mappings.json');
+    const store = new JsonMappingStore(path);
+    const { reconciler } = await harness(path);
+    const first = await reconciler.reconcile(seed());
+    const data = await store.read();
+    data.mappings['JAC-7'] = {
+      ...structuredClone(first.mapping),
+      linear: { ...structuredClone(first.mapping.linear), key: 'JAC-7' },
+    };
+
+    await expect(store.write(data)).rejects.toThrow('Duplicate Buzz channel mapping');
+  });
+
+  it('rejects an unsupported schema', async () => {
+    const directory = await temporaryDirectory();
+    const path = join(directory, 'mappings.json');
+    await writeFile(path, JSON.stringify({ ...emptyStore(), schemaVersion: 99 }), 'utf8');
+
+    await expect(new JsonMappingStore(path).read()).rejects.toThrow(
+      'Unsupported mapping store schema',
+    );
+  });
+
+  it('rejects an incomplete mapping record', async () => {
+    const directory = await temporaryDirectory();
+    const path = join(directory, 'mappings.json');
+    await writeFile(
+      path,
+      JSON.stringify({ schemaVersion: 1, mappings: { 'JAC-6': { schemaVersion: 1 } } }),
+      'utf8',
+    );
+
+    await expect(new JsonMappingStore(path).read()).rejects.toThrow(
+      'Invalid mapping record: JAC-6',
+    );
+  });
+
+  it('serializes local writers with a lock file', async () => {
+    const directory = await temporaryDirectory();
+    const store = new JsonMappingStore(join(directory, 'mappings.json'));
+
+    await store.withLock(async () => {
+      await expect(store.withLock(async () => undefined)).rejects.toThrow(
+        'Mapping store is locked by another reconcile process',
+      );
+    });
+  });
+});
+
+const HUMAN_PUBKEY = 'a'.repeat(64);
+const CHANNEL_NAME = 'JAC-6-linear-buzz-reconciler';
+
+function seed(): ReconcileRequest {
+  return {
+    key: 'JAC-6',
+    title: '[Phase 2] Build and prove the Linear-Buzz reconciler',
+    linearUrl: 'https://linear.app/example/issue/JAC-6/example',
+    teamId: 'team-id',
+    statusIds: {
+      todo: 'todo-id',
+      inProgress: 'progress-id',
+      inReview: 'review-id',
+      done: 'done-id',
+    },
+    channelName: CHANNEL_NAME,
+    repository: 'https://github.com/example/repo',
+    branch: CHANNEL_NAME,
+    worktree: '/worktrees/JAC-6-linear-buzz-reconciler',
+    owner: 'Codex Sol',
+    members: [{ pubkey: HUMAN_PUBKEY, role: 'owner' }],
+  };
+}
+
+async function harness(storePath?: string) {
+  const directory = storePath === undefined ? await temporaryDirectory() : undefined;
+  const store = new JsonMappingStore(storePath ?? join(directory!, 'mappings.json'));
+  const buzz = new MemoryBuzz();
+  const reconciler = new WorkflowReconciler(
+    store,
+    buzz,
+    () => new Date('2026-08-14T03:00:00.000Z'),
+  );
+  return { store, buzz, reconciler };
+}
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(join(tmpdir(), 'ai-workflow-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+class MemoryBuzz implements BuzzGateway {
+  channels: ChannelSummary[] = [];
+  members = new Map<string, DesiredMember[]>();
+  canvas = new Map<string, string>();
+  archived = new Set<string>();
+  createCount = 0;
+  addMemberCount = 0;
+  setCanvasCount = 0;
+  archiveCount = 0;
+  failNextCanvasWrite = false;
+
+  async listChannels() {
+    return structuredClone(this.channels);
+  }
+
+  async createChannel(input: {
+    name: string;
+    description: string;
+    type: 'stream' | 'forum';
+    visibility: 'open' | 'private';
+  }) {
+    this.createCount += 1;
+    const channel = {
+      channelId: `channel-${this.createCount}`,
+      name: input.name,
+      description: input.description,
+    };
+    this.channels.push(channel);
+    this.members.set(channel.channelId, []);
+    return structuredClone(channel);
+  }
+
+  async getChannel(channelId: string) {
+    const channel = this.channels.find(x => x.channelId === channelId);
+    if (channel === undefined) {
+      throw new Error(`missing channel ${channelId}`);
+    }
+    return structuredClone(channel);
+  }
+
+  async listMembers(channelId: string) {
+    return structuredClone(this.members.get(channelId) ?? []);
+  }
+
+  async addMember(channelId: string, member: DesiredMember) {
+    this.addMemberCount += 1;
+    const members = this.members.get(channelId) ?? [];
+    const existing = members.find(x => x.pubkey === member.pubkey);
+    if (existing === undefined) {
+      members.push(structuredClone(member));
+    } else {
+      existing.role = member.role;
+    }
+    this.members.set(channelId, members);
+  }
+
+  async getCanvas(channelId: string) {
+    return this.canvas.get(channelId) ?? null;
+  }
+
+  async setCanvas(channelId: string, content: string) {
+    if (this.failNextCanvasWrite) {
+      this.failNextCanvasWrite = false;
+      throw new Error('canvas write failed');
+    }
+    this.setCanvasCount += 1;
+    this.canvas.set(channelId, content);
+  }
+
+  async archiveChannel(channelId: string) {
+    this.archiveCount += 1;
+    this.archived.add(channelId);
+  }
+}

--- a/scripts/ai-workflow/reconcile.ts
+++ b/scripts/ai-workflow/reconcile.ts
@@ -1,0 +1,174 @@
+import type { BuzzGateway } from './buzz.ts';
+import {
+  assertCreationRequest,
+  assertRequestCompatible,
+  createMapping,
+  mergeDesiredMembers,
+  normalizeIssueKey,
+  renderCanvas,
+  type ReconcileRequest,
+  type TaskMapping,
+} from './model.ts';
+import { JsonMappingStore } from './store.ts';
+
+export interface ReconcileResult {
+  mapping: TaskMapping;
+  actions: string[];
+}
+
+export class WorkflowReconciler {
+  readonly store: JsonMappingStore;
+  readonly buzz: BuzzGateway;
+  readonly now: () => Date;
+
+  constructor(store: JsonMappingStore, buzz: BuzzGateway, now = () => new Date()) {
+    this.store = store;
+    this.buzz = buzz;
+    this.now = now;
+  }
+
+  async reconcile(request: ReconcileRequest) {
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const key = normalizeIssueKey(request.key);
+      let mapping = data.mappings[key];
+      const actions: string[] = [];
+
+      if (mapping !== undefined) {
+        assertRequestCompatible(mapping, request);
+        mergeDesiredMembers(mapping, request.members);
+        if (mapping.execution.desiredState === 'archived') {
+          actions.push('preserved-archived-channel');
+          return { mapping, actions } satisfies ReconcileResult;
+        }
+      } else {
+        mapping = await this.createOrAdoptMapping(request, actions);
+        data.mappings[key] = mapping;
+        await this.store.write(data);
+      }
+
+      try {
+        const channel = await this.buzz.getChannel(mapping.buzz.channelId);
+        if (channel.name !== mapping.buzz.channelName) {
+          throw new Error(
+            `Mapped Buzz channel was renamed from ${mapping.buzz.channelName} to ${channel.name}`,
+          );
+        }
+        actions.push('reused-channel');
+        await this.ensureMembers(mapping, actions);
+
+        mapping.execution.observedState = 'active';
+        mapping.execution.lastError = null;
+        mapping.execution.updatedAt = this.now().toISOString();
+        const desiredCanvas = renderCanvas(mapping);
+        const currentCanvas = await this.buzz.getCanvas(mapping.buzz.channelId);
+        if (currentCanvas === desiredCanvas) {
+          actions.push('canvas-current');
+        } else {
+          await this.buzz.setCanvas(mapping.buzz.channelId, desiredCanvas);
+          actions.push('updated-canvas');
+        }
+        await this.store.write(data);
+        return { mapping, actions } satisfies ReconcileResult;
+      } catch (error) {
+        mapping.execution.observedState = 'error';
+        mapping.execution.lastError = errorMessage(error);
+        mapping.execution.updatedAt = this.now().toISOString();
+        await this.store.write(data);
+        throw error;
+      }
+    });
+  }
+
+  async inspect(issueKey: string) {
+    const data = await this.store.read();
+    const key = normalizeIssueKey(issueKey);
+    const mapping = data.mappings[key];
+    if (mapping === undefined) {
+      throw new Error(`No mapping exists for ${key}`);
+    }
+    return mapping;
+  }
+
+  async archive(issueKey: string, confirmed: boolean) {
+    if (!confirmed) {
+      throw new Error('Archive requires --confirm');
+    }
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const key = normalizeIssueKey(issueKey);
+      const mapping = data.mappings[key];
+      if (mapping === undefined) {
+        throw new Error(`No mapping exists for ${key}`);
+      }
+      if (mapping.execution.desiredState === 'archived') {
+        return { mapping, actions: ['already-archived'] } satisfies ReconcileResult;
+      }
+
+      try {
+        await this.buzz.archiveChannel(mapping.buzz.channelId);
+        const now = this.now().toISOString();
+        mapping.execution.desiredState = 'archived';
+        mapping.execution.observedState = 'archived';
+        mapping.execution.archivedAt = now;
+        mapping.execution.updatedAt = now;
+        mapping.execution.lastError = null;
+        await this.store.write(data);
+        return { mapping, actions: ['archived-channel'] } satisfies ReconcileResult;
+      } catch (error) {
+        mapping.execution.observedState = 'error';
+        mapping.execution.lastError = errorMessage(error);
+        mapping.execution.updatedAt = this.now().toISOString();
+        await this.store.write(data);
+        throw error;
+      }
+    });
+  }
+
+  private async createOrAdoptMapping(request: ReconcileRequest, actions: string[]) {
+    assertCreationRequest(request);
+    const channels = await this.buzz.listChannels();
+    const matches = channels.filter(x => x.name === request.channelName);
+    if (matches.length > 1) {
+      throw new Error(`Multiple visible Buzz channels are named ${request.channelName}`);
+    }
+
+    let channel;
+    if (matches.length === 1) {
+      if (request.adoptExisting !== true) {
+        throw new Error(
+          `Buzz channel ${request.channelName} already exists; rerun with --adopt-existing after verifying it`,
+        );
+      }
+      channel = matches[0];
+      actions.push('adopted-channel');
+    } else {
+      channel = await this.buzz.createChannel({
+        name: request.channelName,
+        description: request.channelDescription ?? `Linear ${request.key}: ${request.title}`,
+        type: request.channelType ?? 'stream',
+        visibility: request.channelVisibility ?? 'open',
+      });
+      actions.push('created-channel');
+    }
+
+    return createMapping(request, channel.channelId, this.now().toISOString());
+  }
+
+  private async ensureMembers(mapping: TaskMapping, actions: string[]) {
+    const current = new Map(
+      (await this.buzz.listMembers(mapping.buzz.channelId)).map(x => [x.pubkey, x.role]),
+    );
+    for (const member of mapping.buzz.members) {
+      if (current.get(member.pubkey) === member.role) {
+        continue;
+      }
+      await this.buzz.addMember(mapping.buzz.channelId, member);
+      actions.push(`set-member:${member.pubkey}:${member.role}`);
+    }
+  }
+}
+
+function errorMessage(value: unknown) {
+  return value instanceof Error ? value.message : String(value);
+}

--- a/scripts/ai-workflow/store.ts
+++ b/scripts/ai-workflow/store.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { assertValidStore, emptyStore, type MappingStoreData } from './model.ts';
+
+export class JsonMappingStore {
+  readonly path: string;
+  readonly lockPath: string;
+
+  constructor(path: string) {
+    this.path = path;
+    this.lockPath = `${path}.lock`;
+  }
+
+  async read() {
+    let content: string;
+    try {
+      content = await readFile(this.path, 'utf8');
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        return emptyStore();
+      }
+      throw error;
+    }
+    const parsed: unknown = JSON.parse(content);
+    assertValidStore(parsed);
+    return parsed;
+  }
+
+  async write(data: MappingStoreData) {
+    assertValidStore(data);
+    await mkdir(dirname(this.path), { recursive: true });
+    const temporaryPath = `${this.path}.${process.pid}.${randomUUID()}.tmp`;
+    await writeFile(temporaryPath, `${JSON.stringify(data, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    await rename(temporaryPath, this.path);
+  }
+
+  async withLock<T>(operation: () => Promise<T>) {
+    await mkdir(dirname(this.path), { recursive: true });
+    let handle;
+    try {
+      handle = await open(this.lockPath, 'wx');
+      await handle.writeFile(
+        `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+      );
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'EEXIST') {
+        throw new Error(`Mapping store is locked by another reconcile process: ${this.lockPath}`);
+      }
+      throw error;
+    }
+
+    try {
+      return await operation();
+    } finally {
+      await releaseLock(handle, this.lockPath);
+    }
+  }
+}
+
+async function releaseLock(handle: Awaited<ReturnType<typeof open>>, lockPath: string) {
+  await handle.close();
+  try {
+    await unlink(lockPath);
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && 'code' in value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "allowJs": true,
     "noEmit": true,
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "strict": true,
     "noImplicitAny": false,
@@ -26,5 +26,12 @@
     },
     "lib": ["DOM", "WebWorker", "ESNext"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "src/**/*.vue", "vite.config.mts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.d.ts",
+    "src/**/*.vue",
+    "scripts/**/*.ts",
+    "vite.config.mts"
+  ]
 }


### PR DESCRIPTION
## Summary

- add a manual-trigger TypeScript reconciler for one Linear issue to one Buzz task channel
- persist a schema-versioned mapping outside the repository with atomic writes and a local lock
- make channel creation, membership, and canvas updates idempotent
- require explicit adoption of pre-existing channels and explicit confirmation before archive
- add recovery, collision, failure-resume, and archive safety tests

## Why

Phase 1 proved the manual Linear → Buzz → worktree → GitHub → Linear loop. Phase 2 removes the fragile hand-written channel/canvas step while keeping native Linear/GitHub automation primary and avoiding chat synchronization.

## Live Phase 2 evidence

- created exactly one Buzz channel: `a3e91f5f-0354-4f1b-93cf-917eb0ad4777`
- added the human operator as channel owner
- persisted the mapping at `C:\Users\cyrus\.buzz\.state\ai-workflow\mappings.json` (outside the repository)
- a fresh-process rerun returned `reused-channel` and `canvas-current`
- the `needs-human` label synchronized to GitHub issue #150 while Linear remained In Progress, then was removed

## Validation

At commit `fdb84aaab6cf461678d74da9b4f33d6cbd1c5371`:

- `pnpm run compile`
- `pnpm run test` — 9 files, 88 tests passed

Fixes JAC-6
Closes #150