### PR TITLE
[JAC-7] Add replay-safe In Review projection

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## `ai-workflow/`
 
-Manual-trigger Linear-to-Buzz task-channel reconciler. It keeps its mapping store outside the repository, provisions one channel/canvas per issue idempotently, and archives only after an explicit confirmed command. See `scripts/ai-workflow/README.md`.
+Manual-trigger Linear-to-Buzz task-channel reconciler and opt-in, replay-safe In Review projector. It keeps its mapping store outside the repository, provisions one channel/canvas per issue idempotently, preserves native merge-to-Done behavior, and archives only after an explicit confirmed command. See `scripts/ai-workflow/README.md`.
 
 ## `build-dist.sh`
 

--- a/scripts/ai-workflow/README.md
+++ b/scripts/ai-workflow/README.md
@@ -1,12 +1,12 @@
-# Linear-Buzz workflow reconciler
+# Linear-Buzz workflow reconciler and lifecycle projector
 
-Manual-trigger Phase 2 bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after an explicit command.
+Manual-trigger bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after an explicit command. Its opt-in lifecycle projector handles only the measured In Progress to In Review gap; native GitHub-to-Linear merge-to-Done remains primary.
 
 The bridge does not call Linear directly. The initiating agent reads Linear through its authenticated connector and supplies the issue snapshot on the first reconcile. Later reconciles need only the issue key and mapping store. This keeps OAuth credentials out of the repository and mapping data.
 
 ## Runtime state
 
-Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 1, atomic replacement, and a local lock file.
+Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 2, atomic replacement, and a local lock file. Existing schema-v1 mappings migrate on the next write.
 
 ```powershell
 $env:AI_WORKFLOW_MAPPING_STORE = 'C:\Users\cyrus\.buzz\.state\ai-workflow\mappings.json'
@@ -33,6 +33,46 @@ pnpm workflow reconcile JAC-6 `
 
 If a verified channel already exists after an interrupted first run, add `--adopt-existing`. Adoption is never implicit.
 
+## Review lifecycle projection
+
+Enable the policy explicitly for the mapping's Linear team:
+
+```powershell
+pnpm workflow lifecycle-configure JAC-7 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --enable --stale-after-seconds 300 --max-deliveries 100
+```
+
+For a GitHub ready-for-review or review-activity event, record the stable delivery identity and current Linear state:
+
+```powershell
+pnpm workflow lifecycle-observe JAC-7 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id 'github:jackinabox86/refined-prun:pull:152:ready-for-review:<head-sha>' `
+  --event-kind ready-for-review `
+  --source 'https://github.com/jackinabox86/refined-prun/pull/152' `
+  --linear-state in-progress
+```
+
+When the result contains one `set-linear-status` action, apply that status through the authenticated Linear connector. Then acknowledge success or failure:
+
+```powershell
+pnpm workflow lifecycle-ack JAC-7 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id '<same-delivery-id>' --result applied
+
+pnpm workflow lifecycle-ack JAC-7 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id '<same-delivery-id>' --result failed --error '<boundary error>'
+```
+
+Planning and acknowledgment are separate deliberately. A duplicate event while acknowledgment is pending produces no second write. Failed or stale deliveries remain retryable. If the Linear write succeeded but acknowledgment was lost, reconciliation infers success from current Linear truth:
+
+```powershell
+pnpm workflow lifecycle-reconcile JAC-7 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --linear-state in-review
+```
+
+Reconciliation emits one stored attention signal for stale, failed, or unexpected state. A delivery observed after Done is recorded as ignored and can never regress the issue. The delivery ledger is bounded by the configured maximum and prunes only resolved entries.
+
+The CLI does not contain Linear credentials or an always-on webhook listener. The authenticated operator supplies current Linear truth and applies the explicit action.
+
 ## Recovery and archive
 
 ```powershell
@@ -41,7 +81,7 @@ pnpm workflow inspect JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE
 pnpm workflow archive JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE --confirm
 ```
 
-Archive is idempotent. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no delete operation.
+Archive is idempotent. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no delete operation. Schema-v1 Phase 2 mappings migrate to schema v2 on the next write without losing channel or archive state.
 
 ## Validation
 

--- a/scripts/ai-workflow/cli.ts
+++ b/scripts/ai-workflow/cli.ts
@@ -1,16 +1,21 @@
 import { resolve } from 'node:path';
 import { BuzzCliGateway } from './buzz.ts';
+import { LifecycleProjector } from './lifecycle.ts';
 import {
+  LINEAR_LIFECYCLE_STATES,
+  REVIEW_EVENT_KINDS,
   parseMemberRole,
   normalizePubkey,
   type DesiredMember,
+  type LinearLifecycleState,
   type LinearStatusIds,
   type ReconcileRequest,
+  type ReviewEventKind,
 } from './model.ts';
 import { WorkflowReconciler } from './reconcile.ts';
 import { JsonMappingStore } from './store.ts';
 
-const SWITCHES = new Set(['adopt-existing', 'confirm', 'help']);
+const SWITCHES = new Set(['adopt-existing', 'confirm', 'disable', 'enable', 'help']);
 
 async function main() {
   const rawArguments = process.argv.slice(2);
@@ -38,6 +43,7 @@ async function main() {
   const store = new JsonMappingStore(resolve(storePath));
   const buzz = new BuzzCliGateway(option(parsed, 'buzz-bin') ?? process.env.BUZZ_CLI ?? 'buzz');
   const reconciler = new WorkflowReconciler(store, buzz);
+  const lifecycle = new LifecycleProjector(store);
 
   if (parsed.command === 'inspect') {
     printJson(await reconciler.inspect(issueKey));
@@ -45,6 +51,52 @@ async function main() {
   }
   if (parsed.command === 'archive') {
     printJson(await reconciler.archive(issueKey, parsed.switches.has('confirm')));
+    return;
+  }
+  if (parsed.command === 'lifecycle-configure') {
+    const enabled = exactlyOneSwitch(parsed, 'enable', 'disable') === 'enable';
+    printJson(
+      await lifecycle.configure({
+        issueKey,
+        enabled,
+        staleAfterSeconds: integerOption(parsed, 'stale-after-seconds', 300),
+        maxDeliveries: integerOption(parsed, 'max-deliveries', 100),
+      }),
+    );
+    return;
+  }
+  if (parsed.command === 'lifecycle-observe') {
+    printJson(
+      await lifecycle.observe({
+        issueKey,
+        eventId: requiredOption(parsed, 'event-id'),
+        eventKind: eventKind(requiredOption(parsed, 'event-kind')),
+        source: requiredOption(parsed, 'source'),
+        linearState: linearState(requiredOption(parsed, 'linear-state')),
+        observedAt: option(parsed, 'observed-at'),
+      }),
+    );
+    return;
+  }
+  if (parsed.command === 'lifecycle-ack') {
+    printJson(
+      await lifecycle.acknowledge({
+        issueKey,
+        eventId: requiredOption(parsed, 'event-id'),
+        result: acknowledgmentResult(requiredOption(parsed, 'result')),
+        error: option(parsed, 'error'),
+      }),
+    );
+    return;
+  }
+  if (parsed.command === 'lifecycle-reconcile') {
+    printJson(
+      await lifecycle.reconcile({
+        issueKey,
+        linearState: linearState(requiredOption(parsed, 'linear-state')),
+        now: option(parsed, 'now'),
+      }),
+    );
     return;
   }
   if (parsed.command !== 'reconcile') {
@@ -177,6 +229,55 @@ function option(parsed: ParsedArguments, name: string) {
   return values[0];
 }
 
+function requiredOption(parsed: ParsedArguments, name: string) {
+  const value = option(parsed, name);
+  if (value === undefined || value === '') {
+    throw new Error(`--${name} is required`);
+  }
+  return value;
+}
+
+function integerOption(parsed: ParsedArguments, name: string, defaultValue: number) {
+  const value = option(parsed, name);
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const parsedValue = Number(value);
+  if (!Number.isSafeInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsedValue;
+}
+
+function exactlyOneSwitch(parsed: ParsedArguments, first: string, second: string) {
+  const present = [first, second].filter(x => parsed.switches.has(x));
+  if (present.length !== 1) {
+    throw new Error(`Provide exactly one of --${first} or --${second}`);
+  }
+  return present[0];
+}
+
+function eventKind(value: string): ReviewEventKind {
+  if (!REVIEW_EVENT_KINDS.includes(value as ReviewEventKind)) {
+    throw new Error(`Invalid --event-kind: ${value}`);
+  }
+  return value as ReviewEventKind;
+}
+
+function linearState(value: string): LinearLifecycleState {
+  if (!LINEAR_LIFECYCLE_STATES.includes(value as LinearLifecycleState)) {
+    throw new Error(`Invalid --linear-state: ${value}`);
+  }
+  return value as LinearLifecycleState;
+}
+
+function acknowledgmentResult(value: string) {
+  if (value !== 'applied' && value !== 'failed') {
+    throw new Error(`Invalid --result: ${value}`);
+  }
+  return value;
+}
+
 function printJson(value: unknown) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
@@ -192,6 +293,10 @@ Usage:
   pnpm workflow reconcile ISSUE-ID --store PATH [metadata options]
   pnpm workflow inspect ISSUE-ID --store PATH
   pnpm workflow archive ISSUE-ID --store PATH --confirm
+  pnpm workflow lifecycle-configure ISSUE-ID --store PATH --enable|--disable
+  pnpm workflow lifecycle-observe ISSUE-ID --store PATH --event-id ID --event-kind KIND --source URL --linear-state STATE
+  pnpm workflow lifecycle-ack ISSUE-ID --store PATH --event-id ID --result applied|failed [--error TEXT]
+  pnpm workflow lifecycle-reconcile ISSUE-ID --store PATH --linear-state STATE [--now ISO]
 
 First reconcile requires:
   --title --linear-url --team-id
@@ -206,6 +311,13 @@ Optional:
   --member PUBKEY:owner|admin|member|guest|bot (repeatable)
   --adopt-existing
   --buzz-bin PATH
+
+Lifecycle options:
+  --event-kind ready-for-review|review-activity
+  --linear-state todo|in-progress|in-review|done|other
+  --observed-at ISO
+  --stale-after-seconds N (default 300)
+  --max-deliveries N (default 100)
 `;
 }
 

--- a/scripts/ai-workflow/lifecycle.test.ts
+++ b/scripts/ai-workflow/lifecycle.test.ts
@@ -1,0 +1,216 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { LifecycleProjector } from './lifecycle.ts';
+import { createMapping, emptyStore, type ReconcileRequest } from './model.ts';
+import { JsonMappingStore } from './store.ts';
+
+const temporaryDirectories: string[] = [];
+const NOW = '2026-08-14T12:00:00.000Z';
+
+afterEach(async () => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe('LifecycleProjector', () => {
+  it('requires an explicit per-team opt in', async () => {
+    const { projector } = await harness();
+    const result = await projector.observe(event());
+
+    expect(result.actions).toEqual([{ type: 'none', reason: 'projection-disabled' }]);
+    expect(result.mapping.lifecycle.deliveries[0].outcome).toBe('ignored');
+  });
+
+  it('plans one Linear write and suppresses duplicate delivery while awaiting acknowledgment', async () => {
+    const { projector } = await harness(true);
+    const first = await projector.observe(event());
+    const duplicate = await projector.observe(event());
+
+    expect(first.actions).toEqual([
+      {
+        type: 'set-linear-status',
+        issueKey: 'JAC-7',
+        deliveryId: 'github:pr:152:ready',
+        statusId: 'review-id',
+        reason: 'eligible-review-event',
+      },
+    ]);
+    expect(duplicate.actions).toEqual([{ type: 'none', reason: 'duplicate-event-awaiting-ack' }]);
+    expect(duplicate.mapping.lifecycle.deliveries).toHaveLength(1);
+    expect(duplicate.mapping.lifecycle.deliveries[0].attempts).toBe(1);
+  });
+
+  it('keeps failed writes retryable and clears the alert after acknowledgment', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(event());
+    const failed = await projector.acknowledge({
+      issueKey: 'JAC-7',
+      eventId: 'github:pr:152:ready',
+      result: 'failed',
+      error: 'Linear unavailable',
+    });
+    const retry = await projector.observe(event());
+    const applied = await projector.acknowledge({
+      issueKey: 'JAC-7',
+      eventId: 'github:pr:152:ready',
+      result: 'applied',
+    });
+
+    expect(failed.mapping.lifecycle.alert.state).toBe('attention');
+    expect(retry.actions[0]).toMatchObject({
+      type: 'set-linear-status',
+      reason: 'retry-failed-delivery',
+    });
+    expect(retry.mapping.lifecycle.deliveries[0].attempts).toBe(2);
+    expect(applied.mapping.lifecycle.deliveries[0].outcome).toBe('applied');
+    expect(applied.mapping.lifecycle.alert.state).toBe('clear');
+  });
+
+  it('re-emits one stale pending delivery and stores one attention signal', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(event());
+    const result = await projector.reconcile({
+      issueKey: 'JAC-7',
+      linearState: 'in-progress',
+      now: '2026-08-14T12:06:00.000Z',
+    });
+
+    expect(result.actions).toEqual([
+      {
+        type: 'needs-attention',
+        deliveryId: 'github:pr:152:ready',
+        reason: 'retry-stale-delivery',
+      },
+      {
+        type: 'set-linear-status',
+        issueKey: 'JAC-7',
+        deliveryId: 'github:pr:152:ready',
+        statusId: 'review-id',
+        reason: 'retry-stale-delivery',
+      },
+    ]);
+    expect(result.mapping.lifecycle.alert).toMatchObject({
+      state: 'attention',
+      deliveryId: 'github:pr:152:ready',
+    });
+  });
+
+  it('infers a lost acknowledgment from current Linear truth', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(event());
+    const result = await projector.reconcile({
+      issueKey: 'JAC-7',
+      linearState: 'in-review',
+    });
+
+    expect(result.actions).toEqual([
+      { type: 'none', reason: 'inferred-applied-from-linear-state' },
+    ]);
+    expect(result.mapping.lifecycle.deliveries[0].outcome).toBe('applied');
+    expect(result.mapping.lifecycle.alert.state).toBe('clear');
+  });
+
+  it('never regresses Done for pending, duplicate, or delayed review events', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(event());
+    const reconciled = await projector.reconcile({ issueKey: 'JAC-7', linearState: 'done' });
+    const duplicate = await projector.observe({ ...event(), linearState: 'done' });
+    const delayed = await projector.observe({
+      ...event(),
+      eventId: 'github:pr:152:late-review',
+      eventKind: 'review-activity',
+      linearState: 'done',
+    });
+
+    expect(reconciled.mapping.lifecycle.deliveries[0]).toMatchObject({
+      outcome: 'ignored',
+      reason: 'linear-terminal-done',
+    });
+    expect(duplicate.actions).toEqual([
+      { type: 'none', reason: 'duplicate-event-linear-terminal-done' },
+    ]);
+    expect(delayed.actions).toEqual([{ type: 'none', reason: 'linear-terminal-done' }]);
+    expect(delayed.actions.some(x => x.type === 'set-linear-status')).toBe(false);
+  });
+
+  it('bounds the ledger by pruning the oldest resolved delivery', async () => {
+    const { projector } = await harness();
+    await projector.configure({
+      issueKey: 'JAC-7',
+      enabled: true,
+      staleAfterSeconds: 300,
+      maxDeliveries: 1,
+    });
+    await projector.observe({ ...event(), linearState: 'done' });
+    const result = await projector.observe({
+      ...event(),
+      eventId: 'github:pr:152:review',
+      eventKind: 'review-activity',
+    });
+
+    expect(result.mapping.lifecycle.deliveries).toHaveLength(1);
+    expect(result.mapping.lifecycle.deliveries[0].id).toBe('github:pr:152:review');
+  });
+
+  it('rejects conflicting payloads that reuse a delivery identity', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(event());
+
+    await expect(projector.observe({ ...event(), eventKind: 'review-activity' })).rejects.toThrow(
+      'identity conflicts',
+    );
+  });
+});
+
+function event() {
+  return {
+    issueKey: 'JAC-7',
+    eventId: 'github:pr:152:ready',
+    eventKind: 'ready-for-review' as const,
+    source: 'https://github.com/example/repo/pull/152',
+    linearState: 'in-progress' as const,
+    observedAt: NOW,
+  };
+}
+
+async function harness(enable = false) {
+  const directory = await mkdtemp(join(tmpdir(), 'ai-workflow-lifecycle-'));
+  temporaryDirectories.push(directory);
+  const store = new JsonMappingStore(join(directory, 'mappings.json'));
+  const data = emptyStore();
+  data.mappings['JAC-7'] = createMapping(seed(), 'channel-id', NOW);
+  await store.write(data);
+  const projector = new LifecycleProjector(store, () => new Date(NOW));
+  if (enable) {
+    await projector.configure({
+      issueKey: 'JAC-7',
+      enabled: true,
+      staleAfterSeconds: 300,
+      maxDeliveries: 100,
+    });
+  }
+  return { projector, store };
+}
+
+function seed(): ReconcileRequest {
+  return {
+    key: 'JAC-7',
+    title: '[Phase 3] Add replay-safe In Review projection',
+    linearUrl: 'https://linear.app/example/issue/JAC-7/example',
+    teamId: 'team-id',
+    statusIds: {
+      todo: 'todo-id',
+      inProgress: 'progress-id',
+      inReview: 'review-id',
+      done: 'done-id',
+    },
+    channelName: 'JAC-7-replay-safe-in-review',
+    repository: 'https://github.com/example/repo',
+    branch: 'JAC-7-replay-safe-in-review',
+    worktree: '/worktrees/JAC-7-replay-safe-in-review',
+    owner: 'Codex Sol',
+  };
+}

--- a/scripts/ai-workflow/lifecycle.ts
+++ b/scripts/ai-workflow/lifecycle.ts
@@ -1,0 +1,516 @@
+import {
+  LINEAR_LIFECYCLE_STATES,
+  REVIEW_EVENT_KINDS,
+  normalizeIssueKey,
+  type LifecycleDelivery,
+  type LinearLifecycleState,
+  type ReviewEventKind,
+  type TaskMapping,
+  type TeamLifecyclePolicy,
+} from './model.ts';
+import { JsonMappingStore } from './store.ts';
+
+export interface ObserveReviewEventRequest {
+  issueKey: string;
+  eventId: string;
+  eventKind: ReviewEventKind;
+  source: string;
+  linearState: LinearLifecycleState;
+  observedAt?: string;
+}
+
+export interface AcknowledgeDeliveryRequest {
+  issueKey: string;
+  eventId: string;
+  result: 'applied' | 'failed';
+  error?: string;
+}
+
+export interface ConfigureProjectionRequest {
+  issueKey: string;
+  enabled: boolean;
+  staleAfterSeconds: number;
+  maxDeliveries: number;
+}
+
+export interface ReconcileLifecycleRequest {
+  issueKey: string;
+  linearState: LinearLifecycleState;
+  now?: string;
+}
+
+export interface SetLinearStatusAction {
+  type: 'set-linear-status';
+  issueKey: string;
+  deliveryId: string;
+  statusId: string;
+  reason: string;
+}
+
+export interface LifecycleResult {
+  mapping: TaskMapping;
+  actions: Array<
+    | SetLinearStatusAction
+    | { type: 'none'; reason: string }
+    | { type: 'needs-attention'; deliveryId: string | null; reason: string }
+  >;
+}
+
+export class LifecycleProjector {
+  readonly store: JsonMappingStore;
+  readonly now: () => Date;
+
+  constructor(store: JsonMappingStore, now = () => new Date()) {
+    this.store = store;
+    this.now = now;
+  }
+
+  async configure(request: ConfigureProjectionRequest) {
+    assertPositiveInteger(request.staleAfterSeconds, 'stale-after-seconds');
+    assertPositiveInteger(request.maxDeliveries, 'max-deliveries');
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const now = this.now().toISOString();
+      const desired: TeamLifecyclePolicy = {
+        inReview: {
+          enabled: request.enabled,
+          staleAfterSeconds: request.staleAfterSeconds,
+          maxDeliveries: request.maxDeliveries,
+        },
+        updatedAt: now,
+      };
+      const current = data.teamPolicies[mapping.linear.teamId];
+      const unchanged =
+        current?.inReview.enabled === desired.inReview.enabled &&
+        current.inReview.staleAfterSeconds === desired.inReview.staleAfterSeconds &&
+        current.inReview.maxDeliveries === desired.inReview.maxDeliveries;
+      if (unchanged) {
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'projection-current' }],
+        } satisfies LifecycleResult;
+      }
+      data.teamPolicies[mapping.linear.teamId] = desired;
+      await this.store.write(data);
+      return {
+        mapping,
+        actions: [
+          {
+            type: 'none',
+            reason: request.enabled
+              ? 'enabled-in-review-projection'
+              : 'disabled-in-review-projection',
+          },
+        ],
+      } satisfies LifecycleResult;
+    });
+  }
+
+  async observe(request: ObserveReviewEventRequest) {
+    assertEventId(request.eventId);
+    assertEventKind(request.eventKind);
+    assertLinearState(request.linearState);
+    assertNonempty(request.source, 'source');
+    const observedAt = request.observedAt ?? this.now().toISOString();
+    assertTimestamp(observedAt, 'observed-at');
+
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const policy = data.teamPolicies[mapping.linear.teamId];
+      const now = this.now().toISOString();
+      const existing = mapping.lifecycle.deliveries.find(x => x.id === request.eventId);
+      if (existing !== undefined) {
+        assertSameEvent(existing, request);
+        const actions = handleExistingDelivery(mapping, existing, request.linearState, policy, now);
+        mapping.lifecycle.lastObservedAt = observedAt;
+        await this.store.write(data);
+        return { mapping, actions } satisfies LifecycleResult;
+      }
+
+      ensureLedgerCapacity(mapping, policy);
+      const delivery = createDelivery(request, observedAt, now, mapping, policy);
+      mapping.lifecycle.deliveries.push(delivery);
+      mapping.lifecycle.lastObservedAt = observedAt;
+      const actions = initialActions(mapping, delivery);
+      await this.store.write(data);
+      return { mapping, actions } satisfies LifecycleResult;
+    });
+  }
+
+  async acknowledge(request: AcknowledgeDeliveryRequest) {
+    assertEventId(request.eventId);
+    if (request.result === 'failed') {
+      assertNonempty(request.error, 'error');
+    }
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const delivery = mapping.lifecycle.deliveries.find(x => x.id === request.eventId);
+      if (delivery === undefined) {
+        throw new Error(`No lifecycle delivery exists for ${request.eventId}`);
+      }
+      if (delivery.outcome === 'ignored') {
+        throw new Error(`Ignored delivery cannot be acknowledged: ${request.eventId}`);
+      }
+      if (delivery.outcome === 'applied' && request.result === 'applied') {
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'delivery-already-applied' }],
+        } satisfies LifecycleResult;
+      }
+      if (delivery.outcome === 'applied' && request.result === 'failed') {
+        throw new Error(`Applied delivery cannot be changed to failed: ${request.eventId}`);
+      }
+
+      const now = this.now().toISOString();
+      delivery.updatedAt = now;
+      if (request.result === 'applied') {
+        delivery.outcome = 'applied';
+        delivery.reason = 'acknowledged-applied';
+        delivery.lastError = null;
+        clearAlertFor(mapping, delivery.id);
+      } else {
+        delivery.outcome = 'failed';
+        delivery.reason = 'linear-write-failed';
+        delivery.lastError = request.error!;
+        setAlert(mapping, delivery.id, `linear-write-failed: ${request.error!}`, now);
+      }
+      await this.store.write(data);
+      const action: LifecycleResult['actions'][number] =
+        request.result === 'applied'
+          ? { type: 'none', reason: delivery.reason }
+          : { type: 'needs-attention', deliveryId: delivery.id, reason: delivery.reason };
+      return {
+        mapping,
+        actions: [action],
+      } satisfies LifecycleResult;
+    });
+  }
+
+  async reconcile(request: ReconcileLifecycleRequest) {
+    assertLinearState(request.linearState);
+    const now = request.now ?? this.now().toISOString();
+    assertTimestamp(now, 'now');
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const policy = data.teamPolicies[mapping.linear.teamId];
+      if (policy?.inReview.enabled !== true) {
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'projection-disabled' }],
+        } satisfies LifecycleResult;
+      }
+
+      const unresolved = mapping.lifecycle.deliveries.filter(
+        x => x.outcome === 'pending' || x.outcome === 'failed',
+      );
+      if (request.linearState === 'done') {
+        for (const delivery of unresolved) {
+          markIgnored(delivery, 'linear-terminal-done', now);
+        }
+        clearAlert(mapping);
+        await this.store.write(data);
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'linear-terminal-done' }],
+        } satisfies LifecycleResult;
+      }
+      if (request.linearState === 'in-review') {
+        for (const delivery of unresolved) {
+          delivery.outcome = 'applied';
+          delivery.reason = 'inferred-applied-from-linear-state';
+          delivery.updatedAt = now;
+          delivery.lastError = null;
+        }
+        clearAlert(mapping);
+        await this.store.write(data);
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'inferred-applied-from-linear-state' }],
+        } satisfies LifecycleResult;
+      }
+      if (request.linearState !== 'in-progress') {
+        const deliveryId = unresolved[0]?.id ?? null;
+        setAlert(mapping, deliveryId, `unexpected-linear-state:${request.linearState}`, now);
+        await this.store.write(data);
+        return {
+          mapping,
+          actions: [
+            {
+              type: 'needs-attention',
+              deliveryId,
+              reason: `unexpected-linear-state:${request.linearState}`,
+            },
+          ],
+        } satisfies LifecycleResult;
+      }
+
+      const retry = unresolved.find(
+        x => x.outcome === 'failed' || isStale(x.updatedAt, now, policy.inReview.staleAfterSeconds),
+      );
+      if (retry !== undefined) {
+        retry.outcome = 'pending';
+        retry.reason = retry.lastError === null ? 'retry-stale-delivery' : 'retry-failed-delivery';
+        retry.updatedAt = now;
+        retry.attempts += 1;
+        retry.lastError = null;
+        setAlert(mapping, retry.id, retry.reason, now);
+        await this.store.write(data);
+        return {
+          mapping,
+          actions: [
+            { type: 'needs-attention', deliveryId: retry.id, reason: retry.reason },
+            statusAction(mapping, retry, retry.reason),
+          ],
+        } satisfies LifecycleResult;
+      }
+
+      if (unresolved.length > 0) {
+        clearAlert(mapping);
+        await this.store.write(data);
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'delivery-awaiting-ack' }],
+        } satisfies LifecycleResult;
+      }
+
+      const applied = mapping.lifecycle.deliveries.findLast(x => x.outcome === 'applied');
+      if (applied !== undefined) {
+        setAlert(mapping, applied.id, 'linear-state-regressed-after-applied-delivery', now);
+        await this.store.write(data);
+        return {
+          mapping,
+          actions: [
+            {
+              type: 'needs-attention',
+              deliveryId: applied.id,
+              reason: 'linear-state-regressed-after-applied-delivery',
+            },
+          ],
+        } satisfies LifecycleResult;
+      }
+
+      clearAlert(mapping);
+      await this.store.write(data);
+      return {
+        mapping,
+        actions: [{ type: 'none', reason: 'no-review-delivery' }],
+      } satisfies LifecycleResult;
+    });
+  }
+}
+
+function createDelivery(
+  request: ObserveReviewEventRequest,
+  observedAt: string,
+  now: string,
+  mapping: TaskMapping,
+  policy: TeamLifecyclePolicy | undefined,
+): LifecycleDelivery {
+  const delivery: LifecycleDelivery = {
+    id: request.eventId,
+    kind: request.eventKind,
+    source: request.source,
+    observedAt,
+    updatedAt: now,
+    outcome: 'ignored',
+    reason: 'projection-disabled',
+    targetStatusId: null,
+    attempts: 0,
+    lastError: null,
+  };
+  if (policy?.inReview.enabled !== true) {
+    return delivery;
+  }
+  if (mapping.execution.desiredState === 'archived') {
+    delivery.reason = 'channel-archived';
+    return delivery;
+  }
+  if (request.linearState === 'done') {
+    delivery.reason = 'linear-terminal-done';
+    return delivery;
+  }
+  if (request.linearState === 'in-review') {
+    delivery.reason = 'linear-already-in-review';
+    return delivery;
+  }
+  if (request.linearState !== 'in-progress') {
+    delivery.reason = `ineligible-linear-state:${request.linearState}`;
+    return delivery;
+  }
+  delivery.outcome = 'pending';
+  delivery.reason = 'eligible-review-event';
+  delivery.targetStatusId = mapping.linear.statusIds.inReview;
+  delivery.attempts = 1;
+  return delivery;
+}
+
+function initialActions(mapping: TaskMapping, delivery: LifecycleDelivery) {
+  if (delivery.outcome !== 'pending') {
+    return [{ type: 'none', reason: delivery.reason }] satisfies LifecycleResult['actions'];
+  }
+  return [statusAction(mapping, delivery, delivery.reason)] satisfies LifecycleResult['actions'];
+}
+
+function handleExistingDelivery(
+  mapping: TaskMapping,
+  delivery: LifecycleDelivery,
+  linearState: LinearLifecycleState,
+  policy: TeamLifecyclePolicy | undefined,
+  now: string,
+): LifecycleResult['actions'] {
+  if (linearState === 'done') {
+    if (delivery.outcome === 'pending' || delivery.outcome === 'failed') {
+      markIgnored(delivery, 'linear-terminal-done', now);
+      clearAlertFor(mapping, delivery.id);
+    }
+    return [{ type: 'none', reason: 'duplicate-event-linear-terminal-done' }];
+  }
+  if (linearState === 'in-review') {
+    if (delivery.outcome === 'pending' || delivery.outcome === 'failed') {
+      delivery.outcome = 'applied';
+      delivery.reason = 'inferred-applied-from-linear-state';
+      delivery.updatedAt = now;
+      delivery.lastError = null;
+      clearAlertFor(mapping, delivery.id);
+    }
+    return [{ type: 'none', reason: 'duplicate-event-linear-in-review' }];
+  }
+  if (delivery.outcome === 'applied' || delivery.outcome === 'ignored') {
+    return [{ type: 'none', reason: `duplicate-event-${delivery.outcome}` }];
+  }
+  if (policy?.inReview.enabled !== true) {
+    return [{ type: 'none', reason: 'projection-disabled' }];
+  }
+  if (linearState !== 'in-progress') {
+    return [{ type: 'none', reason: `duplicate-event-ineligible-state:${linearState}` }];
+  }
+  if (
+    delivery.outcome === 'pending' &&
+    !isStale(delivery.updatedAt, now, policy.inReview.staleAfterSeconds)
+  ) {
+    return [{ type: 'none', reason: 'duplicate-event-awaiting-ack' }];
+  }
+
+  delivery.outcome = 'pending';
+  delivery.reason = delivery.lastError === null ? 'retry-stale-delivery' : 'retry-failed-delivery';
+  delivery.updatedAt = now;
+  delivery.attempts += 1;
+  delivery.lastError = null;
+  setAlert(mapping, delivery.id, delivery.reason, now);
+  return [statusAction(mapping, delivery, delivery.reason)];
+}
+
+function statusAction(mapping: TaskMapping, delivery: LifecycleDelivery, reason: string) {
+  if (delivery.targetStatusId === null) {
+    throw new Error(`Delivery ${delivery.id} has no target status`);
+  }
+  return {
+    type: 'set-linear-status',
+    issueKey: mapping.linear.key,
+    deliveryId: delivery.id,
+    statusId: delivery.targetStatusId,
+    reason,
+  } satisfies SetLinearStatusAction;
+}
+
+function ensureLedgerCapacity(mapping: TaskMapping, policy: TeamLifecyclePolicy | undefined) {
+  const maxDeliveries = policy?.inReview.maxDeliveries ?? 100;
+  while (mapping.lifecycle.deliveries.length >= maxDeliveries) {
+    const index = mapping.lifecycle.deliveries.findIndex(
+      x => x.outcome === 'applied' || x.outcome === 'ignored',
+    );
+    if (index === -1) {
+      throw new Error(`Lifecycle delivery ledger is full of unresolved entries (${maxDeliveries})`);
+    }
+    mapping.lifecycle.deliveries.splice(index, 1);
+  }
+}
+
+function requireMapping(mappings: Record<string, TaskMapping>, issueKey: string) {
+  const key = normalizeIssueKey(issueKey);
+  const mapping = mappings[key];
+  if (mapping === undefined) {
+    throw new Error(`No mapping exists for ${key}`);
+  }
+  return mapping;
+}
+
+function assertSameEvent(delivery: LifecycleDelivery, request: ObserveReviewEventRequest) {
+  if (delivery.kind !== request.eventKind || delivery.source !== request.source) {
+    throw new Error(`Lifecycle delivery identity conflicts with stored event: ${request.eventId}`);
+  }
+}
+
+function markIgnored(delivery: LifecycleDelivery, reason: string, now: string) {
+  delivery.outcome = 'ignored';
+  delivery.reason = reason;
+  delivery.updatedAt = now;
+  delivery.lastError = null;
+}
+
+function setAlert(mapping: TaskMapping, deliveryId: string | null, reason: string, now: string) {
+  mapping.lifecycle.alert = {
+    state: 'attention',
+    reason,
+    since:
+      mapping.lifecycle.alert.state === 'attention' && mapping.lifecycle.alert.reason === reason
+        ? (mapping.lifecycle.alert.since ?? now)
+        : now,
+    deliveryId,
+  };
+}
+
+function clearAlertFor(mapping: TaskMapping, deliveryId: string) {
+  if (mapping.lifecycle.alert.deliveryId === deliveryId) {
+    clearAlert(mapping);
+  }
+}
+
+function clearAlert(mapping: TaskMapping) {
+  mapping.lifecycle.alert = { state: 'clear', reason: null, since: null, deliveryId: null };
+}
+
+function isStale(updatedAt: string, now: string, staleAfterSeconds: number) {
+  return Date.parse(now) - Date.parse(updatedAt) >= staleAfterSeconds * 1_000;
+}
+
+function assertEventId(value: string) {
+  assertNonempty(value, 'event-id');
+  if (value.length > 512) {
+    throw new Error('--event-id must be at most 512 characters');
+  }
+}
+
+function assertEventKind(value: string): asserts value is ReviewEventKind {
+  if (!REVIEW_EVENT_KINDS.includes(value as ReviewEventKind)) {
+    throw new Error(`Invalid --event-kind: ${value}`);
+  }
+}
+
+function assertLinearState(value: string): asserts value is LinearLifecycleState {
+  if (!LINEAR_LIFECYCLE_STATES.includes(value as LinearLifecycleState)) {
+    throw new Error(`Invalid --linear-state: ${value}`);
+  }
+}
+
+function assertTimestamp(value: string, name: string) {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new Error(`--${name} must be an ISO-8601 timestamp`);
+  }
+}
+
+function assertPositiveInteger(value: number, name: string) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+}
+
+function assertNonempty(value: string | undefined, name: string): asserts value is string {
+  if (value === undefined || value.trim() === '') {
+    throw new Error(`--${name} is required`);
+  }
+}

--- a/scripts/ai-workflow/model.ts
+++ b/scripts/ai-workflow/model.ts
@@ -1,7 +1,22 @@
-export const STORE_SCHEMA_VERSION = 1;
+export const STORE_SCHEMA_VERSION = 2;
 
 export const MEMBER_ROLES = ['owner', 'admin', 'member', 'guest', 'bot'] as const;
 export type MemberRole = (typeof MEMBER_ROLES)[number];
+
+export const REVIEW_EVENT_KINDS = ['ready-for-review', 'review-activity'] as const;
+export type ReviewEventKind = (typeof REVIEW_EVENT_KINDS)[number];
+
+export const LINEAR_LIFECYCLE_STATES = [
+  'todo',
+  'in-progress',
+  'in-review',
+  'done',
+  'other',
+] as const;
+export type LinearLifecycleState = (typeof LINEAR_LIFECYCLE_STATES)[number];
+
+export const DELIVERY_OUTCOMES = ['pending', 'applied', 'ignored', 'failed'] as const;
+export type DeliveryOutcome = (typeof DELIVERY_OUTCOMES)[number];
 
 export interface DesiredMember {
   pubkey: string;
@@ -13,6 +28,39 @@ export interface LinearStatusIds {
   inProgress: string;
   inReview: string;
   done: string;
+}
+
+export interface TeamLifecyclePolicy {
+  inReview: {
+    enabled: boolean;
+    staleAfterSeconds: number;
+    maxDeliveries: number;
+  };
+  updatedAt: string;
+}
+
+export interface LifecycleDelivery {
+  id: string;
+  kind: ReviewEventKind;
+  source: string;
+  observedAt: string;
+  updatedAt: string;
+  outcome: DeliveryOutcome;
+  reason: string;
+  targetStatusId: string | null;
+  attempts: number;
+  lastError: string | null;
+}
+
+export interface LifecycleState {
+  deliveries: LifecycleDelivery[];
+  lastObservedAt: string | null;
+  alert: {
+    state: 'clear' | 'attention';
+    reason: string | null;
+    since: string | null;
+    deliveryId: string | null;
+  };
 }
 
 export interface ReconcileRequest {
@@ -35,7 +83,7 @@ export interface ReconcileRequest {
 }
 
 export interface TaskMapping {
-  schemaVersion: 1;
+  schemaVersion: 2;
   linear: {
     key: string;
     title: string;
@@ -66,10 +114,12 @@ export interface TaskMapping {
     archivedAt: string | null;
     lastError: string | null;
   };
+  lifecycle: LifecycleState;
 }
 
 export interface MappingStoreData {
-  schemaVersion: 1;
+  schemaVersion: 2;
+  teamPolicies: Record<string, TeamLifecyclePolicy>;
   mappings: Record<string, TaskMapping>;
 }
 
@@ -89,8 +139,47 @@ type CreationRequest = ReconcileRequest &
     >
   >;
 
+interface TaskMappingV1 extends Omit<TaskMapping, 'schemaVersion' | 'lifecycle'> {
+  schemaVersion: 1;
+}
+
+export function emptyLifecycleState(): LifecycleState {
+  return {
+    deliveries: [],
+    lastObservedAt: null,
+    alert: { state: 'clear', reason: null, since: null, deliveryId: null },
+  };
+}
+
 export function emptyStore(): MappingStoreData {
-  return { schemaVersion: STORE_SCHEMA_VERSION, mappings: {} };
+  return { schemaVersion: STORE_SCHEMA_VERSION, teamPolicies: {}, mappings: {} };
+}
+
+export function migrateStore(value: unknown) {
+  if (!isRecord(value)) {
+    throw new Error(`Unsupported mapping store schema; expected ${STORE_SCHEMA_VERSION}`);
+  }
+  if (value.schemaVersion === STORE_SCHEMA_VERSION) {
+    assertValidStore(value);
+    return value;
+  }
+  if (value.schemaVersion !== 1 || !isRecord(value.mappings)) {
+    throw new Error(`Unsupported mapping store schema; expected ${STORE_SCHEMA_VERSION}`);
+  }
+
+  const migrated = emptyStore();
+  for (const [key, candidate] of Object.entries(value.mappings)) {
+    if (!isTaskMappingV1(candidate) || candidate.linear.key !== key) {
+      throw new Error(`Invalid mapping record: ${key}`);
+    }
+    migrated.mappings[key] = {
+      ...candidate,
+      schemaVersion: STORE_SCHEMA_VERSION,
+      lifecycle: emptyLifecycleState(),
+    };
+  }
+  assertValidStore(migrated);
+  return migrated;
 }
 
 export function normalizeIssueKey(value: string) {
@@ -116,7 +205,11 @@ export function parseMemberRole(value: string): MemberRole {
   return value as MemberRole;
 }
 
-export function createMapping(request: ReconcileRequest, channelId: string, now: string) {
+export function createMapping(
+  request: ReconcileRequest,
+  channelId: string,
+  now: string,
+): TaskMapping {
   assertCreationRequest(request);
   const key = normalizeIssueKey(request.key);
   return {
@@ -151,6 +244,7 @@ export function createMapping(request: ReconcileRequest, channelId: string, now:
       archivedAt: null,
       lastError: null,
     },
+    lifecycle: emptyLifecycleState(),
   } satisfies TaskMapping;
 }
 
@@ -221,8 +315,13 @@ export function assertValidStore(value: unknown): asserts value is MappingStoreD
   if (!isRecord(value) || value.schemaVersion !== STORE_SCHEMA_VERSION) {
     throw new Error(`Unsupported mapping store schema; expected ${STORE_SCHEMA_VERSION}`);
   }
-  if (!isRecord(value.mappings)) {
-    throw new Error('Mapping store must contain a mappings object');
+  if (!isRecord(value.teamPolicies) || !isRecord(value.mappings)) {
+    throw new Error('Mapping store must contain teamPolicies and mappings objects');
+  }
+  for (const [teamId, policy] of Object.entries(value.teamPolicies)) {
+    if (teamId === '' || !isTeamLifecyclePolicy(policy)) {
+      throw new Error(`Invalid team lifecycle policy: ${teamId}`);
+    }
   }
 
   const channelIds = new Set<string>();
@@ -244,8 +343,9 @@ export function assertValidStore(value: unknown): asserts value is MappingStoreD
   }
 }
 
-export function renderCanvas(mapping: TaskMapping) {
+export function renderCanvas(mapping: TaskMapping, teamPolicy?: TeamLifecyclePolicy) {
   const statusIds = mapping.linear.statusIds;
+  const lastDelivery = mapping.lifecycle.deliveries.at(-1);
   return `# ${mapping.linear.key} - ${mapping.linear.title}
 
 ## Task truth
@@ -265,17 +365,26 @@ export function renderCanvas(mapping: TaskMapping) {
 - Branch: \`${mapping.git.branch}\`
 - Worktree: \`${mapping.git.worktree}\`
 
+## Lifecycle projection
+
+- In Review projection: \`${teamPolicy?.inReview.enabled === true ? 'enabled' : 'disabled'}\`
+- Delivery ledger entries: \`${mapping.lifecycle.deliveries.length}\`
+- Last delivery: ${lastDelivery === undefined ? 'none' : `\`${lastDelivery.id}\` (${lastDelivery.outcome}: ${lastDelivery.reason})`}
+- Alert: \`${mapping.lifecycle.alert.state}\`${mapping.lifecycle.alert.reason === null ? '' : ` - ${mapping.lifecycle.alert.reason}`}
+
 ## Recovery check
 
 1. Read this canvas and the mapping store.
 2. Verify \`git worktree list\` contains the recorded worktree and branch.
 3. Verify \`HEAD\`, \`git status\`, and the current Linear lifecycle state before editing.
-4. Only the recorded owner writes in the worktree; handoffs transfer these same pointers.
+4. Reconcile lifecycle state from Linear truth before retrying a pending or failed delivery.
+5. Only the recorded owner writes in the worktree; handoffs transfer these same pointers.
 
 ## Guardrails
 
 - Never synchronize chat into Linear or GitHub.
 - Reconcile creates or updates structured pointers; it never deletes.
+- Lifecycle projection may move In Progress to In Review only; native merge-to-Done remains primary.
 - Archive the channel only after completion is verified.
 - Never remove the worktree or branch without clean-status and unique-commit checks.
 `;
@@ -291,7 +400,22 @@ function dedupeMembers(members: DesiredMember[]) {
 }
 
 function isTaskMapping(value: unknown): value is TaskMapping {
-  if (!isRecord(value) || value.schemaVersion !== STORE_SCHEMA_VERSION) {
+  return (
+    isBaseTaskMapping(value, STORE_SCHEMA_VERSION) &&
+    'lifecycle' in value &&
+    isLifecycleState(value.lifecycle)
+  );
+}
+
+function isTaskMappingV1(value: unknown): value is TaskMappingV1 {
+  return isBaseTaskMapping(value, 1);
+}
+
+function isBaseTaskMapping(
+  value: unknown,
+  schemaVersion: 1 | 2,
+): value is TaskMapping | TaskMappingV1 {
+  if (!isRecord(value) || value.schemaVersion !== schemaVersion) {
     return false;
   }
   if (
@@ -336,6 +460,51 @@ function isTaskMapping(value: unknown): value is TaskMapping {
   );
 }
 
+function isLifecycleState(value: unknown): value is LifecycleState {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.deliveries) &&
+    value.deliveries.every(isLifecycleDelivery) &&
+    (value.lastObservedAt === null || typeof value.lastObservedAt === 'string') &&
+    isRecord(value.alert) &&
+    (value.alert.state === 'clear' || value.alert.state === 'attention') &&
+    (value.alert.reason === null || typeof value.alert.reason === 'string') &&
+    (value.alert.since === null || typeof value.alert.since === 'string') &&
+    (value.alert.deliveryId === null || typeof value.alert.deliveryId === 'string')
+  );
+}
+
+function isLifecycleDelivery(value: unknown): value is LifecycleDelivery {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.kind === 'string' &&
+    REVIEW_EVENT_KINDS.includes(value.kind as ReviewEventKind) &&
+    typeof value.source === 'string' &&
+    typeof value.observedAt === 'string' &&
+    typeof value.updatedAt === 'string' &&
+    typeof value.outcome === 'string' &&
+    DELIVERY_OUTCOMES.includes(value.outcome as DeliveryOutcome) &&
+    typeof value.reason === 'string' &&
+    (value.targetStatusId === null || typeof value.targetStatusId === 'string') &&
+    typeof value.attempts === 'number' &&
+    Number.isSafeInteger(value.attempts) &&
+    value.attempts >= 0 &&
+    (value.lastError === null || typeof value.lastError === 'string')
+  );
+}
+
+function isTeamLifecyclePolicy(value: unknown): value is TeamLifecyclePolicy {
+  return (
+    isRecord(value) &&
+    isRecord(value.inReview) &&
+    typeof value.inReview.enabled === 'boolean' &&
+    isPositiveInteger(value.inReview.staleAfterSeconds) &&
+    isPositiveInteger(value.inReview.maxDeliveries) &&
+    typeof value.updatedAt === 'string'
+  );
+}
+
 function isDesiredMember(value: unknown): value is DesiredMember {
   return (
     isRecord(value) &&
@@ -344,6 +513,10 @@ function isDesiredMember(value: unknown): value is DesiredMember {
     typeof value.role === 'string' &&
     MEMBER_ROLES.includes(value.role as MemberRole)
   );
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/scripts/ai-workflow/reconcile.test.ts
+++ b/scripts/ai-workflow/reconcile.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { BuzzGateway, ChannelSummary } from './buzz.ts';
-import { emptyStore, renderCanvas, type DesiredMember, type ReconcileRequest } from './model.ts';
+import {
+  createMapping,
+  emptyStore,
+  renderCanvas,
+  type DesiredMember,
+  type ReconcileRequest,
+} from './model.ts';
 import { WorkflowReconciler } from './reconcile.ts';
 import { JsonMappingStore } from './store.ts';
 
@@ -149,6 +155,36 @@ describe('WorkflowReconciler', () => {
 });
 
 describe('JsonMappingStore', () => {
+  it('migrates schema-v1 mappings without losing archived execution state', async () => {
+    const directory = await temporaryDirectory();
+    const path = join(directory, 'mappings.json');
+    const mapping = createMapping(seed(), 'channel-id', '2026-08-14T03:00:00.000Z');
+    mapping.execution.desiredState = 'archived';
+    mapping.execution.observedState = 'archived';
+    mapping.execution.archivedAt = '2026-08-14T04:00:00.000Z';
+    const base = structuredClone(mapping) as unknown as Record<string, unknown>;
+    delete base.lifecycle;
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        mappings: { 'JAC-6': { ...base, schemaVersion: 1 } },
+      }),
+      'utf8',
+    );
+
+    const migrated = await new JsonMappingStore(path).read();
+
+    expect(migrated.schemaVersion).toBe(2);
+    expect(migrated.teamPolicies).toEqual({});
+    expect(migrated.mappings['JAC-6'].execution).toMatchObject({
+      desiredState: 'archived',
+      observedState: 'archived',
+      archivedAt: '2026-08-14T04:00:00.000Z',
+    });
+    expect(migrated.mappings['JAC-6'].lifecycle.deliveries).toEqual([]);
+  });
+
   it('rejects a duplicate Buzz channel invariant', async () => {
     const directory = await temporaryDirectory();
     const path = join(directory, 'mappings.json');

--- a/scripts/ai-workflow/reconcile.ts
+++ b/scripts/ai-workflow/reconcile.ts
@@ -60,7 +60,7 @@ export class WorkflowReconciler {
         mapping.execution.observedState = 'active';
         mapping.execution.lastError = null;
         mapping.execution.updatedAt = this.now().toISOString();
-        const desiredCanvas = renderCanvas(mapping);
+        const desiredCanvas = renderCanvas(mapping, data.teamPolicies[mapping.linear.teamId]);
         const currentCanvas = await this.buzz.getCanvas(mapping.buzz.channelId);
         if (currentCanvas === desiredCanvas) {
           actions.push('canvas-current');

--- a/scripts/ai-workflow/store.ts
+++ b/scripts/ai-workflow/store.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { assertValidStore, emptyStore, type MappingStoreData } from './model.ts';
+import { assertValidStore, emptyStore, migrateStore, type MappingStoreData } from './model.ts';
 
 export class JsonMappingStore {
   readonly path: string;
@@ -23,8 +23,7 @@ export class JsonMappingStore {
       throw error;
     }
     const parsed: unknown = JSON.parse(content);
-    assertValidStore(parsed);
-    return parsed;
+    return migrateStore(parsed);
   }
 
   async write(data: MappingStoreData) {


### PR DESCRIPTION
## Summary

- migrate Phase 2 mapping state from schema v1 to schema v2 without losing channel/archive data
- add an opt-in per-team In Review lifecycle policy
- persist a bounded review-event delivery ledger with explicit pending, applied, failed, and ignored outcomes
- split action planning from acknowledgment so failed or lost Linear writes remain recoverable
- suppress duplicate writes while acknowledgment is pending
- reconcile stale/failed work, infer lost acknowledgments from Linear truth, and store one attention signal
- ignore delayed review events after Done so lifecycle cannot regress

## Why

Thin slice 002 proved that this team's ready-for-review and submitted review activity do not move Linear from In Progress to In Review. Native attachment, label, issue-close, and merge-to-Done behavior all work, so this change fills only that measured edge.

## Operator impact

The CLI emits an explicit `set-linear-status` action. The authenticated operator applies it through Linear and acknowledges success or failure. No Linear credentials, webhook listener, chat synchronization, or product runtime code are added.

## Live migration evidence

- schema-v1 JAC-6 migrated to schema v2 with its archived channel, timestamps, and pointers intact
- JAC-7's team policy is enabled explicitly
- JAC-7's dedicated canvas was reconciled with a clear lifecycle ledger/alert

## Validation

At commit `269051633803b5ba3a2164999f4ae03c65b087eb`:

- `pnpm run compile`
- `pnpm run test` — 10 files, 97 tests passed

Fixes JAC-7
Closes #152