### PR TITLE
[JAC-8] Add structured attention, heartbeat, and safe archival

### DIFF
--- a/scripts/ai-workflow/README.md
+++ b/scripts/ai-workflow/README.md
@@ -1,12 +1,12 @@
-# Linear-Buzz workflow reconciler and lifecycle projector
+# Linear-Buzz workflow reconciler, lifecycle, and attention projector
 
-Manual-trigger bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after an explicit command. Its opt-in lifecycle projector handles only the measured In Progress to In Review gap; native GitHub-to-Linear merge-to-Done remains primary.
+Manual-trigger bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after verified completion. Its opt-in lifecycle projector handles only the measured In Progress to In Review gap. Its opt-in attention projector tracks heartbeat, stalls, recovery, and ownership handoff without storing chat. Native GitHub-to-Linear merge-to-Done remains primary.
 
 The bridge does not call Linear directly. The initiating agent reads Linear through its authenticated connector and supplies the issue snapshot on the first reconcile. Later reconciles need only the issue key and mapping store. This keeps OAuth credentials out of the repository and mapping data.
 
 ## Runtime state
 
-Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 2, atomic replacement, and a local lock file. Existing schema-v1 mappings migrate on the next write.
+Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 3, atomic replacement, and a local lock file. Existing schema-v1 and schema-v2 mappings migrate on the next write without losing lifecycle or archive state.
 
 ```powershell
 $env:AI_WORKFLOW_MAPPING_STORE = 'C:\Users\cyrus\.buzz\.state\ai-workflow\mappings.json'
@@ -73,15 +73,56 @@ Reconciliation emits one stored attention signal for stale, failed, or unexpecte
 
 The CLI does not contain Linear credentials or an always-on webhook listener. The authenticated operator supplies current Linear truth and applies the explicit action.
 
+## Structured attention and heartbeat
+
+Enable heartbeat monitoring for the mapping's exact Linear team and repository scope:
+
+```powershell
+pnpm workflow attention-configure JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --enable --stale-after-seconds 900 --max-signals 100
+```
+
+Record stable, replay-safe signals. A progress heartbeat starts or renews the lease. A stall requires a concise structured reason. Recovery is explicit, so ordinary progress cannot silently clear a human-attention request. Handoff changes only the owner while retaining the same branch and worktree.
+
+```powershell
+pnpm workflow heartbeat JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id 'heartbeat:JAC-8:1' --kind progress --owner 'Codex Sol'
+
+pnpm workflow heartbeat JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id 'heartbeat:JAC-8:2' --kind stall --owner 'Codex Sol' `
+  --reason 'waiting-for-human-decision'
+
+pnpm workflow heartbeat JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id 'heartbeat:JAC-8:3' --kind recovery --owner 'Codex Sol' `
+  --reason 'decision-received'
+
+pnpm workflow heartbeat JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --event-id 'heartbeat:JAC-8:4' --kind handoff --owner 'Codex Sol' `
+  --next-owner 'Codex Terra' --reason 'verification-owner'
+```
+
+Manual reconciliation supplies current Linear lifecycle and label truth. When the output contains `set-linear-needs-human`, apply that label change through the authenticated Linear connector, then acknowledge the delivery. Duplicate signals and pending delivery replays produce no duplicate write. Reconciliation infers a lost acknowledgment when Linear already matches the desired label.
+
+```powershell
+pnpm workflow attention-reconcile JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --linear-state in-progress --linear-needs-human absent
+
+pnpm workflow attention-ack JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --delivery-id '<delivery-id>' --result applied
+```
+
+Attention changes only Linear's `needs-human` label and the Buzz canvas. It never changes lifecycle status. The history is bounded, carries no credentials or chat, and records only stable signal identity, owner, time, handoff target, and concise reason.
+
 ## Recovery and archive
 
 ```powershell
 pnpm workflow reconcile JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE
 pnpm workflow inspect JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE
-pnpm workflow archive JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE --confirm
+pnpm workflow archive JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --confirm --linear-state done
 ```
 
-Archive is idempotent. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no delete operation. Schema-v1 Phase 2 mappings migrate to schema v2 on the next write without losing channel or archive state.
+Archive is idempotent and completion-gated. It refuses an active mapping unless Linear is Done, lifecycle deliveries are resolved, and structured attention plus `needs-human` delivery state are clear. It writes a final canvas before archiving. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no delete operation.
 
 ## Validation
 

--- a/scripts/ai-workflow/attention.test.ts
+++ b/scripts/ai-workflow/attention.test.ts
@@ -1,0 +1,259 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AttentionProjector } from './attention.ts';
+import { createMapping, emptyStore, type ReconcileRequest } from './model.ts';
+import { JsonMappingStore } from './store.ts';
+
+const temporaryDirectories: string[] = [];
+const NOW = '2026-08-14T12:00:00.000Z';
+
+afterEach(async () => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe('AttentionProjector', () => {
+  it('requires an explicit repository-scoped opt in', async () => {
+    const { projector, store } = await harness();
+    const disabled = await projector.observe(progress());
+    await enable(projector);
+    const data = await store.read();
+
+    expect(disabled.actions).toEqual([{ type: 'none', reason: 'attention-policy-disabled' }]);
+    expect(data.attentionPolicies['team-id'][REPOSITORY]).toMatchObject({
+      enabled: true,
+      staleAfterSeconds: 300,
+      maxSignals: 100,
+    });
+  });
+
+  it('records one replay-safe healthy heartbeat', async () => {
+    const { projector } = await harness(true);
+    const first = await projector.observe(progress());
+    const duplicate = await projector.observe(progress());
+
+    expect(first.actions).toEqual([{ type: 'none', reason: 'progress-recorded' }]);
+    expect(first.mapping.attention.status).toBe('healthy');
+    expect(first.mapping.attention.lastProgressAt).toBe(NOW);
+    expect(duplicate.actions).toEqual([{ type: 'none', reason: 'duplicate-heartbeat' }]);
+    expect(duplicate.mapping.attention.signals).toHaveLength(1);
+  });
+
+  it('rejects a conflicting payload that reuses a heartbeat identity', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(progress());
+
+    await expect(projector.observe({ ...progress(), reason: 'different payload' })).rejects.toThrow(
+      'identity conflicts',
+    );
+  });
+
+  it('emits one needs-human action for a stale heartbeat and infers a lost acknowledgment', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(progress());
+    const stale = await projector.reconcile({
+      issueKey: 'JAC-8',
+      linearState: 'in-progress',
+      linearNeedsHuman: false,
+      now: '2026-08-14T12:06:00.000Z',
+    });
+    const duplicate = await projector.reconcile({
+      issueKey: 'JAC-8',
+      linearState: 'in-progress',
+      linearNeedsHuman: false,
+      now: '2026-08-14T12:06:01.000Z',
+    });
+    const inferred = await projector.reconcile({
+      issueKey: 'JAC-8',
+      linearState: 'in-progress',
+      linearNeedsHuman: true,
+      now: '2026-08-14T12:06:02.000Z',
+    });
+
+    expect(stale.actions).toEqual([
+      { type: 'needs-attention', reason: 'heartbeat-stale' },
+      {
+        type: 'set-linear-needs-human',
+        issueKey: 'JAC-8',
+        deliveryId: `heartbeat-stale:${NOW}:set`,
+        enabled: true,
+        reason: 'heartbeat-stale',
+      },
+    ]);
+    expect(duplicate.actions).toEqual([
+      { type: 'none', reason: 'attention-delivery-awaiting-ack' },
+    ]);
+    expect(inferred.actions).toEqual([
+      { type: 'none', reason: 'inferred-attention-applied-from-linear-label' },
+    ]);
+    expect(inferred.mapping.attention.label.outcome).toBe('applied');
+  });
+
+  it('clears attention only through an explicit recovery signal', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(progress());
+    const stalled = await projector.observe({
+      issueKey: 'JAC-8',
+      eventId: 'heartbeat:stall:1',
+      kind: 'stall',
+      owner: 'Codex Sol',
+      observedAt: '2026-08-14T12:01:00.000Z',
+      reason: 'waiting-for-human-decision',
+    });
+    await projector.acknowledge({
+      issueKey: 'JAC-8',
+      deliveryId: 'attention:heartbeat:stall:1:set',
+      result: 'applied',
+    });
+    const progressWhileStalled = await projector.observe({
+      ...progress(),
+      eventId: 'heartbeat:progress:2',
+      observedAt: '2026-08-14T12:02:00.000Z',
+    });
+    const recovered = await projector.observe({
+      issueKey: 'JAC-8',
+      eventId: 'heartbeat:recovery:1',
+      kind: 'recovery',
+      owner: 'Codex Sol',
+      observedAt: '2026-08-14T12:03:00.000Z',
+      reason: 'decision-received',
+    });
+
+    expect(stalled.mapping.attention.status).toBe('attention');
+    expect(progressWhileStalled.mapping.attention.status).toBe('attention');
+    expect(recovered.mapping.attention.status).toBe('recovered');
+    expect(recovered.mapping.attention.stallReason).toBeNull();
+    expect(recovered.actions).toEqual([
+      {
+        type: 'set-linear-needs-human',
+        issueKey: 'JAC-8',
+        deliveryId: 'attention:heartbeat:recovery:1:clear',
+        enabled: false,
+        reason: 'decision-received',
+      },
+    ]);
+  });
+
+  it('hands off the same branch and worktree to a new owner', async () => {
+    const { projector } = await harness(true);
+    await projector.observe(progress());
+    const handedOff = await projector.observe({
+      issueKey: 'JAC-8',
+      eventId: 'heartbeat:handoff:1',
+      kind: 'handoff',
+      owner: 'Codex Sol',
+      nextOwner: 'Codex Terra',
+      observedAt: '2026-08-14T12:01:00.000Z',
+      reason: 'verification-owner',
+    });
+
+    expect(handedOff.mapping.execution.owner).toBe('Codex Terra');
+    expect(handedOff.mapping.git.branch).toBe('JAC-8-structured-attention-heartbeat');
+    expect(handedOff.mapping.git.worktree).toBe('/worktrees/JAC-8');
+    await expect(
+      projector.observe({
+        ...progress(),
+        eventId: 'heartbeat:progress:old-owner',
+        observedAt: '2026-08-14T12:02:00.000Z',
+      }),
+    ).rejects.toThrow('does not match current owner');
+  });
+
+  it('retries one failed label delivery and bounds signal history', async () => {
+    const { projector } = await harness();
+    await projector.configure({
+      issueKey: 'JAC-8',
+      enabled: true,
+      staleAfterSeconds: 300,
+      maxSignals: 1,
+    });
+    await projector.observe(progress());
+    const stalled = await projector.observe({
+      issueKey: 'JAC-8',
+      eventId: 'heartbeat:stall:1',
+      kind: 'stall',
+      owner: 'Codex Sol',
+      observedAt: '2026-08-14T12:01:00.000Z',
+      reason: 'blocked',
+    });
+    await projector.acknowledge({
+      issueKey: 'JAC-8',
+      deliveryId: 'attention:heartbeat:stall:1:set',
+      result: 'failed',
+      error: 'Linear unavailable',
+    });
+    const retry = await projector.reconcile({
+      issueKey: 'JAC-8',
+      linearState: 'in-progress',
+      linearNeedsHuman: false,
+      now: '2026-08-14T12:01:01.000Z',
+    });
+
+    expect(stalled.mapping.attention.signals).toHaveLength(1);
+    expect(retry.mapping.attention.signals).toHaveLength(1);
+    expect(retry.mapping.attention.signals[0].id).toBe('heartbeat:stall:1');
+    expect(retry.actions[0]).toMatchObject({
+      type: 'set-linear-needs-human',
+      enabled: true,
+    });
+    expect(retry.mapping.attention.label.attempts).toBe(2);
+  });
+});
+
+function progress() {
+  return {
+    issueKey: 'JAC-8',
+    eventId: 'heartbeat:progress:1',
+    kind: 'progress' as const,
+    owner: 'Codex Sol',
+    observedAt: NOW,
+  };
+}
+
+async function enable(projector: AttentionProjector) {
+  await projector.configure({
+    issueKey: 'JAC-8',
+    enabled: true,
+    staleAfterSeconds: 300,
+    maxSignals: 100,
+  });
+}
+
+async function harness(enablePolicy = false) {
+  const directory = await mkdtemp(join(tmpdir(), 'ai-workflow-attention-'));
+  temporaryDirectories.push(directory);
+  const store = new JsonMappingStore(join(directory, 'mappings.json'));
+  const data = emptyStore();
+  data.mappings['JAC-8'] = createMapping(seed(), 'channel-id', NOW);
+  await store.write(data);
+  const projector = new AttentionProjector(store, () => new Date(NOW));
+  if (enablePolicy) {
+    await enable(projector);
+  }
+  return { projector, store };
+}
+
+const REPOSITORY = 'https://github.com/example/repo';
+
+function seed(): ReconcileRequest {
+  return {
+    key: 'JAC-8',
+    title: '[Phase 4] Add structured attention, heartbeat, and safe archival',
+    linearUrl: 'https://linear.app/example/issue/JAC-8/example',
+    teamId: 'team-id',
+    statusIds: {
+      todo: 'todo-id',
+      inProgress: 'progress-id',
+      inReview: 'review-id',
+      done: 'done-id',
+    },
+    channelName: 'JAC-8-structured-attention-heartbeat',
+    repository: REPOSITORY,
+    branch: 'JAC-8-structured-attention-heartbeat',
+    worktree: '/worktrees/JAC-8',
+    owner: 'Codex Sol',
+  };
+}

--- a/scripts/ai-workflow/attention.ts
+++ b/scripts/ai-workflow/attention.ts
@@ -1,0 +1,455 @@
+import {
+  ATTENTION_SIGNAL_KINDS,
+  LINEAR_LIFECYCLE_STATES,
+  normalizeIssueKey,
+  type AttentionPolicy,
+  type AttentionSignal,
+  type AttentionSignalKind,
+  type LinearLifecycleState,
+  type TaskMapping,
+} from './model.ts';
+import { JsonMappingStore } from './store.ts';
+
+export interface ConfigureAttentionRequest {
+  issueKey: string;
+  enabled: boolean;
+  staleAfterSeconds: number;
+  maxSignals: number;
+}
+
+export interface ObserveHeartbeatRequest {
+  issueKey: string;
+  eventId: string;
+  kind: AttentionSignalKind;
+  owner: string;
+  observedAt?: string;
+  reason?: string;
+  nextOwner?: string;
+}
+
+export interface ReconcileAttentionRequest {
+  issueKey: string;
+  linearState: LinearLifecycleState;
+  linearNeedsHuman: boolean;
+  now?: string;
+}
+
+export interface AcknowledgeAttentionRequest {
+  issueKey: string;
+  deliveryId: string;
+  result: 'applied' | 'failed';
+  error?: string;
+}
+
+export interface SetLinearNeedsHumanAction {
+  type: 'set-linear-needs-human';
+  issueKey: string;
+  deliveryId: string;
+  enabled: boolean;
+  reason: string;
+}
+
+export interface AttentionResult {
+  mapping: TaskMapping;
+  actions: Array<
+    | SetLinearNeedsHumanAction
+    | { type: 'none'; reason: string }
+    | { type: 'needs-attention'; reason: string }
+  >;
+}
+
+export class AttentionProjector {
+  readonly store: JsonMappingStore;
+  readonly now: () => Date;
+
+  constructor(store: JsonMappingStore, now = () => new Date()) {
+    this.store = store;
+    this.now = now;
+  }
+
+  async configure(request: ConfigureAttentionRequest) {
+    assertPositiveInteger(request.staleAfterSeconds, 'stale-after-seconds');
+    assertPositiveInteger(request.maxSignals, 'max-signals');
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const now = this.now().toISOString();
+      const desired: AttentionPolicy = {
+        enabled: request.enabled,
+        staleAfterSeconds: request.staleAfterSeconds,
+        maxSignals: request.maxSignals,
+        updatedAt: now,
+      };
+      const teamPolicies = (data.attentionPolicies[mapping.linear.teamId] ??= {});
+      const current = teamPolicies[mapping.git.repository];
+      const unchanged =
+        current?.enabled === desired.enabled &&
+        current.staleAfterSeconds === desired.staleAfterSeconds &&
+        current.maxSignals === desired.maxSignals;
+      if (unchanged) {
+        return result(mapping, 'attention-policy-current');
+      }
+      teamPolicies[mapping.git.repository] = desired;
+      await this.store.write(data);
+      return result(
+        mapping,
+        request.enabled ? 'enabled-attention-policy' : 'disabled-attention-policy',
+      );
+    });
+  }
+
+  async observe(request: ObserveHeartbeatRequest) {
+    assertEventId(request.eventId);
+    assertSignalKind(request.kind);
+    assertNonempty(request.owner, 'owner');
+    const observedAt = request.observedAt ?? this.now().toISOString();
+    assertTimestamp(observedAt, 'observed-at');
+    validateSignalDetails(request);
+
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const policy = attentionPolicy(data.attentionPolicies, mapping);
+      if (policy?.enabled !== true) {
+        return result(mapping, 'attention-policy-disabled');
+      }
+      if (mapping.execution.desiredState === 'archived') {
+        return result(mapping, 'channel-archived');
+      }
+      if (mapping.execution.owner !== request.owner) {
+        throw new Error(
+          `Heartbeat owner ${request.owner} does not match current owner ${mapping.execution.owner}`,
+        );
+      }
+
+      const existing = mapping.attention.signals.find(x => x.id === request.eventId);
+      if (existing !== undefined) {
+        assertSameSignal(existing, request, observedAt);
+        return result(mapping, 'duplicate-heartbeat');
+      }
+
+      while (mapping.attention.signals.length >= policy.maxSignals) {
+        mapping.attention.signals.shift();
+      }
+      const signal = createSignal(request, observedAt);
+      mapping.attention.signals.push(signal);
+      mapping.attention.lastObservedAt = observedAt;
+      mapping.execution.updatedAt = this.now().toISOString();
+
+      let actions: AttentionResult['actions'] = [];
+      if (signal.kind === 'stall') {
+        mapping.attention.status = 'attention';
+        mapping.attention.stallReason = signal.reason;
+        actions = planLabel(
+          mapping,
+          true,
+          signal.reason!,
+          `attention:${signal.id}:set`,
+          mapping.execution.updatedAt,
+        );
+      } else if (signal.kind === 'recovery') {
+        mapping.attention.status = 'recovered';
+        mapping.attention.stallReason = null;
+        mapping.attention.lastProgressAt = observedAt;
+        const required = mapping.lifecycle.alert.state === 'attention';
+        actions = planLabel(
+          mapping,
+          required,
+          required ? 'lifecycle-alert-remains' : (signal.reason ?? 'recovered'),
+          `attention:${signal.id}:${required ? 'set' : 'clear'}`,
+          mapping.execution.updatedAt,
+        );
+      } else if (signal.kind === 'handoff') {
+        mapping.execution.owner = signal.nextOwner!;
+        mapping.attention.lastProgressAt = observedAt;
+        if (mapping.attention.status !== 'attention') {
+          mapping.attention.status = 'healthy';
+        }
+      } else {
+        mapping.attention.lastProgressAt = observedAt;
+        if (mapping.attention.status !== 'attention') {
+          mapping.attention.status = 'healthy';
+        }
+      }
+
+      await this.store.write(data);
+      return {
+        mapping,
+        actions:
+          actions.length === 0 ? [{ type: 'none', reason: `${signal.kind}-recorded` }] : actions,
+      } satisfies AttentionResult;
+    });
+  }
+
+  async acknowledge(request: AcknowledgeAttentionRequest) {
+    assertEventId(request.deliveryId);
+    if (request.result === 'failed') {
+      assertNonempty(request.error, 'error');
+    }
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const label = mapping.attention.label;
+      if (label.deliveryId !== request.deliveryId) {
+        throw new Error(`No current attention delivery exists for ${request.deliveryId}`);
+      }
+      if (label.outcome === 'applied' && request.result === 'applied') {
+        return result(mapping, 'attention-delivery-already-applied');
+      }
+      if (label.outcome === 'applied' && request.result === 'failed') {
+        throw new Error(
+          `Applied attention delivery cannot be changed to failed: ${request.deliveryId}`,
+        );
+      }
+
+      label.updatedAt = this.now().toISOString();
+      if (request.result === 'applied') {
+        label.observed = label.desired;
+        label.outcome = 'applied';
+        label.lastError = null;
+        await this.store.write(data);
+        return result(mapping, 'acknowledged-attention-applied');
+      }
+
+      label.outcome = 'failed';
+      label.lastError = request.error!;
+      await this.store.write(data);
+      return {
+        mapping,
+        actions: [
+          { type: 'needs-attention', reason: `linear-label-write-failed: ${request.error!}` },
+        ],
+      } satisfies AttentionResult;
+    });
+  }
+
+  async reconcile(request: ReconcileAttentionRequest) {
+    assertLinearState(request.linearState);
+    const now = request.now ?? this.now().toISOString();
+    assertTimestamp(now, 'now');
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const policy = attentionPolicy(data.attentionPolicies, mapping);
+      if (policy?.enabled !== true) {
+        return result(mapping, 'attention-policy-disabled');
+      }
+      if (mapping.execution.desiredState === 'archived') {
+        return result(mapping, 'channel-archived');
+      }
+
+      mapping.attention.lastObservedAt = now;
+      const monitorsHeartbeat =
+        request.linearState === 'in-progress' || request.linearState === 'in-review';
+      if (
+        monitorsHeartbeat &&
+        mapping.attention.lastProgressAt !== null &&
+        isStale(mapping.attention.lastProgressAt, now, policy.staleAfterSeconds)
+      ) {
+        mapping.attention.status = 'attention';
+        mapping.attention.stallReason ??= 'heartbeat-stale';
+      }
+
+      const label = mapping.attention.label;
+      label.observed = request.linearNeedsHuman;
+      const required =
+        mapping.attention.status === 'attention' || mapping.lifecycle.alert.state === 'attention';
+      const reason = attentionReason(mapping);
+      let actions: AttentionResult['actions'];
+
+      if (label.desired !== required) {
+        const deliveryId = required
+          ? `heartbeat-stale:${mapping.attention.lastProgressAt ?? now}:set`
+          : `attention-recovered:${mapping.attention.lastProgressAt ?? now}:clear`;
+        actions = planLabel(mapping, required, reason, deliveryId, now);
+      } else if (label.observed === label.desired) {
+        if (label.outcome === 'pending' || label.outcome === 'failed') {
+          label.outcome = 'applied';
+          label.lastError = null;
+          label.updatedAt = now;
+          actions = [{ type: 'none', reason: 'inferred-attention-applied-from-linear-label' }];
+        } else {
+          actions = [{ type: 'none', reason: 'attention-current' }];
+        }
+      } else if (label.outcome === 'failed') {
+        label.outcome = 'pending';
+        label.attempts += 1;
+        label.updatedAt = now;
+        label.lastError = null;
+        actions = [labelAction(mapping)];
+      } else if (label.outcome === 'pending') {
+        actions = [{ type: 'none', reason: 'attention-delivery-awaiting-ack' }];
+      } else {
+        actions = planLabel(
+          mapping,
+          required,
+          reason,
+          `attention-reconcile:${mapping.attention.lastProgressAt ?? now}:${required ? 'set' : 'clear'}`,
+          now,
+        );
+      }
+
+      mapping.execution.updatedAt = now;
+      await this.store.write(data);
+      return { mapping, actions } satisfies AttentionResult;
+    });
+  }
+}
+
+function createSignal(request: ObserveHeartbeatRequest, observedAt: string): AttentionSignal {
+  return {
+    id: request.eventId,
+    kind: request.kind,
+    observedAt,
+    owner: request.owner,
+    nextOwner: request.nextOwner ?? null,
+    reason: request.reason ?? null,
+  };
+}
+
+function planLabel(
+  mapping: TaskMapping,
+  desired: boolean,
+  reason: string,
+  deliveryId: string,
+  now: string,
+) {
+  const label = mapping.attention.label;
+  label.desired = desired;
+  label.deliveryId = deliveryId;
+  label.reason = reason;
+  label.updatedAt = now;
+  label.lastError = null;
+  if (label.observed === desired) {
+    label.outcome = 'applied';
+    label.attempts = 0;
+    return [
+      { type: 'none', reason: 'linear-needs-human-already-current' },
+    ] satisfies AttentionResult['actions'];
+  }
+  label.outcome = 'pending';
+  label.attempts = 1;
+  const actions: AttentionResult['actions'] = [labelAction(mapping)];
+  if (desired) {
+    actions.unshift({ type: 'needs-attention', reason });
+  }
+  return actions;
+}
+
+function labelAction(mapping: TaskMapping) {
+  const label = mapping.attention.label;
+  if (label.deliveryId === null || label.reason === null) {
+    throw new Error('Attention label delivery is incomplete');
+  }
+  return {
+    type: 'set-linear-needs-human',
+    issueKey: mapping.linear.key,
+    deliveryId: label.deliveryId,
+    enabled: label.desired,
+    reason: label.reason,
+  } satisfies SetLinearNeedsHumanAction;
+}
+
+function attentionReason(mapping: TaskMapping) {
+  if (mapping.attention.status === 'attention') {
+    return mapping.attention.stallReason ?? 'heartbeat-stale';
+  }
+  if (mapping.lifecycle.alert.state === 'attention') {
+    return mapping.lifecycle.alert.reason ?? 'lifecycle-delivery-alert';
+  }
+  return 'recovered';
+}
+
+function attentionPolicy(
+  policies: Record<string, Record<string, AttentionPolicy>>,
+  mapping: TaskMapping,
+) {
+  return policies[mapping.linear.teamId]?.[mapping.git.repository];
+}
+
+function requireMapping(mappings: Record<string, TaskMapping>, issueKey: string) {
+  const key = normalizeIssueKey(issueKey);
+  const mapping = mappings[key];
+  if (mapping === undefined) {
+    throw new Error(`No mapping exists for ${key}`);
+  }
+  return mapping;
+}
+
+function result(mapping: TaskMapping, reason: string): AttentionResult {
+  return { mapping, actions: [{ type: 'none', reason }] };
+}
+
+function validateSignalDetails(request: ObserveHeartbeatRequest) {
+  if (request.kind === 'stall') {
+    assertNonempty(request.reason, 'reason');
+  }
+  if (request.kind === 'handoff') {
+    assertNonempty(request.nextOwner, 'next-owner');
+    if (request.nextOwner === request.owner) {
+      throw new Error('--next-owner must differ from --owner');
+    }
+  } else if (request.nextOwner !== undefined) {
+    throw new Error('--next-owner is valid only for a handoff heartbeat');
+  }
+  if (request.reason !== undefined && request.reason.length > 512) {
+    throw new Error('--reason must be at most 512 characters');
+  }
+}
+
+function assertSameSignal(
+  signal: AttentionSignal,
+  request: ObserveHeartbeatRequest,
+  observedAt: string,
+) {
+  if (
+    signal.kind !== request.kind ||
+    signal.owner !== request.owner ||
+    signal.observedAt !== observedAt ||
+    signal.nextOwner !== (request.nextOwner ?? null) ||
+    signal.reason !== (request.reason ?? null)
+  ) {
+    throw new Error(`Heartbeat identity conflicts with stored signal: ${request.eventId}`);
+  }
+}
+
+function isStale(updatedAt: string, now: string, staleAfterSeconds: number) {
+  return Date.parse(now) - Date.parse(updatedAt) >= staleAfterSeconds * 1_000;
+}
+
+function assertSignalKind(value: string): asserts value is AttentionSignalKind {
+  if (!ATTENTION_SIGNAL_KINDS.includes(value as AttentionSignalKind)) {
+    throw new Error(`Invalid --kind: ${value}`);
+  }
+}
+
+function assertLinearState(value: string): asserts value is LinearLifecycleState {
+  if (!LINEAR_LIFECYCLE_STATES.includes(value as LinearLifecycleState)) {
+    throw new Error(`Invalid --linear-state: ${value}`);
+  }
+}
+
+function assertEventId(value: string) {
+  assertNonempty(value, 'event-id');
+  if (value.length > 512) {
+    throw new Error('--event-id must be at most 512 characters');
+  }
+}
+
+function assertTimestamp(value: string, name: string) {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new Error(`--${name} must be an ISO-8601 timestamp`);
+  }
+}
+
+function assertPositiveInteger(value: number, name: string) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+}
+
+function assertNonempty(value: string | undefined, name: string): asserts value is string {
+  if (value === undefined || value.trim() === '') {
+    throw new Error(`--${name} is required`);
+  }
+}

--- a/scripts/ai-workflow/cli.ts
+++ b/scripts/ai-workflow/cli.ts
@@ -1,12 +1,15 @@
 import { resolve } from 'node:path';
+import { AttentionProjector } from './attention.ts';
 import { BuzzCliGateway } from './buzz.ts';
 import { LifecycleProjector } from './lifecycle.ts';
 import {
   LINEAR_LIFECYCLE_STATES,
+  ATTENTION_SIGNAL_KINDS,
   REVIEW_EVENT_KINDS,
   parseMemberRole,
   normalizePubkey,
   type DesiredMember,
+  type AttentionSignalKind,
   type LinearLifecycleState,
   type LinearStatusIds,
   type ReconcileRequest,
@@ -44,13 +47,64 @@ async function main() {
   const buzz = new BuzzCliGateway(option(parsed, 'buzz-bin') ?? process.env.BUZZ_CLI ?? 'buzz');
   const reconciler = new WorkflowReconciler(store, buzz);
   const lifecycle = new LifecycleProjector(store);
+  const attention = new AttentionProjector(store);
 
   if (parsed.command === 'inspect') {
     printJson(await reconciler.inspect(issueKey));
     return;
   }
   if (parsed.command === 'archive') {
-    printJson(await reconciler.archive(issueKey, parsed.switches.has('confirm')));
+    printJson(
+      await reconciler.archive(
+        issueKey,
+        parsed.switches.has('confirm'),
+        optionalLinearState(option(parsed, 'linear-state')),
+      ),
+    );
+    return;
+  }
+  if (parsed.command === 'attention-configure') {
+    const enabled = exactlyOneSwitch(parsed, 'enable', 'disable') === 'enable';
+    const result = await attention.configure({
+      issueKey,
+      enabled,
+      staleAfterSeconds: integerOption(parsed, 'stale-after-seconds', 900),
+      maxSignals: integerOption(parsed, 'max-signals', 100),
+    });
+    printJson(await withCanvas(result, reconciler, issueKey));
+    return;
+  }
+  if (parsed.command === 'heartbeat') {
+    const result = await attention.observe({
+      issueKey,
+      eventId: requiredOption(parsed, 'event-id'),
+      kind: attentionSignalKind(requiredOption(parsed, 'kind')),
+      owner: requiredOption(parsed, 'owner'),
+      observedAt: option(parsed, 'observed-at'),
+      reason: option(parsed, 'reason'),
+      nextOwner: option(parsed, 'next-owner'),
+    });
+    printJson(await withCanvas(result, reconciler, issueKey));
+    return;
+  }
+  if (parsed.command === 'attention-ack') {
+    const result = await attention.acknowledge({
+      issueKey,
+      deliveryId: requiredOption(parsed, 'delivery-id'),
+      result: acknowledgmentResult(requiredOption(parsed, 'result')),
+      error: option(parsed, 'error'),
+    });
+    printJson(await withCanvas(result, reconciler, issueKey));
+    return;
+  }
+  if (parsed.command === 'attention-reconcile') {
+    const result = await attention.reconcile({
+      issueKey,
+      linearState: linearState(requiredOption(parsed, 'linear-state')),
+      linearNeedsHuman: linearNeedsHuman(requiredOption(parsed, 'linear-needs-human')),
+      now: option(parsed, 'now'),
+    });
+    printJson(await withCanvas(result, reconciler, issueKey));
     return;
   }
   if (parsed.command === 'lifecycle-configure') {
@@ -271,6 +325,24 @@ function linearState(value: string): LinearLifecycleState {
   return value as LinearLifecycleState;
 }
 
+function optionalLinearState(value: string | undefined) {
+  return value === undefined ? undefined : linearState(value);
+}
+
+function attentionSignalKind(value: string): AttentionSignalKind {
+  if (!ATTENTION_SIGNAL_KINDS.includes(value as AttentionSignalKind)) {
+    throw new Error(`Invalid --kind: ${value}`);
+  }
+  return value as AttentionSignalKind;
+}
+
+function linearNeedsHuman(value: string) {
+  if (value !== 'present' && value !== 'absent') {
+    throw new Error(`Invalid --linear-needs-human: ${value}`);
+  }
+  return value === 'present';
+}
+
 function acknowledgmentResult(value: string) {
   if (value !== 'applied' && value !== 'failed') {
     throw new Error(`Invalid --result: ${value}`);
@@ -280,6 +352,15 @@ function acknowledgmentResult(value: string) {
 
 function printJson(value: unknown) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function withCanvas(
+  result: Awaited<ReturnType<AttentionProjector['observe']>>,
+  reconciler: WorkflowReconciler,
+  issueKey: string,
+) {
+  const canvas = await reconciler.reconcile({ key: issueKey });
+  return { ...result, mapping: canvas.mapping, canvasActions: canvas.actions };
 }
 
 function toKebabCase(value: string) {
@@ -292,7 +373,11 @@ function helpText() {
 Usage:
   pnpm workflow reconcile ISSUE-ID --store PATH [metadata options]
   pnpm workflow inspect ISSUE-ID --store PATH
-  pnpm workflow archive ISSUE-ID --store PATH --confirm
+  pnpm workflow archive ISSUE-ID --store PATH --confirm --linear-state done
+  pnpm workflow attention-configure ISSUE-ID --store PATH --enable|--disable
+  pnpm workflow heartbeat ISSUE-ID --store PATH --event-id ID --kind KIND --owner OWNER
+  pnpm workflow attention-ack ISSUE-ID --store PATH --delivery-id ID --result applied|failed
+  pnpm workflow attention-reconcile ISSUE-ID --store PATH --linear-state STATE --linear-needs-human present|absent
   pnpm workflow lifecycle-configure ISSUE-ID --store PATH --enable|--disable
   pnpm workflow lifecycle-observe ISSUE-ID --store PATH --event-id ID --event-kind KIND --source URL --linear-state STATE
   pnpm workflow lifecycle-ack ISSUE-ID --store PATH --event-id ID --result applied|failed [--error TEXT]
@@ -318,6 +403,15 @@ Lifecycle options:
   --observed-at ISO
   --stale-after-seconds N (default 300)
   --max-deliveries N (default 100)
+
+Attention options:
+  --kind progress|stall|recovery|handoff
+  --observed-at ISO
+  --reason TEXT (required for stall; concise structured reason, not chat)
+  --next-owner OWNER (required for handoff)
+  --linear-needs-human present|absent
+  --stale-after-seconds N (default 900)
+  --max-signals N (default 100)
 `;
 }
 

--- a/scripts/ai-workflow/model.ts
+++ b/scripts/ai-workflow/model.ts
@@ -1,4 +1,4 @@
-export const STORE_SCHEMA_VERSION = 2;
+export const STORE_SCHEMA_VERSION = 3;
 
 export const MEMBER_ROLES = ['owner', 'admin', 'member', 'guest', 'bot'] as const;
 export type MemberRole = (typeof MEMBER_ROLES)[number];
@@ -17,6 +17,15 @@ export type LinearLifecycleState = (typeof LINEAR_LIFECYCLE_STATES)[number];
 
 export const DELIVERY_OUTCOMES = ['pending', 'applied', 'ignored', 'failed'] as const;
 export type DeliveryOutcome = (typeof DELIVERY_OUTCOMES)[number];
+
+export const ATTENTION_SIGNAL_KINDS = ['progress', 'stall', 'recovery', 'handoff'] as const;
+export type AttentionSignalKind = (typeof ATTENTION_SIGNAL_KINDS)[number];
+
+export const ATTENTION_STATES = ['idle', 'healthy', 'attention', 'recovered'] as const;
+export type AttentionStateName = (typeof ATTENTION_STATES)[number];
+
+export const ATTENTION_DELIVERY_OUTCOMES = ['none', 'pending', 'applied', 'failed'] as const;
+export type AttentionDeliveryOutcome = (typeof ATTENTION_DELIVERY_OUTCOMES)[number];
 
 export interface DesiredMember {
   pubkey: string;
@@ -37,6 +46,40 @@ export interface TeamLifecyclePolicy {
     maxDeliveries: number;
   };
   updatedAt: string;
+}
+
+export interface AttentionPolicy {
+  enabled: boolean;
+  staleAfterSeconds: number;
+  maxSignals: number;
+  updatedAt: string;
+}
+
+export interface AttentionSignal {
+  id: string;
+  kind: AttentionSignalKind;
+  observedAt: string;
+  owner: string;
+  nextOwner: string | null;
+  reason: string | null;
+}
+
+export interface AttentionState {
+  status: AttentionStateName;
+  signals: AttentionSignal[];
+  lastProgressAt: string | null;
+  lastObservedAt: string | null;
+  stallReason: string | null;
+  label: {
+    desired: boolean;
+    observed: boolean | null;
+    deliveryId: string | null;
+    outcome: AttentionDeliveryOutcome;
+    reason: string | null;
+    updatedAt: string | null;
+    attempts: number;
+    lastError: string | null;
+  };
 }
 
 export interface LifecycleDelivery {
@@ -83,7 +126,7 @@ export interface ReconcileRequest {
 }
 
 export interface TaskMapping {
-  schemaVersion: 2;
+  schemaVersion: 3;
   linear: {
     key: string;
     title: string;
@@ -115,11 +158,13 @@ export interface TaskMapping {
     lastError: string | null;
   };
   lifecycle: LifecycleState;
+  attention: AttentionState;
 }
 
 export interface MappingStoreData {
-  schemaVersion: 2;
+  schemaVersion: 3;
   teamPolicies: Record<string, TeamLifecyclePolicy>;
+  attentionPolicies: Record<string, Record<string, AttentionPolicy>>;
   mappings: Record<string, TaskMapping>;
 }
 
@@ -139,7 +184,11 @@ type CreationRequest = ReconcileRequest &
     >
   >;
 
-interface TaskMappingV1 extends Omit<TaskMapping, 'schemaVersion' | 'lifecycle'> {
+interface TaskMappingV2 extends Omit<TaskMapping, 'schemaVersion' | 'attention'> {
+  schemaVersion: 2;
+}
+
+interface TaskMappingV1 extends Omit<TaskMappingV2, 'schemaVersion' | 'lifecycle'> {
   schemaVersion: 1;
 }
 
@@ -151,8 +200,33 @@ export function emptyLifecycleState(): LifecycleState {
   };
 }
 
+export function emptyAttentionState(): AttentionState {
+  return {
+    status: 'idle',
+    signals: [],
+    lastProgressAt: null,
+    lastObservedAt: null,
+    stallReason: null,
+    label: {
+      desired: false,
+      observed: null,
+      deliveryId: null,
+      outcome: 'none',
+      reason: null,
+      updatedAt: null,
+      attempts: 0,
+      lastError: null,
+    },
+  };
+}
+
 export function emptyStore(): MappingStoreData {
-  return { schemaVersion: STORE_SCHEMA_VERSION, teamPolicies: {}, mappings: {} };
+  return {
+    schemaVersion: STORE_SCHEMA_VERSION,
+    teamPolicies: {},
+    attentionPolicies: {},
+    mappings: {},
+  };
 }
 
 export function migrateStore(value: unknown) {
@@ -163,19 +237,36 @@ export function migrateStore(value: unknown) {
     assertValidStore(value);
     return value;
   }
-  if (value.schemaVersion !== 1 || !isRecord(value.mappings)) {
+  if ((value.schemaVersion !== 1 && value.schemaVersion !== 2) || !isRecord(value.mappings)) {
     throw new Error(`Unsupported mapping store schema; expected ${STORE_SCHEMA_VERSION}`);
   }
 
   const migrated = emptyStore();
+  if (value.schemaVersion === 2) {
+    if (!isRecord(value.teamPolicies)) {
+      throw new Error('Schema-v2 mapping store must contain teamPolicies');
+    }
+    for (const [teamId, policy] of Object.entries(value.teamPolicies)) {
+      if (teamId === '' || !isTeamLifecyclePolicy(policy)) {
+        throw new Error(`Invalid team lifecycle policy: ${teamId}`);
+      }
+      migrated.teamPolicies[teamId] = policy;
+    }
+  }
   for (const [key, candidate] of Object.entries(value.mappings)) {
-    if (!isTaskMappingV1(candidate) || candidate.linear.key !== key) {
+    const base =
+      value.schemaVersion === 1 && isTaskMappingV1(candidate)
+        ? { ...candidate, lifecycle: emptyLifecycleState() }
+        : value.schemaVersion === 2 && isTaskMappingV2(candidate)
+          ? candidate
+          : undefined;
+    if (base === undefined || base.linear.key !== key) {
       throw new Error(`Invalid mapping record: ${key}`);
     }
     migrated.mappings[key] = {
-      ...candidate,
+      ...base,
       schemaVersion: STORE_SCHEMA_VERSION,
-      lifecycle: emptyLifecycleState(),
+      attention: emptyAttentionState(),
     };
   }
   assertValidStore(migrated);
@@ -245,6 +336,7 @@ export function createMapping(
       lastError: null,
     },
     lifecycle: emptyLifecycleState(),
+    attention: emptyAttentionState(),
   } satisfies TaskMapping;
 }
 
@@ -318,9 +410,22 @@ export function assertValidStore(value: unknown): asserts value is MappingStoreD
   if (!isRecord(value.teamPolicies) || !isRecord(value.mappings)) {
     throw new Error('Mapping store must contain teamPolicies and mappings objects');
   }
+  if (!isRecord(value.attentionPolicies)) {
+    throw new Error('Mapping store must contain an attentionPolicies object');
+  }
   for (const [teamId, policy] of Object.entries(value.teamPolicies)) {
     if (teamId === '' || !isTeamLifecyclePolicy(policy)) {
       throw new Error(`Invalid team lifecycle policy: ${teamId}`);
+    }
+  }
+  for (const [teamId, repositoryPolicies] of Object.entries(value.attentionPolicies)) {
+    if (teamId === '' || !isRecord(repositoryPolicies)) {
+      throw new Error(`Invalid attention policy team: ${teamId}`);
+    }
+    for (const [repository, policy] of Object.entries(repositoryPolicies)) {
+      if (repository === '' || !isAttentionPolicy(policy)) {
+        throw new Error(`Invalid attention policy: ${teamId}/${repository}`);
+      }
     }
   }
 
@@ -343,9 +448,14 @@ export function assertValidStore(value: unknown): asserts value is MappingStoreD
   }
 }
 
-export function renderCanvas(mapping: TaskMapping, teamPolicy?: TeamLifecyclePolicy) {
+export function renderCanvas(
+  mapping: TaskMapping,
+  teamPolicy?: TeamLifecyclePolicy,
+  attentionPolicy?: AttentionPolicy,
+) {
   const statusIds = mapping.linear.statusIds;
   const lastDelivery = mapping.lifecycle.deliveries.at(-1);
+  const lastSignal = mapping.attention.signals.at(-1);
   return `# ${mapping.linear.key} - ${mapping.linear.title}
 
 ## Task truth
@@ -372,20 +482,30 @@ export function renderCanvas(mapping: TaskMapping, teamPolicy?: TeamLifecyclePol
 - Last delivery: ${lastDelivery === undefined ? 'none' : `\`${lastDelivery.id}\` (${lastDelivery.outcome}: ${lastDelivery.reason})`}
 - Alert: \`${mapping.lifecycle.alert.state}\`${mapping.lifecycle.alert.reason === null ? '' : ` - ${mapping.lifecycle.alert.reason}`}
 
+## Structured attention and heartbeat
+
+- Attention policy: \`${attentionPolicy?.enabled === true ? 'enabled' : 'disabled'}\`${attentionPolicy === undefined ? '' : `; stale after ${attentionPolicy.staleAfterSeconds}s`}
+- Heartbeat state: \`${mapping.attention.status}\`
+- Last progress: ${mapping.attention.lastProgressAt ?? 'none'}
+- Last signal: ${lastSignal === undefined ? 'none' : `\`${lastSignal.id}\` (${lastSignal.kind})`}
+- Stall reason: ${mapping.attention.stallReason ?? 'none'}
+- Linear \`needs-human\`: desired \`${mapping.attention.label.desired}\`; observed \`${mapping.attention.label.observed ?? 'unknown'}\`; delivery \`${mapping.attention.label.outcome}\`
+
 ## Recovery check
 
 1. Read this canvas and the mapping store.
 2. Verify \`git worktree list\` contains the recorded worktree and branch.
 3. Verify \`HEAD\`, \`git status\`, and the current Linear lifecycle state before editing.
-4. Reconcile lifecycle state from Linear truth before retrying a pending or failed delivery.
-5. Only the recorded owner writes in the worktree; handoffs transfer these same pointers.
+4. Reconcile lifecycle and \`needs-human\` truth before retrying a pending or failed delivery.
+5. Verify the latest heartbeat is healthy before writing; handoffs transfer the same pointers and owner.
 
 ## Guardrails
 
 - Never synchronize chat into Linear or GitHub.
 - Reconcile creates or updates structured pointers; it never deletes.
 - Lifecycle projection may move In Progress to In Review only; native merge-to-Done remains primary.
-- Archive the channel only after completion is verified.
+- Attention projection changes only the \`needs-human\` label and canvas, never lifecycle.
+- Archive only after Linear is Done and lifecycle/attention delivery state is clear.
 - Never remove the worktree or branch without clean-status and unique-commit checks.
 `;
 }
@@ -403,8 +523,14 @@ function isTaskMapping(value: unknown): value is TaskMapping {
   return (
     isBaseTaskMapping(value, STORE_SCHEMA_VERSION) &&
     'lifecycle' in value &&
-    isLifecycleState(value.lifecycle)
+    isLifecycleState(value.lifecycle) &&
+    'attention' in value &&
+    isAttentionState(value.attention)
   );
+}
+
+function isTaskMappingV2(value: unknown): value is TaskMappingV2 {
+  return isBaseTaskMapping(value, 2) && 'lifecycle' in value && isLifecycleState(value.lifecycle);
 }
 
 function isTaskMappingV1(value: unknown): value is TaskMappingV1 {
@@ -413,8 +539,8 @@ function isTaskMappingV1(value: unknown): value is TaskMappingV1 {
 
 function isBaseTaskMapping(
   value: unknown,
-  schemaVersion: 1 | 2,
-): value is TaskMapping | TaskMappingV1 {
+  schemaVersion: 1 | 2 | 3,
+): value is TaskMapping | TaskMappingV1 | TaskMappingV2 {
   if (!isRecord(value) || value.schemaVersion !== schemaVersion) {
     return false;
   }
@@ -502,6 +628,54 @@ function isTeamLifecyclePolicy(value: unknown): value is TeamLifecyclePolicy {
     isPositiveInteger(value.inReview.staleAfterSeconds) &&
     isPositiveInteger(value.inReview.maxDeliveries) &&
     typeof value.updatedAt === 'string'
+  );
+}
+
+function isAttentionPolicy(value: unknown): value is AttentionPolicy {
+  return (
+    isRecord(value) &&
+    typeof value.enabled === 'boolean' &&
+    isPositiveInteger(value.staleAfterSeconds) &&
+    isPositiveInteger(value.maxSignals) &&
+    typeof value.updatedAt === 'string'
+  );
+}
+
+function isAttentionState(value: unknown): value is AttentionState {
+  return (
+    isRecord(value) &&
+    typeof value.status === 'string' &&
+    ATTENTION_STATES.includes(value.status as AttentionStateName) &&
+    Array.isArray(value.signals) &&
+    value.signals.every(isAttentionSignal) &&
+    (value.lastProgressAt === null || typeof value.lastProgressAt === 'string') &&
+    (value.lastObservedAt === null || typeof value.lastObservedAt === 'string') &&
+    (value.stallReason === null || typeof value.stallReason === 'string') &&
+    isRecord(value.label) &&
+    typeof value.label.desired === 'boolean' &&
+    (value.label.observed === null || typeof value.label.observed === 'boolean') &&
+    (value.label.deliveryId === null || typeof value.label.deliveryId === 'string') &&
+    typeof value.label.outcome === 'string' &&
+    ATTENTION_DELIVERY_OUTCOMES.includes(value.label.outcome as AttentionDeliveryOutcome) &&
+    (value.label.reason === null || typeof value.label.reason === 'string') &&
+    (value.label.updatedAt === null || typeof value.label.updatedAt === 'string') &&
+    typeof value.label.attempts === 'number' &&
+    Number.isSafeInteger(value.label.attempts) &&
+    value.label.attempts >= 0 &&
+    (value.label.lastError === null || typeof value.label.lastError === 'string')
+  );
+}
+
+function isAttentionSignal(value: unknown): value is AttentionSignal {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.kind === 'string' &&
+    ATTENTION_SIGNAL_KINDS.includes(value.kind as AttentionSignalKind) &&
+    typeof value.observedAt === 'string' &&
+    typeof value.owner === 'string' &&
+    (value.nextOwner === null || typeof value.nextOwner === 'string') &&
+    (value.reason === null || typeof value.reason === 'string')
   );
 }
 

--- a/scripts/ai-workflow/reconcile.test.ts
+++ b/scripts/ai-workflow/reconcile.test.ts
@@ -139,14 +139,32 @@ describe('WorkflowReconciler', () => {
     expect(buzz.archiveCount).toBe(0);
   });
 
+  it('refuses archive until Linear is Done and structured attention is clear', async () => {
+    const { reconciler, store } = await harness();
+    await reconciler.reconcile(seed());
+
+    await expect(reconciler.archive('JAC-6', true, 'in-review')).rejects.toThrow(
+      'requires current Linear state',
+    );
+
+    const data = await store.read();
+    data.mappings['JAC-6'].attention.status = 'attention';
+    data.mappings['JAC-6'].attention.stallReason = 'heartbeat-stale';
+    await store.write(data);
+
+    await expect(reconciler.archive('JAC-6', true, 'done')).rejects.toThrow(
+      'structured attention is not clear',
+    );
+  });
+
   it('archives once and preserves the archived mapping on later reconcile', async () => {
     const { reconciler, buzz } = await harness();
     await reconciler.reconcile(seed());
-    const first = await reconciler.archive('JAC-6', true);
+    const first = await reconciler.archive('JAC-6', true, 'done');
     const second = await reconciler.archive('JAC-6', true);
     const recovered = await reconciler.reconcile({ key: 'JAC-6' });
 
-    expect(first.actions).toEqual(['archived-channel']);
+    expect(first.actions).toEqual(['updated-final-canvas', 'archived-channel']);
     expect(second.actions).toEqual(['already-archived']);
     expect(recovered.actions).toEqual(['preserved-archived-channel']);
     expect(buzz.archiveCount).toBe(1);
@@ -175,14 +193,48 @@ describe('JsonMappingStore', () => {
 
     const migrated = await new JsonMappingStore(path).read();
 
-    expect(migrated.schemaVersion).toBe(2);
+    expect(migrated.schemaVersion).toBe(3);
     expect(migrated.teamPolicies).toEqual({});
+    expect(migrated.attentionPolicies).toEqual({});
     expect(migrated.mappings['JAC-6'].execution).toMatchObject({
       desiredState: 'archived',
       observedState: 'archived',
       archivedAt: '2026-08-14T04:00:00.000Z',
     });
     expect(migrated.mappings['JAC-6'].lifecycle.deliveries).toEqual([]);
+    expect(migrated.mappings['JAC-6'].attention.status).toBe('idle');
+  });
+
+  it('migrates schema-v2 lifecycle state without losing archived mappings', async () => {
+    const directory = await temporaryDirectory();
+    const path = join(directory, 'mappings.json');
+    const mapping = createMapping(seed(), 'channel-id', '2026-08-14T03:00:00.000Z');
+    mapping.execution.desiredState = 'archived';
+    mapping.execution.observedState = 'archived';
+    mapping.execution.archivedAt = '2026-08-14T04:00:00.000Z';
+    const base = structuredClone(mapping) as unknown as Record<string, unknown>;
+    delete base.attention;
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 2,
+        teamPolicies: {
+          'team-id': {
+            inReview: { enabled: true, staleAfterSeconds: 300, maxDeliveries: 100 },
+            updatedAt: '2026-08-14T03:30:00.000Z',
+          },
+        },
+        mappings: { 'JAC-6': { ...base, schemaVersion: 2 } },
+      }),
+      'utf8',
+    );
+
+    const migrated = await new JsonMappingStore(path).read();
+
+    expect(migrated.schemaVersion).toBe(3);
+    expect(migrated.teamPolicies['team-id'].inReview.enabled).toBe(true);
+    expect(migrated.mappings['JAC-6'].execution.observedState).toBe('archived');
+    expect(migrated.mappings['JAC-6'].attention.status).toBe('idle');
   });
 
   it('rejects a duplicate Buzz channel invariant', async () => {

--- a/scripts/ai-workflow/reconcile.ts
+++ b/scripts/ai-workflow/reconcile.ts
@@ -6,6 +6,7 @@ import {
   mergeDesiredMembers,
   normalizeIssueKey,
   renderCanvas,
+  type LinearLifecycleState,
   type ReconcileRequest,
   type TaskMapping,
 } from './model.ts';
@@ -60,7 +61,11 @@ export class WorkflowReconciler {
         mapping.execution.observedState = 'active';
         mapping.execution.lastError = null;
         mapping.execution.updatedAt = this.now().toISOString();
-        const desiredCanvas = renderCanvas(mapping, data.teamPolicies[mapping.linear.teamId]);
+        const desiredCanvas = renderCanvas(
+          mapping,
+          data.teamPolicies[mapping.linear.teamId],
+          data.attentionPolicies[mapping.linear.teamId]?.[mapping.git.repository],
+        );
         const currentCanvas = await this.buzz.getCanvas(mapping.buzz.channelId);
         if (currentCanvas === desiredCanvas) {
           actions.push('canvas-current');
@@ -90,7 +95,7 @@ export class WorkflowReconciler {
     return mapping;
   }
 
-  async archive(issueKey: string, confirmed: boolean) {
+  async archive(issueKey: string, confirmed: boolean, linearState?: LinearLifecycleState) {
     if (!confirmed) {
       throw new Error('Archive requires --confirm');
     }
@@ -104,19 +109,35 @@ export class WorkflowReconciler {
       if (mapping.execution.desiredState === 'archived') {
         return { mapping, actions: ['already-archived'] } satisfies ReconcileResult;
       }
+      assertArchiveReady(mapping, linearState);
 
       try {
-        await this.buzz.archiveChannel(mapping.buzz.channelId);
         const now = this.now().toISOString();
         mapping.execution.desiredState = 'archived';
         mapping.execution.observedState = 'archived';
         mapping.execution.archivedAt = now;
         mapping.execution.updatedAt = now;
         mapping.execution.lastError = null;
+        const actions: string[] = [];
+        const finalCanvas = renderCanvas(
+          mapping,
+          data.teamPolicies[mapping.linear.teamId],
+          data.attentionPolicies[mapping.linear.teamId]?.[mapping.git.repository],
+        );
+        if ((await this.buzz.getCanvas(mapping.buzz.channelId)) === finalCanvas) {
+          actions.push('final-canvas-current');
+        } else {
+          await this.buzz.setCanvas(mapping.buzz.channelId, finalCanvas);
+          actions.push('updated-final-canvas');
+        }
+        await this.buzz.archiveChannel(mapping.buzz.channelId);
+        actions.push('archived-channel');
         await this.store.write(data);
-        return { mapping, actions: ['archived-channel'] } satisfies ReconcileResult;
+        return { mapping, actions } satisfies ReconcileResult;
       } catch (error) {
+        mapping.execution.desiredState = 'active';
         mapping.execution.observedState = 'error';
+        mapping.execution.archivedAt = null;
         mapping.execution.lastError = errorMessage(error);
         mapping.execution.updatedAt = this.now().toISOString();
         await this.store.write(data);
@@ -166,6 +187,28 @@ export class WorkflowReconciler {
       await this.buzz.addMember(mapping.buzz.channelId, member);
       actions.push(`set-member:${member.pubkey}:${member.role}`);
     }
+  }
+}
+
+function assertArchiveReady(mapping: TaskMapping, linearState: LinearLifecycleState | undefined) {
+  if (linearState !== 'done') {
+    throw new Error('Archive requires current Linear state --linear-state done');
+  }
+  if (
+    mapping.lifecycle.alert.state === 'attention' ||
+    mapping.lifecycle.deliveries.some(x => x.outcome === 'pending' || x.outcome === 'failed')
+  ) {
+    throw new Error('Archive refused while lifecycle delivery state needs attention');
+  }
+  const label = mapping.attention.label;
+  if (
+    mapping.attention.status === 'attention' ||
+    label.desired ||
+    label.observed === true ||
+    label.outcome === 'pending' ||
+    label.outcome === 'failed'
+  ) {
+    throw new Error('Archive refused while structured attention is not clear');
   }
 }
 


### PR DESCRIPTION
## What changed

- migrate the external mapping store to schema v3 while preserving schema-v1/v2 lifecycle and archive state
- add repository-scoped, opt-in structured heartbeat policy
- record replay-safe progress, stall, recovery, and same-pointer ownership handoff signals
- project only the Linear `needs-human` label and Buzz canvas, with explicit acknowledgment and lost-ack reconciliation
- gate channel archival on Linear Done plus clear lifecycle and attention delivery state
- write a final canvas before archive; retain the existing no-delete behavior

## Why

Phase 3 closed the In Review lifecycle gap but had no structured way to distinguish healthy execution, stalled work, recovered work, or ownership transfer. It also allowed explicit archive without supplying current Linear truth. This phase adds the smallest manual-polling contract needed for those signals without synchronizing chat or adding an always-on service.

## Impact

Repository tooling only under `scripts/ai-workflow/`; product runtime is untouched. Native GitHub/Linear attachment, label synchronization, issue close, and merge-to-Done remain authoritative.

## Live proof so far

- schema v2 migrated to v3; archived JAC-6/JAC-7 mappings were preserved
- exact heartbeat replay emitted no duplicate signal or canvas write
- one stale poll emitted one `needs-human` action; immediate replay emitted none
- recovery emitted one label-clear action
- a Codex Sol → Codex Terra → Codex Sol handoff retained the same branch/worktree
- archive was refused while Linear remained In Progress

## Validation

- `pnpm run compile`
- `pnpm run test` — 11 test files, 106 tests
- validated at `3862b79d7ee492a2463e674e360d343658812b6f`

Linear: https://linear.app/jackinaboxdev/issue/JAC-8/phase-4-add-structured-attention-heartbeat-and-safe-archival

Closes #154