### PR TITLE
[JAC-9] Add multi-repo portfolio reconciliation

### DIFF
--- a/scripts/ai-workflow/README.md
+++ b/scripts/ai-workflow/README.md
@@ -1,12 +1,12 @@
 # Linear-Buzz workflow reconciler, lifecycle, and attention projector
 
-Manual-trigger bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after verified completion. Its opt-in lifecycle projector handles only the measured In Progress to In Review gap. Its opt-in attention projector tracks heartbeat, stalls, recovery, and ownership handoff without storing chat. Native GitHub-to-Linear merge-to-Done remains primary.
+Manual-trigger bridge for one Linear issue to one Buzz task channel. It stores structured pointers, creates or recovers one channel, keeps the channel canvas current, and archives only after verified completion. Its opt-in lifecycle projector handles only the measured In Progress to In Review gap. Its opt-in attention projector tracks heartbeat, stalls, recovery, and ownership handoff without storing chat. Its portfolio reconciler links allowlisted repositories and records read-only drift evidence without repairing or deleting anything. Native GitHub-to-Linear merge-to-Done remains primary.
 
 The bridge does not call Linear directly. The initiating agent reads Linear through its authenticated connector and supplies the issue snapshot on the first reconcile. Later reconciles need only the issue key and mapping store. This keeps OAuth credentials out of the repository and mapping data.
 
 ## Runtime state
 
-Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 3, atomic replacement, and a local lock file. Existing schema-v1 and schema-v2 mappings migrate on the next write without losing lifecycle or archive state.
+Keep the mapping store outside the repository. Set `AI_WORKFLOW_MAPPING_STORE` or pass `--store` on every invocation. The store uses schema version 4, atomic replacement, and a local lock file. Existing schema-v1 through schema-v3 mappings migrate on the next write without losing lifecycle, attention, or archive state.
 
 ```powershell
 $env:AI_WORKFLOW_MAPPING_STORE = 'C:\Users\cyrus\.buzz\.state\ai-workflow\mappings.json'
@@ -113,6 +113,37 @@ pnpm workflow attention-ack JAC-8 --store $env:AI_WORKFLOW_MAPPING_STORE `
 
 Attention changes only Linear's `needs-human` label and the Buzz canvas. It never changes lifecycle status. The history is bounded, carries no credentials or chat, and records only stable signal identity, owner, time, handoff target, and concise reason.
 
+## Multi-repo portfolio reconciliation
+
+Register repositories with the provider's immutable repository ID. Metadata changes are refused unless an operator has reviewed the move or rename and supplies `--replace-metadata`. Paths are allowlisted data only; the tool never uses them to move or delete files.
+
+```powershell
+pnpm workflow repository-register JAC-9 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --provider github --provider-id '<github-node-id>' `
+  --repository-owner jackinabox86 --repository-name refined-prun `
+  --remote-url 'https://github.com/jackinabox86/refined-prun' `
+  --default-branch main `
+  --local-checkout 'C:\Users\cyrus\.buzz\REPOS\refined-prun' `
+  --worktree-root 'C:\Users\cyrus\.buzz\REPOS\worktrees' `
+  --archive-policy retain
+
+pnpm workflow portfolio-link JAC-9 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --repository-id 'github:<github-node-id>' --role primary `
+  --artifact-branch 'JAC-9-multi-repo-portfolio' `
+  --artifact-worktree 'C:\Users\cyrus\.buzz\REPOS\worktrees\JAC-9-multi-repo-portfolio'
+```
+
+A task has at most one primary repository pointer and may link any number of related read-only repositories. The primary link must exactly retain the mapping's branch and worktree. Related links may carry a branch, worktree, or pull-request pointer when the task actually owns one.
+
+The authenticated operator gathers current Linear, Buzz, GitHub, and local Git truth into an observation JSON file outside the repository, then runs:
+
+```powershell
+pnpm workflow portfolio-audit JAC-9 --store $env:AI_WORKFLOW_MAPPING_STORE `
+  --observation-file 'C:\Users\cyrus\.buzz\.scratch\JAC-9-observation.json'
+```
+
+The observation includes a replay-stable `eventId`, `observedAt`, current Linear and Buzz state, and one record per linked repository: immutable provider ID, owner/name, remote, default branch, local checkout presence, branches, worktrees, and pull-request URLs. Exact replay is a no-op. Missing or contradictory artifacts become one structured alert in the mapping and canvas. A later clean observation clears it. The audit ledger is bounded to 100 records and stores no credentials, chat, prompts, or code.
+
 ## Recovery and archive
 
 ```powershell
@@ -122,7 +153,7 @@ pnpm workflow archive JAC-6 --store $env:AI_WORKFLOW_MAPPING_STORE `
   --confirm --linear-state done
 ```
 
-Archive is idempotent and completion-gated. It refuses an active mapping unless Linear is Done, lifecycle deliveries are resolved, and structured attention plus `needs-human` delivery state are clear. It writes a final canvas before archiving. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no delete operation.
+Archive is idempotent and completion-gated. It refuses an active mapping unless Linear is Done, lifecycle deliveries are resolved, structured attention plus `needs-human` delivery state are clear, and every linked repository has a current clean audit. It writes a final canvas before archiving. A later reconcile preserves the archived mapping and never creates a replacement channel. The tool has no repair or delete operation.
 
 ## Validation
 

--- a/scripts/ai-workflow/cli.ts
+++ b/scripts/ai-workflow/cli.ts
@@ -5,6 +5,9 @@ import { LifecycleProjector } from './lifecycle.ts';
 import {
   LINEAR_LIFECYCLE_STATES,
   ATTENTION_SIGNAL_KINDS,
+  REPOSITORY_ARCHIVE_POLICIES,
+  REPOSITORY_LINK_ROLES,
+  REPOSITORY_PROVIDERS,
   REVIEW_EVENT_KINDS,
   parseMemberRole,
   normalizePubkey,
@@ -13,12 +16,25 @@ import {
   type LinearLifecycleState,
   type LinearStatusIds,
   type ReconcileRequest,
+  type RepositoryArchivePolicy,
+  type RepositoryLinkRole,
+  type RepositoryProvider,
   type ReviewEventKind,
+  type TaskMapping,
 } from './model.ts';
+import { PortfolioReconciler } from './portfolio.ts';
 import { WorkflowReconciler } from './reconcile.ts';
 import { JsonMappingStore } from './store.ts';
 
-const SWITCHES = new Set(['adopt-existing', 'confirm', 'disable', 'enable', 'help']);
+const SWITCHES = new Set([
+  'adopt-existing',
+  'confirm',
+  'disable',
+  'enable',
+  'help',
+  'replace-artifacts',
+  'replace-metadata',
+]);
 
 async function main() {
   const rawArguments = process.argv.slice(2);
@@ -48,6 +64,7 @@ async function main() {
   const reconciler = new WorkflowReconciler(store, buzz);
   const lifecycle = new LifecycleProjector(store);
   const attention = new AttentionProjector(store);
+  const portfolio = new PortfolioReconciler(store);
 
   if (parsed.command === 'inspect') {
     printJson(await reconciler.inspect(issueKey));
@@ -61,6 +78,41 @@ async function main() {
         optionalLinearState(option(parsed, 'linear-state')),
       ),
     );
+    return;
+  }
+  if (parsed.command === 'repository-register') {
+    const result = await portfolio.register({
+      issueKey,
+      provider: repositoryProvider(requiredOption(parsed, 'provider')),
+      providerRepositoryId: requiredOption(parsed, 'provider-id'),
+      owner: requiredOption(parsed, 'repository-owner'),
+      name: requiredOption(parsed, 'repository-name'),
+      remoteUrl: requiredOption(parsed, 'remote-url'),
+      defaultBranch: requiredOption(parsed, 'default-branch'),
+      localCheckout: requiredOption(parsed, 'local-checkout'),
+      worktreeRoot: requiredOption(parsed, 'worktree-root'),
+      archivePolicy: repositoryArchivePolicy(option(parsed, 'archive-policy') ?? 'retain'),
+      replaceMetadata: parsed.switches.has('replace-metadata'),
+    });
+    printJson(await withCanvas(result, reconciler, issueKey));
+    return;
+  }
+  if (parsed.command === 'portfolio-link') {
+    const result = await portfolio.link({
+      issueKey,
+      repositoryId: requiredOption(parsed, 'repository-id'),
+      role: repositoryLinkRole(requiredOption(parsed, 'role')),
+      branch: option(parsed, 'artifact-branch'),
+      worktree: option(parsed, 'artifact-worktree'),
+      pullRequestUrl: option(parsed, 'pull-request-url'),
+      replaceArtifacts: parsed.switches.has('replace-artifacts'),
+    });
+    printJson(await withCanvas(result, reconciler, issueKey));
+    return;
+  }
+  if (parsed.command === 'portfolio-audit') {
+    const result = await portfolio.auditFile(issueKey, requiredOption(parsed, 'observation-file'));
+    printJson(await withCanvas(result, reconciler, issueKey));
     return;
   }
   if (parsed.command === 'attention-configure') {
@@ -354,13 +406,34 @@ function printJson(value: unknown) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
-async function withCanvas(
-  result: Awaited<ReturnType<AttentionProjector['observe']>>,
+async function withCanvas<T extends { mapping: TaskMapping }>(
+  result: T,
   reconciler: WorkflowReconciler,
   issueKey: string,
 ) {
   const canvas = await reconciler.reconcile({ key: issueKey });
   return { ...result, mapping: canvas.mapping, canvasActions: canvas.actions };
+}
+
+function repositoryProvider(value: string): RepositoryProvider {
+  if (!REPOSITORY_PROVIDERS.includes(value as RepositoryProvider)) {
+    throw new Error(`Invalid --provider: ${value}`);
+  }
+  return value as RepositoryProvider;
+}
+
+function repositoryLinkRole(value: string): RepositoryLinkRole {
+  if (!REPOSITORY_LINK_ROLES.includes(value as RepositoryLinkRole)) {
+    throw new Error(`Invalid --role: ${value}`);
+  }
+  return value as RepositoryLinkRole;
+}
+
+function repositoryArchivePolicy(value: string): RepositoryArchivePolicy {
+  if (!REPOSITORY_ARCHIVE_POLICIES.includes(value as RepositoryArchivePolicy)) {
+    throw new Error(`Invalid --archive-policy: ${value}`);
+  }
+  return value as RepositoryArchivePolicy;
 }
 
 function toKebabCase(value: string) {
@@ -378,6 +451,9 @@ Usage:
   pnpm workflow heartbeat ISSUE-ID --store PATH --event-id ID --kind KIND --owner OWNER
   pnpm workflow attention-ack ISSUE-ID --store PATH --delivery-id ID --result applied|failed
   pnpm workflow attention-reconcile ISSUE-ID --store PATH --linear-state STATE --linear-needs-human present|absent
+  pnpm workflow repository-register ISSUE-ID --store PATH --provider github --provider-id ID [metadata options]
+  pnpm workflow portfolio-link ISSUE-ID --store PATH --repository-id ID --role primary|related
+  pnpm workflow portfolio-audit ISSUE-ID --store PATH --observation-file ABSOLUTE_PATH
   pnpm workflow lifecycle-configure ISSUE-ID --store PATH --enable|--disable
   pnpm workflow lifecycle-observe ISSUE-ID --store PATH --event-id ID --event-kind KIND --source URL --linear-state STATE
   pnpm workflow lifecycle-ack ISSUE-ID --store PATH --event-id ID --result applied|failed [--error TEXT]
@@ -412,6 +488,15 @@ Attention options:
   --linear-needs-human present|absent
   --stale-after-seconds N (default 900)
   --max-signals N (default 100)
+
+Repository and portfolio options:
+  --provider github --provider-id IMMUTABLE_PROVIDER_ID
+  --repository-owner OWNER --repository-name NAME --remote-url URL
+  --default-branch NAME --local-checkout ABSOLUTE_PATH --worktree-root ABSOLUTE_PATH
+  --archive-policy retain [--replace-metadata]
+  --repository-id PROVIDER:ID --role primary|related
+  --artifact-branch NAME --artifact-worktree ABSOLUTE_PATH --pull-request-url URL
+  --replace-artifacts
 `;
 }
 

--- a/scripts/ai-workflow/model.ts
+++ b/scripts/ai-workflow/model.ts
@@ -1,4 +1,4 @@
-export const STORE_SCHEMA_VERSION = 3;
+export const STORE_SCHEMA_VERSION = 4;
 
 export const MEMBER_ROLES = ['owner', 'admin', 'member', 'guest', 'bot'] as const;
 export type MemberRole = (typeof MEMBER_ROLES)[number];
@@ -26,6 +26,15 @@ export type AttentionStateName = (typeof ATTENTION_STATES)[number];
 
 export const ATTENTION_DELIVERY_OUTCOMES = ['none', 'pending', 'applied', 'failed'] as const;
 export type AttentionDeliveryOutcome = (typeof ATTENTION_DELIVERY_OUTCOMES)[number];
+
+export const REPOSITORY_PROVIDERS = ['github'] as const;
+export type RepositoryProvider = (typeof REPOSITORY_PROVIDERS)[number];
+
+export const REPOSITORY_LINK_ROLES = ['primary', 'related'] as const;
+export type RepositoryLinkRole = (typeof REPOSITORY_LINK_ROLES)[number];
+
+export const REPOSITORY_ARCHIVE_POLICIES = ['retain'] as const;
+export type RepositoryArchivePolicy = (typeof REPOSITORY_ARCHIVE_POLICIES)[number];
 
 export interface DesiredMember {
   pubkey: string;
@@ -106,6 +115,55 @@ export interface LifecycleState {
   };
 }
 
+export interface RepositoryRegistration {
+  id: string;
+  provider: RepositoryProvider;
+  providerRepositoryId: string;
+  owner: string;
+  name: string;
+  remoteUrl: string;
+  defaultBranch: string;
+  localCheckout: string;
+  worktreeRoot: string;
+  archivePolicy: RepositoryArchivePolicy;
+  updatedAt: string;
+}
+
+export interface PortfolioRepositoryLink {
+  repositoryId: string;
+  role: RepositoryLinkRole;
+  branch: string | null;
+  worktree: string | null;
+  pullRequestUrl: string | null;
+}
+
+export interface PortfolioFinding {
+  code: string;
+  repositoryId: string | null;
+  expected: string | null;
+  observed: string | null;
+}
+
+export interface PortfolioAuditRecord {
+  eventId: string;
+  observationHash: string;
+  observedAt: string;
+  outcome: 'clear' | 'attention';
+  findings: PortfolioFinding[];
+}
+
+export interface PortfolioState {
+  repositories: PortfolioRepositoryLink[];
+  audits: PortfolioAuditRecord[];
+  alert: {
+    state: 'clear' | 'attention';
+    reason: string | null;
+    since: string | null;
+    eventId: string | null;
+    findings: PortfolioFinding[];
+  };
+}
+
 export interface ReconcileRequest {
   key: string;
   title?: string;
@@ -126,7 +184,7 @@ export interface ReconcileRequest {
 }
 
 export interface TaskMapping {
-  schemaVersion: 3;
+  schemaVersion: 4;
   linear: {
     key: string;
     title: string;
@@ -159,12 +217,14 @@ export interface TaskMapping {
   };
   lifecycle: LifecycleState;
   attention: AttentionState;
+  portfolio: PortfolioState;
 }
 
 export interface MappingStoreData {
-  schemaVersion: 3;
+  schemaVersion: 4;
   teamPolicies: Record<string, TeamLifecyclePolicy>;
   attentionPolicies: Record<string, Record<string, AttentionPolicy>>;
+  repositories: Record<string, RepositoryRegistration>;
   mappings: Record<string, TaskMapping>;
 }
 
@@ -184,7 +244,11 @@ type CreationRequest = ReconcileRequest &
     >
   >;
 
-interface TaskMappingV2 extends Omit<TaskMapping, 'schemaVersion' | 'attention'> {
+interface TaskMappingV3 extends Omit<TaskMapping, 'schemaVersion' | 'portfolio'> {
+  schemaVersion: 3;
+}
+
+interface TaskMappingV2 extends Omit<TaskMappingV3, 'schemaVersion' | 'attention'> {
   schemaVersion: 2;
 }
 
@@ -220,11 +284,20 @@ export function emptyAttentionState(): AttentionState {
   };
 }
 
+export function emptyPortfolioState(): PortfolioState {
+  return {
+    repositories: [],
+    audits: [],
+    alert: { state: 'clear', reason: null, since: null, eventId: null, findings: [] },
+  };
+}
+
 export function emptyStore(): MappingStoreData {
   return {
     schemaVersion: STORE_SCHEMA_VERSION,
     teamPolicies: {},
     attentionPolicies: {},
+    repositories: {},
     mappings: {},
   };
 }
@@ -237,12 +310,15 @@ export function migrateStore(value: unknown) {
     assertValidStore(value);
     return value;
   }
-  if ((value.schemaVersion !== 1 && value.schemaVersion !== 2) || !isRecord(value.mappings)) {
+  if (
+    (value.schemaVersion !== 1 && value.schemaVersion !== 2 && value.schemaVersion !== 3) ||
+    !isRecord(value.mappings)
+  ) {
     throw new Error(`Unsupported mapping store schema; expected ${STORE_SCHEMA_VERSION}`);
   }
 
   const migrated = emptyStore();
-  if (value.schemaVersion === 2) {
+  if (value.schemaVersion === 2 || value.schemaVersion === 3) {
     if (!isRecord(value.teamPolicies)) {
       throw new Error('Schema-v2 mapping store must contain teamPolicies');
     }
@@ -253,20 +329,33 @@ export function migrateStore(value: unknown) {
       migrated.teamPolicies[teamId] = policy;
     }
   }
+  if (value.schemaVersion === 3) {
+    if (!isRecord(value.attentionPolicies)) {
+      throw new Error('Schema-v3 mapping store must contain attentionPolicies');
+    }
+    for (const [teamId, repositoryPolicies] of Object.entries(value.attentionPolicies)) {
+      if (teamId === '' || !isRecord(repositoryPolicies)) {
+        throw new Error(`Invalid attention policy team: ${teamId}`);
+      }
+      migrated.attentionPolicies[teamId] = repositoryPolicies as Record<string, AttentionPolicy>;
+    }
+  }
   for (const [key, candidate] of Object.entries(value.mappings)) {
     const base =
       value.schemaVersion === 1 && isTaskMappingV1(candidate)
-        ? { ...candidate, lifecycle: emptyLifecycleState() }
+        ? { ...candidate, lifecycle: emptyLifecycleState(), attention: emptyAttentionState() }
         : value.schemaVersion === 2 && isTaskMappingV2(candidate)
-          ? candidate
-          : undefined;
+          ? { ...candidate, attention: emptyAttentionState() }
+          : value.schemaVersion === 3 && isTaskMappingV3(candidate)
+            ? candidate
+            : undefined;
     if (base === undefined || base.linear.key !== key) {
       throw new Error(`Invalid mapping record: ${key}`);
     }
     migrated.mappings[key] = {
       ...base,
       schemaVersion: STORE_SCHEMA_VERSION,
-      attention: emptyAttentionState(),
+      portfolio: emptyPortfolioState(),
     };
   }
   assertValidStore(migrated);
@@ -337,6 +426,7 @@ export function createMapping(
     },
     lifecycle: emptyLifecycleState(),
     attention: emptyAttentionState(),
+    portfolio: emptyPortfolioState(),
   } satisfies TaskMapping;
 }
 
@@ -413,6 +503,9 @@ export function assertValidStore(value: unknown): asserts value is MappingStoreD
   if (!isRecord(value.attentionPolicies)) {
     throw new Error('Mapping store must contain an attentionPolicies object');
   }
+  if (!isRecord(value.repositories)) {
+    throw new Error('Mapping store must contain a repositories object');
+  }
   for (const [teamId, policy] of Object.entries(value.teamPolicies)) {
     if (teamId === '' || !isTeamLifecyclePolicy(policy)) {
       throw new Error(`Invalid team lifecycle policy: ${teamId}`);
@@ -428,12 +521,26 @@ export function assertValidStore(value: unknown): asserts value is MappingStoreD
       }
     }
   }
+  for (const [id, repository] of Object.entries(value.repositories)) {
+    if (
+      !isRepositoryRegistration(repository) ||
+      repository.id !== id ||
+      repository.id !== `${repository.provider}:${repository.providerRepositoryId}`
+    ) {
+      throw new Error(`Invalid repository registration: ${id}`);
+    }
+  }
 
   const channelIds = new Set<string>();
   const issueIds = new Set<string>();
   for (const [key, candidate] of Object.entries(value.mappings)) {
     if (!isTaskMapping(candidate) || candidate.linear.key !== key) {
       throw new Error(`Invalid mapping record: ${key}`);
+    }
+    for (const link of candidate.portfolio.repositories) {
+      if (value.repositories[link.repositoryId] === undefined) {
+        throw new Error(`Mapping ${key} references unregistered repository: ${link.repositoryId}`);
+      }
     }
     if (channelIds.has(candidate.buzz.channelId)) {
       throw new Error(`Duplicate Buzz channel mapping: ${candidate.buzz.channelId}`);
@@ -452,10 +559,19 @@ export function renderCanvas(
   mapping: TaskMapping,
   teamPolicy?: TeamLifecyclePolicy,
   attentionPolicy?: AttentionPolicy,
+  repositories: Record<string, RepositoryRegistration> = {},
 ) {
   const statusIds = mapping.linear.statusIds;
   const lastDelivery = mapping.lifecycle.deliveries.at(-1);
   const lastSignal = mapping.attention.signals.at(-1);
+  const repositoryLinks = mapping.portfolio.repositories
+    .map(link => {
+      const repository = repositories[link.repositoryId];
+      const label =
+        repository === undefined ? link.repositoryId : `${repository.owner}/${repository.name}`;
+      return `- \`${link.role}\`: ${label} (\`${link.repositoryId}\`)`;
+    })
+    .join('\n');
   return `# ${mapping.linear.key} - ${mapping.linear.title}
 
 ## Task truth
@@ -491,6 +607,14 @@ export function renderCanvas(
 - Stall reason: ${mapping.attention.stallReason ?? 'none'}
 - Linear \`needs-human\`: desired \`${mapping.attention.label.desired}\`; observed \`${mapping.attention.label.observed ?? 'unknown'}\`; delivery \`${mapping.attention.label.outcome}\`
 
+## Multi-repo portfolio
+
+- Registered links: \`${mapping.portfolio.repositories.length}\`
+${repositoryLinks === '' ? '- Repositories: none' : repositoryLinks}
+- Audit ledger entries: \`${mapping.portfolio.audits.length}\`
+- Portfolio alert: \`${mapping.portfolio.alert.state}\`${mapping.portfolio.alert.reason === null ? '' : ` - ${mapping.portfolio.alert.reason}`}
+- Portfolio findings: \`${mapping.portfolio.alert.findings.length}\`
+
 ## Recovery check
 
 1. Read this canvas and the mapping store.
@@ -498,6 +622,7 @@ export function renderCanvas(
 3. Verify \`HEAD\`, \`git status\`, and the current Linear lifecycle state before editing.
 4. Reconcile lifecycle and \`needs-human\` truth before retrying a pending or failed delivery.
 5. Verify the latest heartbeat is healthy before writing; handoffs transfer the same pointers and owner.
+6. Re-run the read-only portfolio audit and resolve every finding before archive.
 
 ## Guardrails
 
@@ -506,6 +631,7 @@ export function renderCanvas(
 - Lifecycle projection may move In Progress to In Review only; native merge-to-Done remains primary.
 - Attention projection changes only the \`needs-human\` label and canvas, never lifecycle.
 - Archive only after Linear is Done and lifecycle/attention delivery state is clear.
+- Portfolio reconciliation emits structured evidence only; it never repairs or deletes.
 - Never remove the worktree or branch without clean-status and unique-commit checks.
 `;
 }
@@ -525,6 +651,18 @@ function isTaskMapping(value: unknown): value is TaskMapping {
     'lifecycle' in value &&
     isLifecycleState(value.lifecycle) &&
     'attention' in value &&
+    isAttentionState(value.attention) &&
+    'portfolio' in value &&
+    isPortfolioState(value.portfolio)
+  );
+}
+
+function isTaskMappingV3(value: unknown): value is TaskMappingV3 {
+  return (
+    isBaseTaskMapping(value, 3) &&
+    'lifecycle' in value &&
+    isLifecycleState(value.lifecycle) &&
+    'attention' in value &&
     isAttentionState(value.attention)
   );
 }
@@ -539,8 +677,8 @@ function isTaskMappingV1(value: unknown): value is TaskMappingV1 {
 
 function isBaseTaskMapping(
   value: unknown,
-  schemaVersion: 1 | 2 | 3,
-): value is TaskMapping | TaskMappingV1 | TaskMappingV2 {
+  schemaVersion: 1 | 2 | 3 | 4,
+): value is TaskMapping | TaskMappingV1 | TaskMappingV2 | TaskMappingV3 {
   if (!isRecord(value) || value.schemaVersion !== schemaVersion) {
     return false;
   }
@@ -583,6 +721,85 @@ function isBaseTaskMapping(
     typeof value.execution.updatedAt === 'string' &&
     (value.execution.archivedAt === null || typeof value.execution.archivedAt === 'string') &&
     (value.execution.lastError === null || typeof value.execution.lastError === 'string')
+  );
+}
+
+function isRepositoryRegistration(value: unknown): value is RepositoryRegistration {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.provider === 'string' &&
+    REPOSITORY_PROVIDERS.includes(value.provider as RepositoryProvider) &&
+    typeof value.providerRepositoryId === 'string' &&
+    value.providerRepositoryId !== '' &&
+    typeof value.owner === 'string' &&
+    value.owner !== '' &&
+    typeof value.name === 'string' &&
+    value.name !== '' &&
+    typeof value.remoteUrl === 'string' &&
+    value.remoteUrl !== '' &&
+    typeof value.defaultBranch === 'string' &&
+    value.defaultBranch !== '' &&
+    typeof value.localCheckout === 'string' &&
+    value.localCheckout !== '' &&
+    typeof value.worktreeRoot === 'string' &&
+    value.worktreeRoot !== '' &&
+    typeof value.archivePolicy === 'string' &&
+    REPOSITORY_ARCHIVE_POLICIES.includes(value.archivePolicy as RepositoryArchivePolicy) &&
+    typeof value.updatedAt === 'string'
+  );
+}
+
+function isPortfolioState(value: unknown): value is PortfolioState {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.repositories) &&
+    value.repositories.every(isPortfolioRepositoryLink) &&
+    new Set(value.repositories.map(x => x.repositoryId)).size === value.repositories.length &&
+    value.repositories.filter(x => x.role === 'primary').length <= 1 &&
+    Array.isArray(value.audits) &&
+    value.audits.every(isPortfolioAuditRecord) &&
+    isRecord(value.alert) &&
+    (value.alert.state === 'clear' || value.alert.state === 'attention') &&
+    (value.alert.reason === null || typeof value.alert.reason === 'string') &&
+    (value.alert.since === null || typeof value.alert.since === 'string') &&
+    (value.alert.eventId === null || typeof value.alert.eventId === 'string') &&
+    Array.isArray(value.alert.findings) &&
+    value.alert.findings.every(isPortfolioFinding)
+  );
+}
+
+function isPortfolioRepositoryLink(value: unknown): value is PortfolioRepositoryLink {
+  return (
+    isRecord(value) &&
+    typeof value.repositoryId === 'string' &&
+    typeof value.role === 'string' &&
+    REPOSITORY_LINK_ROLES.includes(value.role as RepositoryLinkRole) &&
+    (value.branch === null || typeof value.branch === 'string') &&
+    (value.worktree === null || typeof value.worktree === 'string') &&
+    (value.pullRequestUrl === null || typeof value.pullRequestUrl === 'string')
+  );
+}
+
+function isPortfolioAuditRecord(value: unknown): value is PortfolioAuditRecord {
+  return (
+    isRecord(value) &&
+    typeof value.eventId === 'string' &&
+    typeof value.observationHash === 'string' &&
+    typeof value.observedAt === 'string' &&
+    (value.outcome === 'clear' || value.outcome === 'attention') &&
+    Array.isArray(value.findings) &&
+    value.findings.every(isPortfolioFinding)
+  );
+}
+
+function isPortfolioFinding(value: unknown): value is PortfolioFinding {
+  return (
+    isRecord(value) &&
+    typeof value.code === 'string' &&
+    (value.repositoryId === null || typeof value.repositoryId === 'string') &&
+    (value.expected === null || typeof value.expected === 'string') &&
+    (value.observed === null || typeof value.observed === 'string')
   );
 }
 

--- a/scripts/ai-workflow/portfolio.test.ts
+++ b/scripts/ai-workflow/portfolio.test.ts
@@ -11,6 +11,7 @@ const STORE_TIME = '2026-08-14T13:00:00.000Z';
 const REFINED_ID = 'github:R_REFINED';
 const APXM_ID = 'github:R_APXM';
 const WORKTREE = 'C:\\nest\\REPOS\\worktrees\\JAC-9-multi-repo-portfolio';
+const POSIX_WORKTREE = '/nest/REPOS/worktrees/JAC-9-multi-repo-portfolio';
 
 afterEach(async () => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -105,6 +106,45 @@ describe('PortfolioReconciler', () => {
     });
     expect(replaced.repository.name).toBe('renamed');
   });
+
+  it('supports both path styles with their native case semantics', async () => {
+    const windows = await linkedHarness();
+    const windowsObservation = healthyObservation('portfolio:JAC-9:windows-case');
+    windowsObservation.repositories[0].localCheckout = 'c:\\NEST\\repos\\REFINED-PRUN';
+    windowsObservation.repositories[0].worktrees[0].path =
+      'c:\\NEST\\repos\\WORKTREES\\jac-9-MULTI-REPO-PORTFOLIO';
+    windowsObservation.repositories[1].localCheckout = 'c:\\NEST\\repos\\apxm';
+    const windowsResult = await windows.portfolio.audit('JAC-9', windowsObservation);
+    expect(windowsResult.mapping.portfolio.alert.findings).toEqual([]);
+
+    const posix = await harness(POSIX_WORKTREE);
+    await posix.portfolio.register({
+      ...refinedRegistration(),
+      localCheckout: '/nest/REPOS/refined-prun',
+      worktreeRoot: '/nest/REPOS/worktrees',
+    });
+    await posix.portfolio.register({
+      ...apxmRegistration(),
+      localCheckout: '/nest/REPOS/APXM',
+      worktreeRoot: '/nest/REPOS/worktrees',
+    });
+    await posix.portfolio.link({ ...primaryLink(), worktree: POSIX_WORKTREE });
+    await posix.portfolio.link(relatedLink());
+
+    const posixHealthy = posixObservation('portfolio:JAC-9:posix-healthy');
+    const posixCurrent = await posix.portfolio.audit('JAC-9', posixHealthy);
+    expect(posixCurrent.mapping.portfolio.alert.findings).toEqual([]);
+
+    const posixCaseDrift = posixObservation('portfolio:JAC-9:posix-case-drift');
+    posixCaseDrift.repositories[0].localCheckout = '/NEST/REPOS/refined-prun';
+    posixCaseDrift.repositories[0].worktrees[0].path =
+      '/NEST/REPOS/worktrees/JAC-9-multi-repo-portfolio';
+    const posixDrift = await posix.portfolio.audit('JAC-9', posixCaseDrift);
+    expect(posixDrift.mapping.portfolio.alert.findings.map(x => x.code)).toEqual([
+      'linked-worktree-missing',
+      'local-checkout-mismatch',
+    ]);
+  });
 });
 
 async function linkedHarness() {
@@ -116,12 +156,12 @@ async function linkedHarness() {
   return result;
 }
 
-async function harness() {
+async function harness(worktree = WORKTREE) {
   const directory = await mkdtemp(join(tmpdir(), 'ai-portfolio-'));
   temporaryDirectories.push(directory);
   const store = new JsonMappingStore(join(directory, 'mappings.json'));
   const data = emptyStore();
-  data.mappings['JAC-9'] = createMapping(seed(), 'channel-id', STORE_TIME);
+  data.mappings['JAC-9'] = createMapping(seed(worktree), 'channel-id', STORE_TIME);
   data.mappings['JAC-9'].execution.observedState = 'active';
   await store.write(data);
   return {
@@ -221,7 +261,15 @@ function healthyObservation(eventId: string): PortfolioObservation {
   };
 }
 
-function seed(): ReconcileRequest {
+function posixObservation(eventId: string): PortfolioObservation {
+  const observation = healthyObservation(eventId);
+  observation.repositories[0].localCheckout = '/nest/REPOS/refined-prun';
+  observation.repositories[0].worktrees[0].path = POSIX_WORKTREE;
+  observation.repositories[1].localCheckout = '/nest/REPOS/APXM';
+  return observation;
+}
+
+function seed(worktree = WORKTREE): ReconcileRequest {
   return {
     key: 'JAC-9',
     title: '[Phase 5] Multi-repo portfolio reconciliation',
@@ -231,7 +279,7 @@ function seed(): ReconcileRequest {
     channelName: 'JAC-9-multi-repo-portfolio',
     repository: 'https://github.com/jackinabox86/refined-prun',
     branch: 'JAC-9-multi-repo-portfolio',
-    worktree: WORKTREE,
+    worktree,
     owner: 'Codex Sol',
   };
 }

--- a/scripts/ai-workflow/portfolio.test.ts
+++ b/scripts/ai-workflow/portfolio.test.ts
@@ -1,0 +1,237 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMapping, emptyStore, type ReconcileRequest } from './model.ts';
+import { PortfolioReconciler, type PortfolioObservation } from './portfolio.ts';
+import { JsonMappingStore } from './store.ts';
+
+const temporaryDirectories: string[] = [];
+const STORE_TIME = '2026-08-14T13:00:00.000Z';
+const REFINED_ID = 'github:R_REFINED';
+const APXM_ID = 'github:R_APXM';
+const WORKTREE = 'C:\\nest\\REPOS\\worktrees\\JAC-9-multi-repo-portfolio';
+
+afterEach(async () => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe('PortfolioReconciler', () => {
+  it('registers and links two repositories idempotently', async () => {
+    const { portfolio, store } = await harness();
+
+    const first = await portfolio.register(refinedRegistration());
+    const replay = await portfolio.register(refinedRegistration());
+    await portfolio.register(apxmRegistration());
+    await portfolio.link(primaryLink());
+    const related = await portfolio.link(relatedLink());
+    const relatedReplay = await portfolio.link(relatedLink());
+
+    expect(first.repository.id).toBe(REFINED_ID);
+    expect(replay.actions).toEqual([{ type: 'none', reason: 'repository-registration-current' }]);
+    expect(related.mapping.portfolio.repositories).toHaveLength(2);
+    expect(relatedReplay.actions).toEqual([{ type: 'none', reason: 'repository-link-current' }]);
+    expect(Object.keys((await store.read()).repositories)).toEqual([REFINED_ID, APXM_ID]);
+  });
+
+  it('emits one drift alert, suppresses replays, and clears only on healthy truth', async () => {
+    const { portfolio } = await linkedHarness();
+    const healthy = healthyObservation('portfolio:JAC-9:healthy-1');
+    const current = await portfolio.audit('JAC-9', healthy);
+    const reorderedReplay = structuredClone(healthy);
+    reorderedReplay.repositories.reverse();
+    reorderedReplay.repositories[1].branches.reverse();
+    const replay = await portfolio.audit('JAC-9', reorderedReplay);
+
+    const drift = healthyObservation('portfolio:JAC-9:drift-1');
+    drift.repositories[0].worktrees = [];
+    drift.repositories[1].name = 'APXM-renamed';
+    const attention = await portfolio.audit('JAC-9', drift);
+    const repeatedDrift = healthyObservation('portfolio:JAC-9:drift-2');
+    repeatedDrift.repositories[0].worktrees = [];
+    repeatedDrift.repositories[1].name = 'APXM-renamed';
+    const noDuplicate = await portfolio.audit('JAC-9', repeatedDrift);
+    const recovered = await portfolio.audit(
+      'JAC-9',
+      healthyObservation('portfolio:JAC-9:healthy-2'),
+    );
+
+    expect(current.actions).toEqual([{ type: 'none', reason: 'portfolio-current' }]);
+    expect(replay.actions).toEqual([{ type: 'none', reason: 'portfolio-observation-replayed' }]);
+    expect(attention.actions).toHaveLength(1);
+    expect(attention.actions[0].type).toBe('needs-attention');
+    expect(attention.mapping.portfolio.alert.findings.map(x => x.code)).toEqual([
+      'repository-name-mismatch',
+      'linked-worktree-missing',
+    ]);
+    expect(noDuplicate.actions).toEqual([{ type: 'none', reason: 'portfolio-alert-current' }]);
+    expect(recovered.actions).toEqual([{ type: 'none', reason: 'portfolio-alert-cleared' }]);
+    expect(recovered.mapping.portfolio.alert.state).toBe('clear');
+    expect(recovered.mapping.portfolio.audits).toHaveLength(4);
+  });
+
+  it('rejects conflicting event identities and unregistered observations', async () => {
+    const { portfolio } = await linkedHarness();
+    const first = healthyObservation('portfolio:JAC-9:1');
+    await portfolio.audit('JAC-9', first);
+    const conflict = healthyObservation('portfolio:JAC-9:1');
+    conflict.observedAt = '2026-08-14T13:01:00.000Z';
+
+    await expect(portfolio.audit('JAC-9', conflict)).rejects.toThrow(
+      'Portfolio event identity conflicts',
+    );
+
+    const unknown = healthyObservation('portfolio:JAC-9:2');
+    unknown.repositories.push({ ...unknown.repositories[1], repositoryId: 'github:R_UNKNOWN' });
+    await expect(portfolio.audit('JAC-9', unknown)).rejects.toThrow('unregistered repository');
+  });
+
+  it('requires explicit replacement for reviewed metadata changes', async () => {
+    const { portfolio } = await harness();
+    await portfolio.register(refinedRegistration());
+
+    const renamed = {
+      ...refinedRegistration(),
+      name: 'renamed',
+      remoteUrl: 'https://github.com/jackinabox86/renamed',
+    };
+    await expect(portfolio.register(renamed)).rejects.toThrow('use --replace-metadata');
+
+    const replaced = await portfolio.register({
+      ...renamed,
+      replaceMetadata: true,
+    });
+    expect(replaced.repository.name).toBe('renamed');
+  });
+});
+
+async function linkedHarness() {
+  const result = await harness();
+  await result.portfolio.register(refinedRegistration());
+  await result.portfolio.register(apxmRegistration());
+  await result.portfolio.link(primaryLink());
+  await result.portfolio.link(relatedLink());
+  return result;
+}
+
+async function harness() {
+  const directory = await mkdtemp(join(tmpdir(), 'ai-portfolio-'));
+  temporaryDirectories.push(directory);
+  const store = new JsonMappingStore(join(directory, 'mappings.json'));
+  const data = emptyStore();
+  data.mappings['JAC-9'] = createMapping(seed(), 'channel-id', STORE_TIME);
+  data.mappings['JAC-9'].execution.observedState = 'active';
+  await store.write(data);
+  return {
+    store,
+    portfolio: new PortfolioReconciler(store, () => new Date(STORE_TIME)),
+  };
+}
+
+function refinedRegistration() {
+  return {
+    issueKey: 'JAC-9',
+    provider: 'github' as const,
+    providerRepositoryId: 'R_REFINED',
+    owner: 'jackinabox86',
+    name: 'refined-prun',
+    remoteUrl: 'https://github.com/jackinabox86/refined-prun',
+    defaultBranch: 'main',
+    localCheckout: 'C:\\nest\\REPOS\\refined-prun',
+    worktreeRoot: 'C:\\nest\\REPOS\\worktrees',
+    archivePolicy: 'retain' as const,
+    replaceMetadata: false,
+  };
+}
+
+function apxmRegistration() {
+  return {
+    issueKey: 'JAC-9',
+    provider: 'github' as const,
+    providerRepositoryId: 'R_APXM',
+    owner: 'jackinabox86',
+    name: 'APXM',
+    remoteUrl: 'https://github.com/jackinabox86/APXM',
+    defaultBranch: 'main',
+    localCheckout: 'C:\\nest\\REPOS\\APXM',
+    worktreeRoot: 'C:\\nest\\REPOS\\worktrees',
+    archivePolicy: 'retain' as const,
+    replaceMetadata: false,
+  };
+}
+
+function primaryLink() {
+  return {
+    issueKey: 'JAC-9',
+    repositoryId: REFINED_ID,
+    role: 'primary' as const,
+    branch: 'JAC-9-multi-repo-portfolio',
+    worktree: WORKTREE,
+    replaceArtifacts: false,
+  };
+}
+
+function relatedLink() {
+  return {
+    issueKey: 'JAC-9',
+    repositoryId: APXM_ID,
+    role: 'related' as const,
+    replaceArtifacts: false,
+  };
+}
+
+function healthyObservation(eventId: string): PortfolioObservation {
+  return {
+    eventId,
+    observedAt: STORE_TIME,
+    linear: { key: 'JAC-9', state: 'in-progress' },
+    buzz: { channelId: 'channel-id', state: 'active' },
+    repositories: [
+      {
+        repositoryId: REFINED_ID,
+        state: 'present',
+        providerRepositoryId: 'R_REFINED',
+        owner: 'jackinabox86',
+        name: 'refined-prun',
+        remoteUrl: 'https://github.com/jackinabox86/refined-prun',
+        defaultBranch: 'main',
+        localCheckout: 'C:\\nest\\REPOS\\refined-prun',
+        localCheckoutPresent: true,
+        branches: ['main', 'JAC-9-multi-repo-portfolio'],
+        worktrees: [{ path: WORKTREE, branch: 'JAC-9-multi-repo-portfolio' }],
+        pullRequestUrls: [],
+      },
+      {
+        repositoryId: APXM_ID,
+        state: 'present',
+        providerRepositoryId: 'R_APXM',
+        owner: 'jackinabox86',
+        name: 'APXM',
+        remoteUrl: 'https://github.com/jackinabox86/APXM',
+        defaultBranch: 'main',
+        localCheckout: 'C:\\nest\\REPOS\\APXM',
+        localCheckoutPresent: true,
+        branches: ['main'],
+        worktrees: [],
+        pullRequestUrls: [],
+      },
+    ],
+  };
+}
+
+function seed(): ReconcileRequest {
+  return {
+    key: 'JAC-9',
+    title: '[Phase 5] Multi-repo portfolio reconciliation',
+    linearUrl: 'https://linear.app/example/issue/JAC-9/example',
+    teamId: 'team-id',
+    statusIds: { todo: 'todo', inProgress: 'working', inReview: 'review', done: 'done' },
+    channelName: 'JAC-9-multi-repo-portfolio',
+    repository: 'https://github.com/jackinabox86/refined-prun',
+    branch: 'JAC-9-multi-repo-portfolio',
+    worktree: WORKTREE,
+    owner: 'Codex Sol',
+  };
+}

--- a/scripts/ai-workflow/portfolio.ts
+++ b/scripts/ai-workflow/portfolio.ts
@@ -1,0 +1,727 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, normalize } from 'node:path';
+import {
+  LINEAR_LIFECYCLE_STATES,
+  REPOSITORY_ARCHIVE_POLICIES,
+  REPOSITORY_LINK_ROLES,
+  REPOSITORY_PROVIDERS,
+  normalizeIssueKey,
+  type LinearLifecycleState,
+  type PortfolioFinding,
+  type PortfolioRepositoryLink,
+  type RepositoryArchivePolicy,
+  type RepositoryLinkRole,
+  type RepositoryProvider,
+  type RepositoryRegistration,
+  type TaskMapping,
+} from './model.ts';
+import { JsonMappingStore } from './store.ts';
+
+const MAX_PORTFOLIO_AUDITS = 100;
+
+export interface RegisterRepositoryRequest {
+  issueKey: string;
+  provider: RepositoryProvider;
+  providerRepositoryId: string;
+  owner: string;
+  name: string;
+  remoteUrl: string;
+  defaultBranch: string;
+  localCheckout: string;
+  worktreeRoot: string;
+  archivePolicy: RepositoryArchivePolicy;
+  replaceMetadata: boolean;
+}
+
+export interface LinkRepositoryRequest {
+  issueKey: string;
+  repositoryId: string;
+  role: RepositoryLinkRole;
+  branch?: string;
+  worktree?: string;
+  pullRequestUrl?: string;
+  replaceArtifacts: boolean;
+}
+
+export interface PortfolioObservation {
+  eventId: string;
+  observedAt: string;
+  linear: { key: string; state: LinearLifecycleState };
+  buzz: { channelId: string; state: 'active' | 'archived' | 'missing' };
+  repositories: RepositoryObservation[];
+}
+
+interface RepositoryObservation {
+  repositoryId: string;
+  state: 'present' | 'missing';
+  providerRepositoryId: string;
+  owner: string;
+  name: string;
+  remoteUrl: string;
+  defaultBranch: string;
+  localCheckout: string;
+  localCheckoutPresent: boolean;
+  branches: string[];
+  worktrees: Array<{ path: string; branch: string }>;
+  pullRequestUrls: string[];
+}
+
+export type PortfolioAction =
+  | { type: 'none'; reason: string }
+  | {
+      type: 'needs-attention';
+      issueKey: string;
+      eventId: string;
+      findings: PortfolioFinding[];
+    };
+
+export class PortfolioReconciler {
+  readonly store: JsonMappingStore;
+  readonly now: () => Date;
+
+  constructor(store: JsonMappingStore, now = () => new Date()) {
+    this.store = store;
+    this.now = now;
+  }
+
+  async register(request: RegisterRepositoryRequest) {
+    validateRegistrationRequest(request);
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const id = repositoryId(request.provider, request.providerRepositoryId);
+      const desired = registration(request, id, this.now().toISOString());
+      const current = data.repositories[id];
+      if (current !== undefined && sameRegistration(current, desired)) {
+        return {
+          mapping,
+          repository: current,
+          actions: [{ type: 'none', reason: 'repository-registration-current' }],
+        };
+      }
+      if (current !== undefined && !request.replaceMetadata) {
+        throw new Error(
+          `Repository ${id} metadata conflicts with the allowlist; use --replace-metadata after review`,
+        );
+      }
+      data.repositories[id] = desired;
+      await this.store.write(data);
+      return {
+        mapping,
+        repository: desired,
+        actions: [
+          {
+            type: 'none',
+            reason:
+              current === undefined ? 'registered-repository' : 'replaced-repository-metadata',
+          },
+        ],
+      };
+    });
+  }
+
+  async link(request: LinkRepositoryRequest) {
+    validateLinkRequest(request);
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, request.issueKey);
+      const repository = data.repositories[request.repositoryId];
+      if (repository === undefined) {
+        throw new Error(`Repository is not registered: ${request.repositoryId}`);
+      }
+      const desired: PortfolioRepositoryLink = {
+        repositoryId: request.repositoryId,
+        role: request.role,
+        branch: request.branch ?? null,
+        worktree: request.worktree === undefined ? null : canonicalPath(request.worktree),
+        pullRequestUrl:
+          request.pullRequestUrl === undefined ? null : canonicalRemote(request.pullRequestUrl),
+      };
+      validatePrimaryLink(mapping, repository, desired);
+      const existingIndex = mapping.portfolio.repositories.findIndex(
+        x => x.repositoryId === request.repositoryId,
+      );
+      const existing = mapping.portfolio.repositories[existingIndex];
+      if (existing !== undefined && sameLink(existing, desired)) {
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'repository-link-current' }],
+        };
+      }
+      if (existing !== undefined && !request.replaceArtifacts) {
+        throw new Error(
+          `Repository link ${request.repositoryId} conflicts; use --replace-artifacts after review`,
+        );
+      }
+      if (
+        desired.role === 'primary' &&
+        mapping.portfolio.repositories.some(
+          (x, index) => x.role === 'primary' && index !== existingIndex,
+        )
+      ) {
+        throw new Error(`Mapping ${mapping.linear.key} already has a primary repository link`);
+      }
+      if (existingIndex === -1) {
+        mapping.portfolio.repositories.push(desired);
+      } else {
+        mapping.portfolio.repositories[existingIndex] = desired;
+      }
+      mapping.portfolio.repositories.sort((a, b) => a.repositoryId.localeCompare(b.repositoryId));
+      await this.store.write(data);
+      return {
+        mapping,
+        actions: [
+          {
+            type: 'none',
+            reason: existing === undefined ? 'linked-repository' : 'replaced-repository-link',
+          },
+        ],
+      };
+    });
+  }
+
+  async auditFile(issueKey: string, observationFile: string) {
+    if (!isAbsolute(observationFile)) {
+      throw new Error('--observation-file must be an absolute path');
+    }
+    const parsed: unknown = JSON.parse(await readFile(observationFile, 'utf8'));
+    return await this.audit(issueKey, parseObservation(parsed));
+  }
+
+  async audit(issueKey: string, observation: PortfolioObservation) {
+    validateObservation(observation);
+    const normalizedObservation = normalizeObservation(observation);
+    const observationHash = hashObservation(normalizedObservation);
+    return await this.store.withLock(async () => {
+      const data = await this.store.read();
+      const mapping = requireMapping(data.mappings, issueKey);
+      const existing = mapping.portfolio.audits.find(x => x.eventId === observation.eventId);
+      if (existing !== undefined) {
+        if (existing.observationHash !== observationHash) {
+          throw new Error(`Portfolio event identity conflicts: ${observation.eventId}`);
+        }
+        return {
+          mapping,
+          actions: [{ type: 'none', reason: 'portfolio-observation-replayed' }],
+        };
+      }
+
+      const findings = evaluate(mapping, data.repositories, normalizedObservation);
+      mapping.portfolio.audits.push({
+        eventId: normalizedObservation.eventId,
+        observationHash,
+        observedAt: normalizedObservation.observedAt,
+        outcome: findings.length === 0 ? 'clear' : 'attention',
+        findings,
+      });
+      while (mapping.portfolio.audits.length > MAX_PORTFOLIO_AUDITS) {
+        mapping.portfolio.audits.shift();
+      }
+
+      const wasAttention = mapping.portfolio.alert.state === 'attention';
+      let actions: PortfolioAction[];
+      if (findings.length === 0) {
+        mapping.portfolio.alert = {
+          state: 'clear',
+          reason: null,
+          since: null,
+          eventId: null,
+          findings: [],
+        };
+        actions = [
+          {
+            type: 'none',
+            reason: wasAttention ? 'portfolio-alert-cleared' : 'portfolio-current',
+          },
+        ];
+      } else {
+        mapping.portfolio.alert = {
+          state: 'attention',
+          reason: `portfolio-drift:${findings.map(x => x.code).join(',')}`,
+          since: wasAttention
+            ? (mapping.portfolio.alert.since ?? normalizedObservation.observedAt)
+            : normalizedObservation.observedAt,
+          eventId: normalizedObservation.eventId,
+          findings,
+        };
+        actions = wasAttention
+          ? [{ type: 'none', reason: 'portfolio-alert-current' }]
+          : [
+              {
+                type: 'needs-attention',
+                issueKey: mapping.linear.key,
+                eventId: normalizedObservation.eventId,
+                findings,
+              },
+            ];
+      }
+      await this.store.write(data);
+      return { mapping, actions };
+    });
+  }
+}
+
+function evaluate(
+  mapping: TaskMapping,
+  registrations: Record<string, RepositoryRegistration>,
+  observation: PortfolioObservation,
+) {
+  const findings: PortfolioFinding[] = [];
+  const add = (
+    code: string,
+    repositoryId: string | null,
+    expected: string | null,
+    observed: string | null,
+  ) => findings.push({ code, repositoryId, expected, observed });
+
+  if (normalizeIssueKey(observation.linear.key) !== mapping.linear.key) {
+    add('linear-key-mismatch', null, mapping.linear.key, observation.linear.key);
+  }
+  if (mapping.execution.desiredState === 'archived' && observation.linear.state !== 'done') {
+    add('archived-mapping-linear-not-done', null, 'done', observation.linear.state);
+  }
+  if (observation.buzz.channelId !== mapping.buzz.channelId) {
+    add('buzz-channel-mismatch', null, mapping.buzz.channelId, observation.buzz.channelId);
+  }
+  const expectedBuzzState = mapping.execution.desiredState === 'archived' ? 'archived' : 'active';
+  if (observation.buzz.state !== expectedBuzzState) {
+    add('buzz-state-mismatch', null, expectedBuzzState, observation.buzz.state);
+  }
+
+  const observedRepositories = new Map(observation.repositories.map(x => [x.repositoryId, x]));
+  for (const observed of observation.repositories) {
+    if (registrations[observed.repositoryId] === undefined) {
+      throw new Error(`Observation contains an unregistered repository: ${observed.repositoryId}`);
+    }
+  }
+  for (const link of mapping.portfolio.repositories) {
+    const registration = registrations[link.repositoryId];
+    if (registration === undefined) {
+      add('repository-registration-missing', link.repositoryId, 'registered', 'missing');
+      continue;
+    }
+    const observed = observedRepositories.get(link.repositoryId);
+    if (observed === undefined) {
+      add('linked-repository-not-observed', link.repositoryId, 'observed', 'missing');
+      continue;
+    }
+    if (observed.state === 'missing') {
+      add('linked-repository-missing', link.repositoryId, 'present', 'missing');
+      continue;
+    }
+    compare(
+      add,
+      'provider-repository-id-mismatch',
+      link.repositoryId,
+      registration.providerRepositoryId,
+      observed.providerRepositoryId,
+    );
+    compareFolded(
+      add,
+      'repository-owner-mismatch',
+      link.repositoryId,
+      registration.owner,
+      observed.owner,
+    );
+    compareFolded(
+      add,
+      'repository-name-mismatch',
+      link.repositoryId,
+      registration.name,
+      observed.name,
+    );
+    compareRemote(
+      add,
+      'repository-remote-mismatch',
+      link.repositoryId,
+      registration.remoteUrl,
+      observed.remoteUrl,
+    );
+    compare(
+      add,
+      'default-branch-mismatch',
+      link.repositoryId,
+      registration.defaultBranch,
+      observed.defaultBranch,
+    );
+    comparePath(
+      add,
+      'local-checkout-mismatch',
+      link.repositoryId,
+      registration.localCheckout,
+      observed.localCheckout,
+    );
+    if (!observed.localCheckoutPresent) {
+      add('local-checkout-missing', link.repositoryId, registration.localCheckout, 'missing');
+    }
+    if (link.branch !== null && !observed.branches.includes(link.branch)) {
+      add('linked-branch-missing', link.repositoryId, link.branch, 'missing');
+    }
+    if (
+      link.worktree !== null &&
+      !observed.worktrees.some(
+        x => samePath(x.path, link.worktree!) && (link.branch === null || x.branch === link.branch),
+      )
+    ) {
+      add('linked-worktree-missing', link.repositoryId, link.worktree, 'missing');
+    }
+    if (
+      link.pullRequestUrl !== null &&
+      !observed.pullRequestUrls.some(x => sameRemote(x, link.pullRequestUrl!))
+    ) {
+      add('linked-pull-request-missing', link.repositoryId, link.pullRequestUrl, 'missing');
+    }
+  }
+  return findings.sort((a, b) =>
+    [a.repositoryId ?? '', a.code, a.expected ?? '', a.observed ?? '']
+      .join('\0')
+      .localeCompare([b.repositoryId ?? '', b.code, b.expected ?? '', b.observed ?? ''].join('\0')),
+  );
+}
+
+function compare(
+  add: (code: string, repositoryId: string, expected: string, observed: string) => void,
+  code: string,
+  repositoryId: string,
+  expected: string,
+  observed: string,
+) {
+  if (expected !== observed) {
+    add(code, repositoryId, expected, observed);
+  }
+}
+
+function compareFolded(
+  add: (code: string, repositoryId: string, expected: string, observed: string) => void,
+  code: string,
+  repositoryId: string,
+  expected: string,
+  observed: string,
+) {
+  if (expected.toLowerCase() !== observed.toLowerCase()) {
+    add(code, repositoryId, expected, observed);
+  }
+}
+
+function compareRemote(
+  add: (code: string, repositoryId: string, expected: string, observed: string) => void,
+  code: string,
+  repositoryId: string,
+  expected: string,
+  observed: string,
+) {
+  if (!sameRemote(expected, observed)) {
+    add(code, repositoryId, expected, observed);
+  }
+}
+
+function comparePath(
+  add: (code: string, repositoryId: string, expected: string, observed: string) => void,
+  code: string,
+  repositoryId: string,
+  expected: string,
+  observed: string,
+) {
+  if (!samePath(expected, observed)) {
+    add(code, repositoryId, expected, observed);
+  }
+}
+
+function registration(request: RegisterRepositoryRequest, id: string, updatedAt: string) {
+  return {
+    id,
+    provider: request.provider,
+    providerRepositoryId: request.providerRepositoryId,
+    owner: request.owner,
+    name: request.name,
+    remoteUrl: canonicalRemote(request.remoteUrl),
+    defaultBranch: request.defaultBranch,
+    localCheckout: canonicalPath(request.localCheckout),
+    worktreeRoot: canonicalPath(request.worktreeRoot),
+    archivePolicy: request.archivePolicy,
+    updatedAt,
+  } satisfies RepositoryRegistration;
+}
+
+function validateRegistrationRequest(request: RegisterRepositoryRequest) {
+  if (!REPOSITORY_PROVIDERS.includes(request.provider)) {
+    throw new Error(`Unsupported repository provider: ${request.provider}`);
+  }
+  for (const [name, value] of Object.entries({
+    'provider-id': request.providerRepositoryId,
+    owner: request.owner,
+    name: request.name,
+    'remote-url': request.remoteUrl,
+    'default-branch': request.defaultBranch,
+    'local-checkout': request.localCheckout,
+    'worktree-root': request.worktreeRoot,
+  })) {
+    assertNonempty(value, name);
+  }
+  if (!REPOSITORY_ARCHIVE_POLICIES.includes(request.archivePolicy)) {
+    throw new Error(`Unsupported archive policy: ${request.archivePolicy}`);
+  }
+  const remote = new URL(canonicalRemote(request.remoteUrl));
+  const expectedPath = `/${request.owner}/${request.name}`.toLowerCase();
+  if (
+    remote.hostname.toLowerCase() !== 'github.com' ||
+    remote.pathname.toLowerCase() !== expectedPath ||
+    remote.username !== '' ||
+    remote.password !== '' ||
+    remote.search !== '' ||
+    remote.hash !== ''
+  ) {
+    throw new Error('GitHub repository URL must match --repository-owner and --repository-name');
+  }
+  canonicalPath(request.localCheckout);
+  canonicalPath(request.worktreeRoot);
+}
+
+function validateLinkRequest(request: LinkRepositoryRequest) {
+  assertNonempty(request.repositoryId, 'repository-id');
+  if (!REPOSITORY_LINK_ROLES.includes(request.role)) {
+    throw new Error(`Unsupported repository role: ${request.role}`);
+  }
+  if (request.worktree !== undefined) {
+    canonicalPath(request.worktree);
+  }
+  if (request.pullRequestUrl !== undefined) {
+    canonicalRemote(request.pullRequestUrl);
+  }
+}
+
+function validatePrimaryLink(
+  mapping: TaskMapping,
+  repository: RepositoryRegistration,
+  link: PortfolioRepositoryLink,
+) {
+  if (link.role !== 'primary') {
+    return;
+  }
+  if (!sameRemote(repository.remoteUrl, mapping.git.repository)) {
+    throw new Error('Primary repository registration must match the mapping repository');
+  }
+  if (
+    link.branch !== mapping.git.branch ||
+    link.worktree === null ||
+    !samePath(link.worktree, mapping.git.worktree)
+  ) {
+    throw new Error('Primary repository link must retain the mapping branch and worktree');
+  }
+}
+
+function validateObservation(value: PortfolioObservation) {
+  assertNonempty(value.eventId, 'event-id');
+  if (value.eventId.length > 512) {
+    throw new Error('--event-id must be at most 512 characters');
+  }
+  if (!Number.isFinite(Date.parse(value.observedAt))) {
+    throw new Error('observedAt must be an ISO-8601 timestamp');
+  }
+  normalizeIssueKey(value.linear.key);
+  if (!LINEAR_LIFECYCLE_STATES.includes(value.linear.state)) {
+    throw new Error(`Invalid Linear state: ${value.linear.state}`);
+  }
+  const repositoryIds = new Set<string>();
+  for (const repository of value.repositories) {
+    if (repositoryIds.has(repository.repositoryId)) {
+      throw new Error(`Duplicate repository observation: ${repository.repositoryId}`);
+    }
+    repositoryIds.add(repository.repositoryId);
+  }
+}
+
+function parseObservation(value: unknown): PortfolioObservation {
+  if (!isRecord(value) || !isRecord(value.linear) || !isRecord(value.buzz)) {
+    throw new Error(
+      'Observation file must contain eventId, observedAt, linear, buzz, and repositories',
+    );
+  }
+  if (!Array.isArray(value.repositories)) {
+    throw new Error('Observation file repositories must be an array');
+  }
+  const observation: PortfolioObservation = {
+    eventId: stringValue(value.eventId, 'eventId'),
+    observedAt: stringValue(value.observedAt, 'observedAt'),
+    linear: {
+      key: stringValue(value.linear.key, 'linear.key'),
+      state: stringValue(value.linear.state, 'linear.state') as LinearLifecycleState,
+    },
+    buzz: {
+      channelId: stringValue(value.buzz.channelId, 'buzz.channelId'),
+      state: stringValue(value.buzz.state, 'buzz.state') as PortfolioObservation['buzz']['state'],
+    },
+    repositories: value.repositories.map(parseRepositoryObservation),
+  };
+  if (!['active', 'archived', 'missing'].includes(observation.buzz.state)) {
+    throw new Error(`Invalid Buzz state: ${observation.buzz.state}`);
+  }
+  validateObservation(observation);
+  return observation;
+}
+
+function parseRepositoryObservation(value: unknown): RepositoryObservation {
+  if (!isRecord(value)) {
+    throw new Error('Repository observation must be an object');
+  }
+  if (
+    !Array.isArray(value.branches) ||
+    !Array.isArray(value.worktrees) ||
+    !Array.isArray(value.pullRequestUrls)
+  ) {
+    throw new Error('Repository observation artifacts must be arrays');
+  }
+  if (typeof value.localCheckoutPresent !== 'boolean') {
+    throw new Error('Repository observation localCheckoutPresent must be boolean');
+  }
+  const state = stringValue(value.state, 'repository.state');
+  if (state !== 'present' && state !== 'missing') {
+    throw new Error(`Invalid repository state: ${state}`);
+  }
+  return {
+    repositoryId: stringValue(value.repositoryId, 'repository.repositoryId'),
+    state,
+    providerRepositoryId: stringValue(
+      value.providerRepositoryId,
+      'repository.providerRepositoryId',
+    ),
+    owner: stringValue(value.owner, 'repository.owner'),
+    name: stringValue(value.name, 'repository.name'),
+    remoteUrl: stringValue(value.remoteUrl, 'repository.remoteUrl'),
+    defaultBranch: stringValue(value.defaultBranch, 'repository.defaultBranch'),
+    localCheckout: stringValue(value.localCheckout, 'repository.localCheckout'),
+    localCheckoutPresent: value.localCheckoutPresent,
+    branches: value.branches.map((x, index) => stringValue(x, `repository.branches[${index}]`)),
+    worktrees: value.worktrees.map((x, index) => {
+      if (!isRecord(x)) {
+        throw new Error(`repository.worktrees[${index}] must be an object`);
+      }
+      return {
+        path: stringValue(x.path, `repository.worktrees[${index}].path`),
+        branch: stringValue(x.branch, `repository.worktrees[${index}].branch`),
+      };
+    }),
+    pullRequestUrls: value.pullRequestUrls.map((x, index) =>
+      stringValue(x, `repository.pullRequestUrls[${index}]`),
+    ),
+  };
+}
+
+function requireMapping(mappings: Record<string, TaskMapping>, issueKey: string) {
+  const key = normalizeIssueKey(issueKey);
+  const mapping = mappings[key];
+  if (mapping === undefined) {
+    throw new Error(`No mapping exists for ${key}`);
+  }
+  return mapping;
+}
+
+function repositoryId(provider: RepositoryProvider, providerRepositoryId: string) {
+  return `${provider}:${providerRepositoryId}`;
+}
+
+function canonicalRemote(value: string) {
+  const url = new URL(value);
+  if (url.protocol !== 'https:') {
+    throw new Error('Repository and pull-request URLs must use HTTPS');
+  }
+  return url
+    .toString()
+    .replace(/\/$/, '')
+    .replace(/\.git$/, '');
+}
+
+function canonicalPath(value: string) {
+  if (!isAbsolute(value)) {
+    throw new Error('Repository and worktree paths must be absolute');
+  }
+  return normalize(value);
+}
+
+function sameRegistration(current: RepositoryRegistration, desired: RepositoryRegistration) {
+  return (
+    current.provider === desired.provider &&
+    current.providerRepositoryId === desired.providerRepositoryId &&
+    current.owner === desired.owner &&
+    current.name === desired.name &&
+    sameRemote(current.remoteUrl, desired.remoteUrl) &&
+    current.defaultBranch === desired.defaultBranch &&
+    samePath(current.localCheckout, desired.localCheckout) &&
+    samePath(current.worktreeRoot, desired.worktreeRoot) &&
+    current.archivePolicy === desired.archivePolicy
+  );
+}
+
+function sameLink(current: PortfolioRepositoryLink, desired: PortfolioRepositoryLink) {
+  return (
+    current.repositoryId === desired.repositoryId &&
+    current.role === desired.role &&
+    current.branch === desired.branch &&
+    ((current.worktree === null && desired.worktree === null) ||
+      (current.worktree !== null &&
+        desired.worktree !== null &&
+        samePath(current.worktree, desired.worktree))) &&
+    current.pullRequestUrl === desired.pullRequestUrl
+  );
+}
+
+function sameRemote(first: string, second: string) {
+  return canonicalRemote(first).toLowerCase() === canonicalRemote(second).toLowerCase();
+}
+
+function samePath(first: string, second: string) {
+  return canonicalPath(first).toLowerCase() === canonicalPath(second).toLowerCase();
+}
+
+function hashObservation(value: PortfolioObservation) {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+function normalizeObservation(value: PortfolioObservation): PortfolioObservation {
+  return {
+    ...value,
+    repositories: value.repositories
+      .map(repository => ({
+        ...repository,
+        branches: [...repository.branches].sort(),
+        worktrees: [...repository.worktrees].sort((a, b) =>
+          [canonicalPath(a.path), a.branch]
+            .join('\0')
+            .localeCompare([canonicalPath(b.path), b.branch].join('\0')),
+        ),
+        pullRequestUrls: [...repository.pullRequestUrls].sort(),
+      }))
+      .sort((a, b) => a.repositoryId.localeCompare(b.repositoryId)),
+  };
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function stringValue(value: unknown, name: string) {
+  if (typeof value !== 'string') {
+    throw new Error(`${name} must be a string`);
+  }
+  return value;
+}
+
+function assertNonempty(value: string, name: string) {
+  if (value.trim() === '') {
+    throw new Error(`--${name} is required`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/scripts/ai-workflow/portfolio.ts
+++ b/scripts/ai-workflow/portfolio.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { isAbsolute, normalize } from 'node:path';
+import { isAbsolute, posix, win32 } from 'node:path';
 import {
   LINEAR_LIFECYCLE_STATES,
   REPOSITORY_ARCHIVE_POLICIES,
@@ -633,10 +633,8 @@ function canonicalRemote(value: string) {
 }
 
 function canonicalPath(value: string) {
-  if (!isAbsolute(value)) {
-    throw new Error('Repository and worktree paths must be absolute');
-  }
-  return normalize(value);
+  const style = absolutePathStyle(value);
+  return style === 'windows' ? win32.normalize(value) : posix.normalize(value);
 }
 
 function sameRegistration(current: RepositoryRegistration, desired: RepositoryRegistration) {
@@ -671,7 +669,28 @@ function sameRemote(first: string, second: string) {
 }
 
 function samePath(first: string, second: string) {
-  return canonicalPath(first).toLowerCase() === canonicalPath(second).toLowerCase();
+  const firstStyle = absolutePathStyle(first);
+  const secondStyle = absolutePathStyle(second);
+  if (firstStyle !== secondStyle) {
+    return false;
+  }
+  const normalizedFirst = canonicalPath(first);
+  const normalizedSecond = canonicalPath(second);
+  return firstStyle === 'windows'
+    ? normalizedFirst.toLowerCase() === normalizedSecond.toLowerCase()
+    : normalizedFirst === normalizedSecond;
+}
+
+function absolutePathStyle(value: string): 'windows' | 'posix' {
+  const hasWindowsDrive = /^[a-z]:[\\/]/i.test(value);
+  const hasWindowsUncRoot = value.startsWith('\\\\');
+  if ((hasWindowsDrive || hasWindowsUncRoot) && win32.isAbsolute(value)) {
+    return 'windows';
+  }
+  if (posix.isAbsolute(value)) {
+    return 'posix';
+  }
+  throw new Error('Repository and worktree paths must be absolute');
 }
 
 function hashObservation(value: PortfolioObservation) {

--- a/scripts/ai-workflow/reconcile.test.ts
+++ b/scripts/ai-workflow/reconcile.test.ts
@@ -157,6 +157,62 @@ describe('WorkflowReconciler', () => {
     );
   });
 
+  it('refuses archive while the multi-repo portfolio has unresolved drift', async () => {
+    const { reconciler, store } = await harness();
+    await reconciler.reconcile(seed());
+    const data = await store.read();
+    data.mappings['JAC-6'].portfolio.alert = {
+      state: 'attention',
+      reason: 'portfolio-drift:linked-worktree-missing',
+      since: '2026-08-14T13:00:00.000Z',
+      eventId: 'portfolio:JAC-6:1',
+      findings: [
+        {
+          code: 'linked-worktree-missing',
+          repositoryId: 'github:repo-id',
+          expected: 'C:\\worktree',
+          observed: 'missing',
+        },
+      ],
+    };
+    await store.write(data);
+
+    await expect(reconciler.archive('JAC-6', true, 'done')).rejects.toThrow(
+      'multi-repo portfolio state needs attention',
+    );
+  });
+
+  it('refuses archive of linked repositories until a clean audit exists', async () => {
+    const { reconciler, store } = await harness();
+    await reconciler.reconcile(seed());
+    const data = await store.read();
+    data.repositories['github:repo-id'] = {
+      id: 'github:repo-id',
+      provider: 'github',
+      providerRepositoryId: 'repo-id',
+      owner: 'example',
+      name: 'repo',
+      remoteUrl: 'https://github.com/example/repo',
+      defaultBranch: 'main',
+      localCheckout: 'C:\\repos\\repo',
+      worktreeRoot: 'C:\\repos\\worktrees',
+      archivePolicy: 'retain',
+      updatedAt: '2026-08-14T13:00:00.000Z',
+    };
+    data.mappings['JAC-6'].portfolio.repositories = [
+      {
+        repositoryId: 'github:repo-id',
+        role: 'primary',
+        branch: 'JAC-6-linear-buzz-reconciler',
+        worktree: 'C:\\worktrees\\JAC-6-linear-buzz-reconciler',
+        pullRequestUrl: null,
+      },
+    ];
+    await store.write(data);
+
+    await expect(reconciler.archive('JAC-6', true, 'done')).rejects.toThrow('current clean audit');
+  });
+
   it('archives once and preserves the archived mapping on later reconcile', async () => {
     const { reconciler, buzz } = await harness();
     await reconciler.reconcile(seed());
@@ -193,9 +249,10 @@ describe('JsonMappingStore', () => {
 
     const migrated = await new JsonMappingStore(path).read();
 
-    expect(migrated.schemaVersion).toBe(3);
+    expect(migrated.schemaVersion).toBe(4);
     expect(migrated.teamPolicies).toEqual({});
     expect(migrated.attentionPolicies).toEqual({});
+    expect(migrated.repositories).toEqual({});
     expect(migrated.mappings['JAC-6'].execution).toMatchObject({
       desiredState: 'archived',
       observedState: 'archived',
@@ -203,6 +260,7 @@ describe('JsonMappingStore', () => {
     });
     expect(migrated.mappings['JAC-6'].lifecycle.deliveries).toEqual([]);
     expect(migrated.mappings['JAC-6'].attention.status).toBe('idle');
+    expect(migrated.mappings['JAC-6'].portfolio.alert.state).toBe('clear');
   });
 
   it('migrates schema-v2 lifecycle state without losing archived mappings', async () => {
@@ -231,10 +289,53 @@ describe('JsonMappingStore', () => {
 
     const migrated = await new JsonMappingStore(path).read();
 
-    expect(migrated.schemaVersion).toBe(3);
+    expect(migrated.schemaVersion).toBe(4);
     expect(migrated.teamPolicies['team-id'].inReview.enabled).toBe(true);
     expect(migrated.mappings['JAC-6'].execution.observedState).toBe('archived');
     expect(migrated.mappings['JAC-6'].attention.status).toBe('idle');
+  });
+
+  it('migrates schema-v3 attention state without losing archived mappings', async () => {
+    const directory = await temporaryDirectory();
+    const path = join(directory, 'mappings.json');
+    const mapping = createMapping(seed(), 'channel-id', '2026-08-14T03:00:00.000Z');
+    mapping.execution.desiredState = 'archived';
+    mapping.execution.observedState = 'archived';
+    mapping.attention.status = 'healthy';
+    const base = structuredClone(mapping) as unknown as Record<string, unknown>;
+    delete base.portfolio;
+    await writeFile(
+      path,
+      JSON.stringify({
+        schemaVersion: 3,
+        teamPolicies: {},
+        attentionPolicies: {
+          'team-id': {
+            'https://github.com/example/repo': {
+              enabled: true,
+              staleAfterSeconds: 60,
+              maxSignals: 100,
+              updatedAt: '2026-08-14T03:30:00.000Z',
+            },
+          },
+        },
+        mappings: { 'JAC-6': { ...base, schemaVersion: 3 } },
+      }),
+      'utf8',
+    );
+
+    const migrated = await new JsonMappingStore(path).read();
+
+    expect(migrated.schemaVersion).toBe(4);
+    expect(migrated.attentionPolicies['team-id']['https://github.com/example/repo'].enabled).toBe(
+      true,
+    );
+    expect(migrated.mappings['JAC-6'].attention.status).toBe('healthy');
+    expect(migrated.mappings['JAC-6'].portfolio).toMatchObject({
+      repositories: [],
+      audits: [],
+      alert: { state: 'clear' },
+    });
   });
 
   it('rejects a duplicate Buzz channel invariant', async () => {

--- a/scripts/ai-workflow/reconcile.ts
+++ b/scripts/ai-workflow/reconcile.ts
@@ -65,6 +65,7 @@ export class WorkflowReconciler {
           mapping,
           data.teamPolicies[mapping.linear.teamId],
           data.attentionPolicies[mapping.linear.teamId]?.[mapping.git.repository],
+          data.repositories,
         );
         const currentCanvas = await this.buzz.getCanvas(mapping.buzz.channelId);
         if (currentCanvas === desiredCanvas) {
@@ -123,6 +124,7 @@ export class WorkflowReconciler {
           mapping,
           data.teamPolicies[mapping.linear.teamId],
           data.attentionPolicies[mapping.linear.teamId]?.[mapping.git.repository],
+          data.repositories,
         );
         if ((await this.buzz.getCanvas(mapping.buzz.channelId)) === finalCanvas) {
           actions.push('final-canvas-current');
@@ -209,6 +211,15 @@ function assertArchiveReady(mapping: TaskMapping, linearState: LinearLifecycleSt
     label.outcome === 'failed'
   ) {
     throw new Error('Archive refused while structured attention is not clear');
+  }
+  if (mapping.portfolio.alert.state === 'attention') {
+    throw new Error('Archive refused while multi-repo portfolio state needs attention');
+  }
+  if (
+    mapping.portfolio.repositories.length > 0 &&
+    mapping.portfolio.audits.at(-1)?.outcome !== 'clear'
+  ) {
+    throw new Error('Archive refused until linked repositories have a current clean audit');
   }
 }
 


### PR DESCRIPTION
## Summary

- migrate the workflow mapping store from schema v3 to v4 without losing Phase 2-4 lifecycle, attention, or archive state
- add an allowlisted GitHub repository registry keyed by immutable provider repository IDs
- link one primary execution repository plus related read-only repositories to a Linear task
- add replay-safe, bounded portfolio audits for Linear, Buzz, GitHub, branch, worktree, and pull-request observations
- block archival while linked repository drift is unresolved or no current clean audit exists

## Safety boundary

- APXM is the live second repository but its product code is unchanged
- observation files are explicit authenticated-operator input and remain outside the repository
- the reconciler never repairs, moves, deletes, or cleans channels, branches, worktrees, or repositories
- credentials, chat, prompts, and code are not stored in the mapping ledger

## Thin slice 005 evidence

- registered `jackinabox86/refined-prun` and `jackinabox86/APXM` by GitHub node ID
- linked refined-prun as the primary execution pointer and APXM as a related read-only repository
- healthy observation: clear; exact replay: no audit or canvas write
- simulated missing primary worktree plus APXM rename contradiction: one structured alert; exact replay: no duplicate alert
- existing attention projector added and cleared Linear `needs-human` without changing lifecycle
- clean recovery observation cleared the portfolio alert; archived JAC-6/JAC-7/JAC-8 mappings remained intact

## Validation

At `b6f01b57f0c97d319f222cf80b0058d14abb82c3`:

- `pnpm run compile`
- `pnpm run test` — 12 files, 113 tests

Linear: https://linear.app/jackinaboxdev/issue/JAC-9/phase-5-add-and-prove-multi-repo-portfolio-reconciliation

Closes #156