### PR TITLE
Restore Firefox automatic extension updates

### DIFF
--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           # Firefox has a separate update stream from Chrome. Existing Firefox builds use this
           # UTC date/run-number format, which must keep increasing for updates.json to apply.
-          version="$(node scripts/firefox-version.mjs \"${{ github.run_number }}\")"
+          version="$(node scripts/firefox-version.mjs "${{ github.run_number }}")"
           npx dot-json@1 "$DIRECTORY/manifest.json" version "$version"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-firefox.yml
+++ b/.github/workflows/release-firefox.yml
@@ -23,10 +23,9 @@ jobs:
       - run: pnpm build
       - name: Stamp version
         run: |
-          # Follows the same release identity as Chrome (VERSION file / CHANGELOG.md), with a
-          # run-number suffix so repeat Firefox-only dispatches against an unchanged VERSION
-          # still strictly increase - required for updates.json to trigger an update check.
-          version="$(cat VERSION).${{ github.run_number }}"
+          # Firefox has a separate update stream from Chrome. Existing Firefox builds use this
+          # UTC date/run-number format, which must keep increasing for updates.json to apply.
+          version="$(node scripts/firefox-version.mjs \"${{ github.run_number }}\")"
           npx dot-json@1 "$DIRECTORY/manifest.json" version "$version"
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `Firefox releases`: Restore the date-stamped version sequence so installed extensions receive automatic updates
+
 ## 1.1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixed
-
-- `Firefox releases`: Restore the date-stamped version sequence so installed extensions receive automatic updates
-
 ## 1.1.1
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,9 +38,9 @@ Verifying UI-visible behaviour against the live game: `docs/browser-testing.md`.
 > **Current Firefox version policy (JAC-11):** Firefox ships the UTC calendar version
 > `YYYY.M.D.<run_number>` (for example, `2026.8.14.19`), calculated by
 > `scripts/firefox-version.mjs`. It must not use Chrome's `VERSION`: `1.1.1.19` is lower than
-> legacy Firefox builds such as `2026.8.9.18`, so it cannot update them. The prior Firefox
-> versioning detail below is superseded by this policy; Chrome and Firefox have independent
-> installed-version streams, while `CHANGELOG.md` remains the cross-store release identity.
+> legacy Firefox builds such as `2026.8.9.18`, so it cannot update them. Chrome and Firefox
+> have independent installed-version streams, while `CHANGELOG.md` remains the cross-store
+> release identity.
 
 All release workflows are `workflow_dispatch` only, and dispatch runs the definition from
 whatever ref you pick — a workflow change has to land on `main` before it affects a real
@@ -49,13 +49,13 @@ release.
 | Workflow | Publishes | Versioning |
 |----------|-----------|------------|
 | `release-chrome.yml` | Chrome Web Store, via the CWS API | semver read from `VERSION`, bumped by a `patch`/`minor`/`major` input, then committed and tagged |
-| `release-firefox.yml` | self-hosted unlisted XPI on GCS, signed by Mozilla, with a generated `updates.json` | reads `VERSION` (doesn't bump it — only Chrome's dispatch does) and appends `.<run_number>`, e.g. `1.2.0.47` |
+| `release-firefox.yml` | self-hosted unlisted XPI on GCS, signed by Mozilla, with a generated `updates.json` | stamps the manifest with the UTC `YYYY.M.D.<run_number>` version from `scripts/firefox-version.mjs`, e.g. `2026.8.14.47`; does not read or bump `VERSION` |
 
-Firefox never bumps `VERSION` itself, so its shipped version only advances when Chrome's
-workflow last bumped it; the `.<run_number>` suffix exists solely so a second Firefox-only
-dispatch against an unchanged `VERSION` still strictly increases — `updates.json`-driven
-auto-update only fires on a version increase. Run the two workflows in either order; Firefox
-just reads whatever `VERSION` currently says.
+Firefox's installed version follows the legacy date-stamped sequence, independently of
+Chrome's `VERSION`: a Chrome-style version such as `1.1.1.19` is lower than existing Firefox
+releases such as `2026.8.9.18`, so it cannot update them. The run-number suffix makes a second
+Firefox dispatch on the same UTC day strictly newer, as required by `updates.json` auto-updates.
+Run the two workflows in either order; Firefox does not read or modify `VERSION`.
 
 (A third workflow, `release.yml`, was inherited from upstream and deleted — it was never
 dispatched and would have failed, wanting `CLIENT_ID`/`CLIENT_SECRET`/`REFRESH_TOKEN`
@@ -71,10 +71,9 @@ Environment-scoped jobs still read repository-level secrets, so adding `environm
 job does not cut it off from existing secrets. It can, however, introduce an approval gate
 if that environment carries protection rules.
 
-Both stores now share the same base version (`VERSION`/`CHANGELOG.md`), but the *installed*
-manifest version still isn't directly comparable across them — Firefox's `.<run_number>`
-suffix and Chrome's plain `X.Y.Z` diverge, and neither is written until each store's own
-build step. Anything that needs a stable, cross-store "release identity" (e.g. `XIT
+Chrome and Firefox have independent installed-version streams: Chrome uses `VERSION` while
+Firefox uses its UTC date/run-number version. Anything that needs a stable, cross-store
+"release identity" (e.g. `XIT
 WHATSNEW`'s changelog view, `src/features/XIT/WHATSNEW/changelog-data.ts`) should still key
 off `CHANGELOG.md`'s own version headings, never `chrome.runtime.getManifest().version` /
 `config.version`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,13 @@ Verifying UI-visible behaviour against the live game: `docs/browser-testing.md`.
 
 ## Release Workflows
 
+> **Current Firefox version policy (JAC-11):** Firefox ships the UTC calendar version
+> `YYYY.M.D.<run_number>` (for example, `2026.8.14.19`), calculated by
+> `scripts/firefox-version.mjs`. It must not use Chrome's `VERSION`: `1.1.1.19` is lower than
+> legacy Firefox builds such as `2026.8.9.18`, so it cannot update them. The prior Firefox
+> versioning detail below is superseded by this policy; Chrome and Firefox have independent
+> installed-version streams, while `CHANGELOG.md` remains the cross-store release identity.
+
 All release workflows are `workflow_dispatch` only, and dispatch runs the definition from
 whatever ref you pick — a workflow change has to land on `main` before it affects a real
 release.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,12 @@
 # scripts/
 
+## `firefox-version.mjs`
+
+Generates Firefox's self-hosted update version as `YYYY.M.D.<GitHub-run-number>` using the UTC
+calendar day. Firefox compares this numeric version against `updates.json`, so it intentionally
+does not use Chrome's `VERSION` value: installed legacy Firefox builds are already in the
+date-stamped sequence.
+
 ## `build-dist.sh`
 
 Builds the extension and packages it as `dist.zip` at the repo root.

--- a/scripts/firefox-version.mjs
+++ b/scripts/firefox-version.mjs
@@ -1,0 +1,20 @@
+import { pathToFileURL } from 'node:url';
+
+export function createFirefoxVersion(date, runNumber) {
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Firefox release version requires a valid date.');
+  }
+
+  const parsedRunNumber = Number(runNumber);
+  if (!Number.isSafeInteger(parsedRunNumber) || parsedRunNumber < 1) {
+    throw new Error('Firefox release version requires a positive integer run number.');
+  }
+
+  return [date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate(), parsedRunNumber].join(
+    '.',
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(createFirefoxVersion(new Date(), process.argv[2]));
+}

--- a/scripts/firefox-version.test.mjs
+++ b/scripts/firefox-version.test.mjs
@@ -1,7 +1,29 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { createFirefoxVersion } from './firefox-version.mjs';
+
+const repositoryDirectory = fileURLToPath(new URL('..', import.meta.url));
+const bashAvailable = spawnSync('bash', ['--version'], { stdio: 'ignore' }).status === 0;
+
+function firefoxStampVersionScript(runNumber) {
+  const workflow = readFileSync(
+    join(repositoryDirectory, '.github/workflows/release-firefox.yml'),
+    'utf8',
+  );
+  const step = workflow.match(
+    /      - name: Stamp version\r?\n        run: \|\r?\n((?:          .*\r?\n?)*)/,
+  );
+
+  if (step === null) {
+    throw new Error('Could not find the Firefox Stamp version workflow step.');
+  }
+
+  return step[1].replace(/^ {10}/gm, '').replace('${{ github.run_number }}', String(runNumber));
+}
 
 function compareVersion(left, right) {
   const leftParts = left.split('.').map(Number);
@@ -43,5 +65,37 @@ describe('createFirefoxVersion', () => {
     );
 
     expect(version).toMatch(/^\d{4}\.\d{1,2}\.\d{1,2}\.19\n$/);
+  });
+
+  it.skipIf(!bashAvailable)('executes the shipped Firefox stamp workflow step under Bash', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'firefox-version-test-'));
+    const binDirectory = join(temporaryDirectory, 'bin');
+    const scriptPath = join(temporaryDirectory, 'stamp-version.sh');
+    const stampedVersionPath = join(temporaryDirectory, 'stamped-version');
+
+    try {
+      mkdirSync(binDirectory);
+      writeFileSync(
+        join(binDirectory, 'npx'),
+        '#!/usr/bin/env bash\nprintf %s "$4" > "$STAMPED_VERSION"\n',
+      );
+      chmodSync(join(binDirectory, 'npx'), 0o755);
+      writeFileSync(scriptPath, firefoxStampVersionScript(19));
+
+      execFileSync('bash', ['-e', scriptPath], {
+        cwd: repositoryDirectory,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          DIRECTORY: join(temporaryDirectory, 'dist'),
+          PATH: `${binDirectory}${delimiter}${process.env.PATH ?? ''}`,
+          STAMPED_VERSION: stampedVersionPath,
+        },
+      });
+
+      expect(readFileSync(stampedVersionPath, 'utf8')).toMatch(/^\d{4}\.\d{1,2}\.\d{1,2}\.19$/);
+    } finally {
+      rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
   });
 });

--- a/scripts/firefox-version.test.mjs
+++ b/scripts/firefox-version.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createFirefoxVersion } from './firefox-version.mjs';
+
+function compareVersion(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+describe('createFirefoxVersion', () => {
+  it('keeps the Firefox update stream above legacy date-stamped releases', () => {
+    const version = createFirefoxVersion(new Date('2026-08-14T12:00:00.000Z'), 19);
+
+    expect(version).toBe('2026.8.14.19');
+    expect(compareVersion(version, '2026.8.9.18')).toBeGreaterThan(0);
+  });
+
+  it('uses the UTC calendar day and run number for repeat-release ordering', () => {
+    const date = new Date('2026-08-14T23:30:00.000Z');
+
+    expect(createFirefoxVersion(date, 19)).toBe('2026.8.14.19');
+    expect(
+      compareVersion(createFirefoxVersion(date, 20), createFirefoxVersion(date, 19)),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/scripts/firefox-version.test.mjs
+++ b/scripts/firefox-version.test.mjs
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { createFirefoxVersion } from './firefox-version.mjs';
 
@@ -27,8 +29,19 @@ describe('createFirefoxVersion', () => {
     const date = new Date('2026-08-14T23:30:00.000Z');
 
     expect(createFirefoxVersion(date, 19)).toBe('2026.8.14.19');
+    expect(createFirefoxVersion(date, '19')).toBe('2026.8.14.19');
     expect(
       compareVersion(createFirefoxVersion(date, 20), createFirefoxVersion(date, 19)),
     ).toBeGreaterThan(0);
+  });
+
+  it('accepts a run number passed on the command line', () => {
+    const version = execFileSync(
+      process.execPath,
+      [fileURLToPath(new URL('./firefox-version.mjs', import.meta.url)), '19'],
+      { encoding: 'utf8' },
+    );
+
+    expect(version).toMatch(/^\d{4}\.\d{1,2}\.\d{1,2}\.19\n$/);
   });
 });


### PR DESCRIPTION
## Summary

- restore Firefox's date-stamped installed-version stream as `YYYY.M.D.<run_number>` in UTC
- add regression coverage for ordering above legacy Firefox releases and later same-day runs
- document the independent Firefox/Chrome version policies

## Why

Firefox's release workflow had begun deriving its manifest version from Chrome's `VERSION`. That produced values such as `1.1.1.19`, which are lower than already-installed date-stamped Firefox releases such as `2026.8.9.18`; Firefox therefore rejected the update described by `updates.json`.

## Impact

New Firefox releases again carry monotonically increasing versions from the installed extension's perspective, so self-hosted automatic updates can apply. Chrome continues to use its existing `VERSION` release identity.

## Validation

- `corepack pnpm test` (9 files, 75 tests)
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec eslint --concurrency auto`
- `corepack pnpm exec vite build`
- `corepack pnpm exec prettier --check` for all six changed files
- `git diff --check`

The repository's Husky hooks could not invoke `pnpm` because this agent process's PATH lacks the Corepack shim; the equivalent checks above passed before commit `bcde45ebb8a42764347be6da87ad435fa539a048` was pushed.