### PR TITLE
[RPR] Fix XIT ACT false abort on successful action feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `shortcut-placeorder`: Type an exchange shortcut and a material ticker (`a dw`) to open the CXPO place-order buffer for that material on that exchange
 
+### Fixed
+
+- `XIT ACT`: Waits for a game action's final success or error state instead of intermittently aborting successful package steps
+
 ## 1.1.1
 
 ### Added

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -203,6 +203,9 @@ the machine, and throws an `ExecutionStopped` sentinel that the step machine's c
 swallows — an `execute()` body never runs past a failed game action. Code after the
 await (e.g. a `watchWhile` for a storage update that will now never come) can rely on
 this; don't wrap `waitActionFeedback` in a step-local try/catch or the hang comes back.
+The feedback overlay is inserted before its state class is guaranteed to be present, so
+wait for the terminal `ActionFeedback.success` / `ActionFeedback.error` selectors; never
+sample `progress` / `success` / `error` once and treat no match as a terminal result.
 
 **`ctx.skip()` and `ctx.fail()` do not unwind `execute()`** — unlike `waitActionFeedback`,
 they just advance/stop the machine and return, so the caller must `return` right after one.

--- a/src/features/XIT/ACT/runner/step-machine.ts
+++ b/src/features/XIT/ACT/runner/step-machine.ts
@@ -20,6 +20,7 @@ interface StepMachineOptions {
 
 const AssertionError = new Error('Assertion failed');
 const ExecutionStopped = new Error('Execution stopped');
+const actionFeedbackTimeoutMs = 30_000;
 
 export class StepMachine {
   private next?: ActionStep;
@@ -206,12 +207,24 @@ async function waitActionFeedback(tile: PrunTile) {
   const outcome = await Promise.race([
     $(tile.frame, C.ActionFeedback.success),
     $(tile.frame, C.ActionFeedback.error),
+    waitActionFeedbackTimeout(),
   ]);
+  if (outcome === undefined) {
+    return 'Timed out waiting for action feedback';
+  }
   if (outcome.classList.contains(C.ActionFeedback.success)) {
     await clickElement(outcome);
     return;
   }
   const message = _$(outcome, C.ActionFeedback.message)?.textContent;
   const dismiss = _$(outcome, C.ActionFeedback.dismiss)?.textContent;
-  return dismiss ? message?.replace(dismiss, '') : message;
+  const error = (dismiss ? message?.replace(dismiss, '') : message)?.trim();
+  if (error === undefined || error.length === 0) {
+    return 'Action failed without an error message';
+  }
+  return error;
+}
+
+async function waitActionFeedbackTimeout() {
+  await sleep(actionFeedbackTimeoutMs);
 }

--- a/src/features/XIT/ACT/runner/step-machine.ts
+++ b/src/features/XIT/ACT/runner/step-machine.ts
@@ -196,39 +196,22 @@ export class StepMachine {
 
 async function waitActionFeedback(tile: PrunTile) {
   const overlay = await $(tile.frame, C.ActionFeedback.overlay);
-  await waitActionProgress(overlay);
   if (overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
     const confirm = _$$(overlay, C.Button.btn)[1];
     if (confirm === undefined) {
       return 'Confirmation overlay is missing confirm button';
     }
     await clickElement(confirm);
-    await waitActionProgress(overlay);
   }
-  if (overlay.classList.contains(C.ActionFeedback.success)) {
-    await clickElement(overlay);
+  const outcome = await Promise.race([
+    $(tile.frame, C.ActionFeedback.success),
+    $(tile.frame, C.ActionFeedback.error),
+  ]);
+  if (outcome.classList.contains(C.ActionFeedback.success)) {
+    await clickElement(outcome);
     return;
   }
-  if (overlay.classList.contains(C.ActionFeedback.error)) {
-    const message = _$(overlay, C.ActionFeedback.message)?.textContent;
-    const dismiss = _$(overlay, C.ActionFeedback.dismiss)?.textContent;
-    return dismiss ? message?.replace(dismiss, '') : message;
-  }
-
-  return 'Unknown action feedback overlay';
-}
-
-async function waitActionProgress(overlay: HTMLElement) {
-  if (!overlay.classList.contains(C.ActionFeedback.progress)) {
-    return;
-  }
-  await new Promise<void>(resolve => {
-    const mutationObserver = new MutationObserver(() => {
-      if (!overlay.classList.contains(C.ActionFeedback.progress)) {
-        mutationObserver.disconnect();
-        resolve();
-      }
-    });
-    mutationObserver.observe(overlay, { attributes: true });
-  });
+  const message = _$(outcome, C.ActionFeedback.message)?.textContent;
+  const dismiss = _$(outcome, C.ActionFeedback.dismiss)?.textContent;
+  return dismiss ? message?.replace(dismiss, '') : message;
 }


### PR DESCRIPTION
## Summary

- wait for XIT ACT action feedback to reach the terminal success or error selector
- preserve the confirmation-overlay click path and existing real error-message handling
- remove the timing-sensitive class sample that produced `Unknown action feedback overlay`
- document the terminal-state rule and add the user-visible changelog entry

## Root cause

The action-feedback element can be inserted before PrUn applies its `progress` class. The old code only waited when `progress` was already present, then sampled `success` / `error` once. In that insertion-to-class gap it falsely classified an in-flight action as unknown and aborted the package, even though the submitted order could later succeed.

## Impact

This prevents ACT from logging one CXPO/MTRA/SHPI step as both failed and successful, and from diverging package state from game state after a real order or transfer was submitted.

## Validation

- `pnpm run compile`
- `pnpm run test` — 76 passed, 1 skipped
- `pnpm run build:fast`
- production bundle inspected for the terminal selector race; neither `waitActionProgress` nor `Unknown action feedback overlay` remains in `src/` or `dist/`

Live-game verification remains required on the configured graphical owner machine. This checkout does not have the required gitignored `.local/` Playwright/profile harness, and `docs/browser-testing.md` explicitly prohibits launching or retrying outside that environment.

Linear: https://linear.app/jackinaboxdev/issue/JAC-12/rpr-fix-xit-act-false-abort-on-successful-action-feedback
Buzz execution channel: `e6783046-43fe-4232-a800-3d015534c7ae`

Closes #162