### PR TITLE
shortcut-placeorder: exchange shortcut commands for the CXPO place-order buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `correct-commands`: Type an exchange shortcut and a material ticker (`a dw`) to open the CXPO place-order buffer for that material on that exchange
+
 ## 1.1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `correct-commands`: Type an exchange shortcut and a material ticker (`a dw`) to open the CXPO place-order buffer for that material on that exchange
+- `shortcut-placeorder`: Type an exchange shortcut and a material ticker (`a dw`) to open the CXPO place-order buffer for that material on that exchange
 
 ## 1.1.1
 

--- a/docs/browser-testing.md
+++ b/docs/browser-testing.md
@@ -203,6 +203,9 @@ Two consequences worth knowing before blaming the browser:
   opens a suggestion dropdown that captures Enter. Press `Escape` first, then Enter — but
   when no suggestion is showing, Escape can clear the field instead, so re-check the value.
   `open-buffer` handles both; see `game/ui-concepts.md` → "Opening a Buffer (Two Paths)".
+  Text the game doesn't recognize as a command is the case where a plain Enter does get
+  through — the dropdown then offers only the literal typed text, so there is no suggestion
+  to capture the key. That is what makes command-rewriting features testable by typing.
 - **Custom XIT panels are not commands.** The extension registers only `XIT` and parses
   the rest as a sub-command (`xit-commands.ts`). `open-buffer DEV` types a bare `DEV` into
   the game's own parser, which silently opens a dead "Illegal command" buffer. Always pass

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -189,6 +189,13 @@ merging" policy existed to avoid: two branches both adding a bullet under `## Un
 can conflict where they land near each other. Resolution is normally trivial (keep both
 bullets) — accept it as the tradeoff for PRs writing their own entries.
 
+One resolution is not trivial: if a release shipped between when the bullet was written and
+when the branch is rebased or cherry-picked onto `main`, the conflict hunk sits under the
+*new version's* `### Added` heading, because the old `## Unreleased` was renamed underneath
+it. Keeping "both sides" there silently backdates the entry into a version that already
+shipped. Move the bullet up under the fresh empty `## Unreleased` instead, and re-create the
+`### Added` subheading there.
+
 ### Editing a PR with `gh`
 
 If `gh pr edit` fails with a Projects (classic) deprecation notice naming

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -830,7 +830,8 @@ natural id, `INV <planet>` → base store, ...) apply it explicitly before calli
 
 A transformer in that chain is not limited to fixing the arguments of a command the game
 knows — it can replace `parts` wholesale and synthesize a different command, which is how
-shorthand the game has never heard of becomes a real buffer. `exchange-order-commands.ts`
+shorthand the game has never heard of becomes a real buffer. A standalone feature
+registers into the chain via `addCommandTransformer`; `src/features/basic/shortcut-placeorder.ts`
 turns `<exchange key> <ticker>` into `CXPO <TICKER>.<MIC>` (`a dw` → `CXPO DW.AI1`).
 
 This works because the game's command `<form>` fires `submit` for *any* typed text: an

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -826,6 +826,25 @@ own command-input `<form>`, so it covers what the player types and nothing else 
 that is already in its final form, and if a feature depends on a correction (planet name →
 natural id, `INV <planet>` → base store, ...) apply it explicitly before calling `showBuffer`.
 
+### Inventing New Typed Commands
+
+A transformer in that chain is not limited to fixing the arguments of a command the game
+knows — it can replace `parts` wholesale and synthesize a different command, which is how
+shorthand the game has never heard of becomes a real buffer. `exchange-order-commands.ts`
+turns `<exchange key> <ticker>` into `CXPO <TICKER>.<MIC>` (`a dw` → `CXPO DW.AI1`).
+
+This works because the game's command `<form>` fires `submit` for *any* typed text: an
+unrecognized first token reaches the submit listener exactly like a valid one, and the
+rewrite lands before the game ever parses it. (The react-autosuggest dropdown offers only
+the literal typed text when nothing matches, so it has no suggestion to swallow the
+Enter — see `docs/browser-testing.md` → "Opening and targeting windows".)
+
+Gate such a transformer on all of: an exact token count, a first token in an explicit
+shortcut table, and a second token that resolves against a store (`materialsStore
+.getByTicker`). Anything that fails a guard must leave `parts` untouched so it falls
+through to the game's own parser. Keep real command names out of the shortcut table
+(`arc` was dropped from the Arclight keys because `ARC` opens the representation center).
+
 ### Auto-Opening a Buffer Once at Startup
 
 For a panel that should open itself once, based on a condition, without the player typing

--- a/src/features/basic/correct-commands/correct-commands.ts
+++ b/src/features/basic/correct-commands/correct-commands.ts
@@ -1,4 +1,5 @@
 import { changeInputValue } from '@src/util';
+import { correctExchangeOrderCommand } from './exchange-order-commands';
 import { correctMaterialCommand } from './material-commands';
 import { correctPlanetCommand } from './planet-commands';
 import { correctShipCommand } from './ship-commands';
@@ -7,6 +8,7 @@ import { correctXitWeb } from './xit-web';
 import { correctXitArgs } from '@src/infrastructure/prun-ui/buffers';
 
 const transformers = [
+  correctExchangeOrderCommand,
   correctMaterialCommand,
   correctPlanetCommand,
   correctShipCommand,

--- a/src/features/basic/correct-commands/correct-commands.ts
+++ b/src/features/basic/correct-commands/correct-commands.ts
@@ -1,5 +1,4 @@
 import { changeInputValue } from '@src/util';
-import { correctExchangeOrderCommand } from './exchange-order-commands';
 import { correctMaterialCommand } from './material-commands';
 import { correctPlanetCommand } from './planet-commands';
 import { correctShipCommand } from './ship-commands';
@@ -8,7 +7,6 @@ import { correctXitWeb } from './xit-web';
 import { correctXitArgs } from '@src/infrastructure/prun-ui/buffers';
 
 const transformers = [
-  correctExchangeOrderCommand,
   correctMaterialCommand,
   correctPlanetCommand,
   correctShipCommand,
@@ -16,6 +14,10 @@ const transformers = [
   correctXitWeb,
   correctXitArgs,
 ];
+
+export function addCommandTransformer(transform: (parts: string[]) => void) {
+  transformers.push(transform);
+}
 
 async function onSelectorReady(selector: HTMLElement) {
   const input: HTMLInputElement = await $(selector, C.PanelSelector.input);

--- a/src/features/basic/correct-commands/exchange-order-commands.ts
+++ b/src/features/basic/correct-commands/exchange-order-commands.ts
@@ -1,0 +1,40 @@
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+
+const exchangeShortcuts = new Map<string, string>([
+  ['a', 'AI1'],
+  ['ant', 'AI1'],
+  ['antares', 'AI1'],
+  ['b', 'CI1'],
+  ['ben', 'CI1'],
+  ['benten', 'CI1'],
+  ['l', 'CI2'],
+  ['arcl', 'CI2'],
+  ['arclight', 'CI2'],
+  ['i', 'IC1'],
+  ['hor', 'IC1'],
+  ['hortus', 'IC1'],
+  ['h', 'NC2'],
+  ['hub', 'NC2'],
+  ['hubur', 'NC2'],
+  ['m', 'NC1'],
+  ['mor', 'NC1'],
+  ['moria', 'NC1'],
+]);
+
+export function correctExchangeOrderCommand(parts: string[]) {
+  if (parts.length !== 2) {
+    return;
+  }
+
+  const mic = exchangeShortcuts.get(parts[0].toLowerCase());
+  if (mic === undefined) {
+    return;
+  }
+
+  const material = materialsStore.getByTicker(parts[1]);
+  if (material === undefined) {
+    return;
+  }
+
+  parts.splice(0, parts.length, 'CXPO', `${material.ticker}.${mic}`);
+}

--- a/src/features/basic/shortcut-placeorder.ts
+++ b/src/features/basic/shortcut-placeorder.ts
@@ -1,4 +1,5 @@
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { addCommandTransformer } from '@src/features/basic/correct-commands/correct-commands';
 
 const exchangeShortcuts = new Map<string, string>([
   ['a', 'AI1'],
@@ -21,7 +22,7 @@ const exchangeShortcuts = new Map<string, string>([
   ['moria', 'NC1'],
 ]);
 
-export function correctExchangeOrderCommand(parts: string[]) {
+function transform(parts: string[]) {
   if (parts.length !== 2) {
     return;
   }
@@ -38,3 +39,13 @@ export function correctExchangeOrderCommand(parts: string[]) {
 
   parts.splice(0, parts.length, 'CXPO', `${material.ticker}.${mic}`);
 }
+
+function init() {
+  addCommandTransformer(transform);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'CXPO: Opens the place order buffer by typing an exchange shortcut and a material ticker, like "a dw".',
+);


### PR DESCRIPTION
New feature `shortcut-placeorder`. Type a short exchange key plus a material ticker into any tile's command input and it becomes a CXPO place-order command before the buffer opens:

```
a dw     ->  CXPO DW.AI1
ben rat  ->  CXPO RAT.CI1
m h2o    ->  CXPO H2O.NC1
```

| key | MIC | exchange |
|---|---|---|
| `a` / `ant` / `antares` | AI1 | Antares |
| `b` / `ben` / `benten` | CI1 | Benten |
| `l` / `arcl` / `arclight` | CI2 | Arclight |
| `i` / `hor` / `hortus` | IC1 | Hortus |
| `h` / `hub` / `hubur` | NC2 | Hubur |
| `m` / `mor` / `moria` | NC1 | Moria |

## How

`src/features/basic/shortcut-placeorder.ts` is a normal feature file — its own id, its own toggle in `XIT SET` — that registers a transformer into the existing `correct-commands` chain through a new exported `addCommandTransformer()`. That chain already intercepts the command input's `submit`, rewrites the value and re-submits, so the rewrite lands before the game parses anything.

The transformer fires only when there are exactly two tokens, the first is in the shortcut table (case-insensitive) and the second resolves to a real material ticker; anything else is left untouched and falls through to the game's parser. `arc` is deliberately not a key, so the real `ARC` command is not shadowed.

## Verification

`pnpm run compile` clean. Checked against the live game before and after the refactor:

- `a dw`, `ben rat`, `M H2O`, `hub rat` open the expected `CXPO <TICKER>.<MIC>` buffers with the right Exchange and Material fields
- a single Enter submits — the suggestion dropdown does not swallow it for an unrecognized command
- `a xyzzy` falls through to the game's normal `Illegal command` buffer
- `MAT DW` and `ARC` behave exactly as before
- `shortcut-placeorder` appears as a toggleable entry in `XIT SET` → Features; no extension errors in the console

Docs commit records the command-rewriting pattern, the Enter behaviour for unknown commands, and a changelog-rebase trap hit while preparing this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dRMxzhwb3QHVpQS1N8BRa
