### PR TITLE
Open full XIT Dispatch burn and repair buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `shortcut-placeorder`: Type an exchange shortcut and a material ticker (`a dw`) to open the CXPO place-order buffer for that material on that exchange
+- `XIT DISPATCH`: Clicking a planet's Burn or Repair value opens its detailed XIT BURN or XIT REP buffer
 
 ### Fixed
 

--- a/src/features/XIT/DISPATCH/PlanetRow.vue
+++ b/src/features/XIT/DISPATCH/PlanetRow.vue
@@ -9,6 +9,7 @@ import { getPlanetBurn } from '@src/core/burn';
 import { burnDaysClass, countDays, formatBurnDays } from '@src/features/XIT/BURN/utils';
 import { getRepairOffset, getRepairThreshold } from '@src/core/buildings';
 import { getPlanetRepairAge } from '@src/features/XIT/REP/entries';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { timestampEachMinute } from '@src/utils/dayjs';
 import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { fixed0 } from '@src/utils/format';
@@ -153,7 +154,9 @@ function clearShip() {
     </td>
     <td :class="$style.statusCell">
       <div :class="[$style.statusContent, burnBgClass]">
-        <span :class="$style.statusNum">{{ daysText }}</span>
+        <span :class="$style.statusNum" @click="showBuffer(`XIT BURN ${naturalId}`)">{{
+          daysText
+        }}</span>
       </div>
     </td>
     <td :class="$style.toggleCell">
@@ -161,7 +164,9 @@ function clearShip() {
     </td>
     <td :class="$style.statusCell">
       <div :class="[$style.statusContent, repairBgClass]">
-        <span :class="$style.statusNum">{{ repairDaysText }}</span>
+        <span :class="$style.statusNum" @click="showBuffer(`XIT REP ${naturalId}`)">{{
+          repairDaysText
+        }}</span>
       </div>
     </td>
     <td

--- a/src/features/XIT/DISPATCH/PlanetRow.vue
+++ b/src/features/XIT/DISPATCH/PlanetRow.vue
@@ -153,20 +153,20 @@ function clearShip() {
       <RadioItem v-model="config.resupply" />
     </td>
     <td :class="$style.statusCell">
-      <div :class="[$style.statusContent, burnBgClass]">
-        <span :class="$style.statusNum" @click="showBuffer(`XIT BURN ${naturalId}`)">{{
-          daysText
-        }}</span>
+      <div
+        :class="[$style.statusContent, burnBgClass]"
+        @click="showBuffer(`XIT BURN ${naturalId}`)">
+        <span :class="$style.statusNum">{{ daysText }}</span>
       </div>
     </td>
     <td :class="$style.toggleCell">
       <RadioItem v-model="config.repair" />
     </td>
     <td :class="$style.statusCell">
-      <div :class="[$style.statusContent, repairBgClass]">
-        <span :class="$style.statusNum" @click="showBuffer(`XIT REP ${naturalId}`)">{{
-          repairDaysText
-        }}</span>
+      <div
+        :class="[$style.statusContent, repairBgClass]"
+        @click="showBuffer(`XIT REP ${naturalId}`)">
+        <span :class="$style.statusNum">{{ repairDaysText }}</span>
       </div>
     </td>
     <td
@@ -243,6 +243,7 @@ function clearShip() {
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
   height: 18px;
   box-sizing: border-box;
   padding: 2px 4px;


### PR DESCRIPTION
## Summary

- Open `XIT BURN <planet>` when the Dispatch Burn value is clicked.
- Open `XIT REP <planet>` when the Dispatch Repair value is clicked.
- Document the behavior under the Unreleased changelog.

## Why

Dispatch exposed the burn and repair values but did not provide a direct route to the full related buffers.

## Validation

- `pnpm run compile`
- `pnpm test` — 9 files passed; 76 tests passed, 1 skipped

Claude Opus independently reviewed the implementation and found no blocking issues.