### PR TITLE
Fix doubled bullet in 1.1.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `XIT GOVBURN`: Import a planet's POPI plan from JSON in the config pane, with a preview of what it overwrites
 - `bs-inv-base-store-link`: Makes the `INV` context link on `BS` open the base store directly
 - `XIT BS`: Shows a green 🚀 next to a base's inventory bar 24 hours before its produced goods fill the ship picked in `XIT PLANETS`, and hides it while a ship is already in flight there
-- - `XIT PLANETS`: New Pickup column allows users to specify a size of ship to receive an alert for when sufficient goods will be produced to fill it within 24 hours
+- `XIT PLANETS`: New Pickup column allows users to specify a size of ship to receive an alert for when sufficient goods will be produced to fill it within 24 hours
 - `production-companion-buffers`: Shift-click a production line button in PROD, PRODQ or PRODCO to open PRODCO and PRODQ side by side as a companion pair
 
 ### Changed


### PR DESCRIPTION
The `XIT PLANETS` Pickup column entry in the shipped **1.1.1** section starts with `- - ` instead of `- `.

`changelog-data.ts:37` parses items with `/^- (.+)$/`, so the capture group keeps the second `- `, and `WHATSNEW.vue` renders `{{ item }}` raw. XIT WHATSNEW therefore prints that line with a literal leading `- ` in the release-notes archive.

One-character fix, no code change. Found while clearing PRs ahead of the next release.
