### PR TITLE
[RPR] Add passive burn, repair, and planet-settings data sources

### DIFF
--- a/docs/data-catalog.md
+++ b/docs/data-catalog.md
@@ -20,6 +20,11 @@ Request-wrapped stores expose a separate `peek()` path for the catalog. CX and F
 their passive entity-store view separately from their request-on-read `all` computed. Tests cover these
 boundaries.
 
+The game source catalog transitively imports `core/repair` → `core/buildings` → `infrastructure/fio/cx`,
+whose module initializer calls `dayjs.duration`. The application initializes the Day.js plugins first in
+`refined-prun.ts`; standalone tests or entry points that import the catalog must likewise import
+`@src/utils/dayjs` first.
+
 The only catalog operation allowed to request data is an explicit human click on **LOAD FROM PRUN** in
 `XIT DATA`. The selected descriptor must declare a loader. Production and workforce loaders also
 require a valid site ID already present in the sites store.
@@ -92,6 +97,8 @@ Rules:
 - Text search is a case-insensitive substring search over the serialized row.
 - Sorting keeps missing and null values last in both directions. Unlike types fall back to string
   comparison.
+- Burn rows use `Number.POSITIVE_INFINITY` for `daysLeft` when net production is non-negative. The JSON
+  clone and export path serializes that value to `null`, so it sorts as missing in both directions.
 - The default limit is 250. Limits above 5,000 are capped at 5,000; invalid non-positive or
   non-integer limits are rejected.
 

--- a/src/core/burn.ts
+++ b/src/core/burn.ts
@@ -33,39 +33,54 @@ export interface PlanetBurn {
   burn: BurnValues;
 }
 
-const burnBySiteId = computed(() => {
-  if (!sitesStore.all.value) {
-    return undefined;
-  }
+const burnBySiteId = createBurnBySiteId(
+  id => workforcesStore.getById(id)?.workforces,
+  id => productionStore.getBySiteId(id),
+);
 
-  const bySiteId = new Map<string, Ref<PlanetBurn | undefined>>();
-  for (const site of sitesStore.all.value) {
-    bySiteId.set(
-      site.siteId,
-      computed(() => {
-        const id = site.siteId;
-        const workforce = workforcesStore.getById(id)?.workforces;
-        const production = productionStore.getBySiteId(id);
-        const storage = storagesStore.getByAddressableId(id);
-        if (!workforce || !production) {
-          return undefined;
-        }
+const passiveBurnBySiteId = createBurnBySiteId(
+  id => workforcesStore.passiveGetById(id)?.workforces,
+  id => productionStore.passiveGetBySiteId(id),
+);
 
-        const naturalId = getEntityNaturalIdFromAddress(site.address);
-        const inboundStores = getInboundShipStores(naturalId);
-        const combinedStorage = [...(storage ?? []), ...inboundStores];
+function createBurnBySiteId(
+  getWorkforces: (siteId: string) => PrunApi.Workforce[] | undefined,
+  getProduction: (siteId: string) => PrunApi.ProductionLine[] | undefined,
+) {
+  return computed(() => {
+    if (!sitesStore.all.value) {
+      return undefined;
+    }
 
-        return {
-          storeId: storage?.[0]?.id,
-          planetName: getEntityNameFromAddress(site.address),
-          naturalId,
-          burn: calculatePlanetBurn(production, workforce, combinedStorage),
-        } as PlanetBurn;
-      }),
-    );
-  }
-  return bySiteId;
-});
+    const bySiteId = new Map<string, Ref<PlanetBurn | undefined>>();
+    for (const site of sitesStore.all.value) {
+      bySiteId.set(
+        site.siteId,
+        computed(() => {
+          const id = site.siteId;
+          const workforce = getWorkforces(id);
+          const production = getProduction(id);
+          const storage = storagesStore.getByAddressableId(id);
+          if (!workforce || !production) {
+            return undefined;
+          }
+
+          const naturalId = getEntityNaturalIdFromAddress(site.address);
+          const inboundStores = getInboundShipStores(naturalId);
+          const combinedStorage = [...(storage ?? []), ...inboundStores];
+
+          return {
+            storeId: storage?.[0]?.id,
+            planetName: getEntityNameFromAddress(site.address),
+            naturalId,
+            burn: calculatePlanetBurn(production, workforce, combinedStorage),
+          } as PlanetBurn;
+        }),
+      );
+    }
+    return bySiteId;
+  });
+}
 
 // Ships currently in flight towards the planet. A landed ship has no flightId,
 // so this is exactly "dispatched but not arrived yet". Unlike
@@ -122,12 +137,23 @@ export function setInboundShipInventoryEnabled(value: boolean) {
 }
 
 export function getPlanetBurn(siteOrId?: PrunApi.Site | string | null) {
+  return getPlanetBurnFromMap(burnBySiteId, siteOrId);
+}
+
+export function getPlanetBurnPassive(siteOrId?: PrunApi.Site | string | null) {
+  return getPlanetBurnFromMap(passiveBurnBySiteId, siteOrId);
+}
+
+function getPlanetBurnFromMap(
+  bySiteId: Ref<Map<string, Ref<PlanetBurn | undefined>> | undefined>,
+  siteOrId?: PrunApi.Site | string | null,
+) {
   const site = typeof siteOrId === 'string' ? sitesStore.getById(siteOrId) : siteOrId;
   if (!site) {
     return undefined;
   }
 
-  return burnBySiteId.value?.get(site.siteId)?.value;
+  return bySiteId.value?.get(site.siteId)?.value;
 }
 
 export function calculatePlanetBurn(

--- a/src/core/repair.ts
+++ b/src/core/repair.ts
@@ -1,0 +1,61 @@
+import { getBuildingBuildMaterials, isRepairableBuilding } from '@src/core/buildings';
+import {
+  getEntityNameFromAddress,
+  getEntityNaturalIdFromAddress,
+} from '@src/infrastructure/prun-api/data/addresses';
+import { getBuildingLastRepair } from '@src/infrastructure/prun-api/data/sites';
+import { getShipLastRepair } from '@src/infrastructure/prun-api/data/ships';
+
+export interface RepairEntry {
+  ticker: string;
+  target: string;
+  naturalId: string;
+  lastRepair: number;
+  condition: number;
+  materials: PrunApi.MaterialAmount[];
+  fullMaterials: PrunApi.MaterialAmount[];
+}
+
+export function calculateBuildingEntries(sites?: PrunApi.Site[]) {
+  if (!sites) {
+    return undefined;
+  }
+  const entries: RepairEntry[] = [];
+  for (const site of sites) {
+    const target = getEntityNameFromAddress(site.address)!;
+    const naturalId = getEntityNaturalIdFromAddress(site.address)!;
+    for (const building of site.platforms.filter(isRepairableBuilding)) {
+      entries.push({
+        ticker: building.module.reactorTicker,
+        target,
+        naturalId,
+        lastRepair: getBuildingLastRepair(building),
+        condition: building.condition,
+        materials: building.repairMaterials,
+        fullMaterials: getBuildingBuildMaterials(building, site),
+      });
+    }
+  }
+  entries.sort((a, b) => a.condition - b.condition);
+  return entries;
+}
+
+export function calculateShipEntries(ships?: PrunApi.Ship[]) {
+  if (!ships) {
+    return undefined;
+  }
+  const entries: RepairEntry[] = [];
+  for (const ship of ships) {
+    entries.push({
+      ticker: ship.name,
+      target: ship.name,
+      naturalId: 'SHIP',
+      lastRepair: getShipLastRepair(ship),
+      condition: ship.condition,
+      materials: ship.repairMaterials,
+      fullMaterials: ship.repairMaterials,
+    });
+  }
+  entries.sort((a, b) => a.condition - b.condition);
+  return entries;
+}

--- a/src/features/XIT/REP/entries.ts
+++ b/src/features/XIT/REP/entries.ts
@@ -1,22 +1,11 @@
+import { isRepairableBuilding } from '@src/core/buildings';
 import { getBuildingLastRepair, sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { getShipLastRepair, shipsStore } from '@src/infrastructure/prun-api/data/ships';
-import {
-  getEntityNameFromAddress,
-  getEntityNaturalIdFromAddress,
-} from '@src/infrastructure/prun-api/data/addresses';
-import { getBuildingBuildMaterials, isRepairableBuilding } from '@src/core/buildings';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
 import { diffDays } from '@src/utils/time-diff';
 import { isEmpty } from 'ts-extras';
 
-export interface RepairEntry {
-  ticker: string;
-  target: string;
-  naturalId: string;
-  lastRepair: number;
-  condition: number;
-  materials: PrunApi.MaterialAmount[];
-  fullMaterials: PrunApi.MaterialAmount[];
-}
+export { calculateBuildingEntries, calculateShipEntries } from '@src/core/repair';
+export type { RepairEntry } from '@src/core/repair';
 
 export function getParameterSites(parameters: string[]) {
   let sites: PrunApi.Site[] = [];
@@ -35,30 +24,6 @@ export function getParameterSites(parameters: string[]) {
   return sites;
 }
 
-export function calculateBuildingEntries(sites?: PrunApi.Site[]) {
-  if (!sites) {
-    return undefined;
-  }
-  const entries: RepairEntry[] = [];
-  for (const site of sites) {
-    const target = getEntityNameFromAddress(site.address)!;
-    const naturalId = getEntityNaturalIdFromAddress(site.address)!;
-    for (const building of site.platforms.filter(isRepairableBuilding)) {
-      entries.push({
-        ticker: building.module.reactorTicker,
-        target,
-        naturalId,
-        lastRepair: getBuildingLastRepair(building),
-        condition: building.condition,
-        materials: building.repairMaterials,
-        fullMaterials: getBuildingBuildMaterials(building, site),
-      });
-    }
-  }
-  entries.sort((a, b) => a.condition - b.condition);
-  return entries;
-}
-
 export function getParameterShips(parameters: string[]) {
   let ships: PrunApi.Ship[] = [];
   if (parameters.length === 0 || parameters.some(isShipParameter)) {
@@ -68,26 +33,6 @@ export function getParameterShips(parameters: string[]) {
     ships = shipsStore.all.value;
   }
   return ships;
-}
-
-export function calculateShipEntries(ships?: PrunApi.Ship[]) {
-  if (!ships) {
-    return undefined;
-  }
-  const entries: RepairEntry[] = [];
-  for (const ship of ships) {
-    entries.push({
-      ticker: ship.name,
-      target: ship.name,
-      naturalId: 'SHIP',
-      lastRepair: getShipLastRepair(ship),
-      condition: ship.condition,
-      materials: ship.repairMaterials,
-      fullMaterials: ship.repairMaterials,
-    });
-  }
-  entries.sort((a, b) => a.condition - b.condition);
-  return entries;
 }
 
 export function getPlanetRepairAge(siteId: string, now: number) {

--- a/src/infrastructure/data-catalog/game-sources.test.ts
+++ b/src/infrastructure/data-catalog/game-sources.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import '@src/utils/dayjs';
 import { DataCatalog } from '@src/core/data-query/catalog';
 import { gameDataSources } from '@src/infrastructure/data-catalog/game-sources';
 import { request } from '@src/infrastructure/prun-api/data/request-hooks';
@@ -7,6 +8,7 @@ const expectedSourceIds = [
   'alerts',
   'balances',
   'blueprints',
+  'burn',
   'company',
   'contract-drafts',
   'contracts',
@@ -24,7 +26,9 @@ const expectedSourceIds = [
   'material-categories',
   'materials',
   'planets',
+  'planet-settings',
   'production',
+  'repair',
   'sectors',
   'ships',
   'shipyard-projects',

--- a/src/infrastructure/data-catalog/game-sources.test.ts
+++ b/src/infrastructure/data-catalog/game-sources.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import '@src/utils/dayjs';
 import { DataCatalog } from '@src/core/data-query/catalog';
 import { gameDataSources } from '@src/infrastructure/data-catalog/game-sources';
+import { dispatch } from '@src/infrastructure/prun-api/data/api-messages';
 import { request } from '@src/infrastructure/prun-api/data/request-hooks';
 
 const expectedSourceIds = [
@@ -25,8 +26,8 @@ const expectedSourceIds = [
   'local-ads',
   'material-categories',
   'materials',
-  'planets',
   'planet-settings',
+  'planets',
   'production',
   'repair',
   'sectors',
@@ -41,6 +42,11 @@ const expectedSourceIds = [
   'warehouses',
   'workforces',
 ];
+
+afterEach(() => {
+  dispatch({ type: 'CLIENT_CONNECTION_OPENED' });
+  vi.restoreAllMocks();
+});
 
 describe('game data sources', () => {
   it('catalogs the explicit gameplay source set with declared provenance and loaders', () => {
@@ -72,6 +78,30 @@ describe('game data sources', () => {
       catalog.query({ sourceId });
       catalog.export({ sourceId });
     }
+    for (const spy of requestSpies) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('snapshots burn for loaded sites without requesting missing data', () => {
+    const requestSpies = Object.keys(request).map(key =>
+      vi.spyOn(request, key as keyof typeof request).mockImplementation(() => undefined),
+    );
+    const site: PrunApi.Site = {
+      siteId: 'site-1',
+      address: { lines: [] },
+      founded: { timestamp: 0 },
+      platforms: [],
+      buildOptions: { options: [] },
+      area: 0,
+      investedPermits: 0,
+      maximumPermits: 0,
+    };
+    dispatch({ type: 'SITE_SITES', data: { sites: [site] } });
+
+    const catalog = new DataCatalog(gameDataSources);
+
+    expect(catalog.snapshot('burn').rows).toEqual([]);
     for (const spy of requestSpies) {
       expect(spy).not.toHaveBeenCalled();
     }

--- a/src/infrastructure/data-catalog/game-sources.test.ts
+++ b/src/infrastructure/data-catalog/game-sources.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+// Mirrors the app's Day.js setup required by core/repair → core/buildings → fio/cx.
 import '@src/utils/dayjs';
+import { getPlanetBurn, getPlanetBurnPassive } from '@src/core/burn';
 import { DataCatalog } from '@src/core/data-query/catalog';
 import { gameDataSources } from '@src/infrastructure/data-catalog/game-sources';
 import { dispatch } from '@src/infrastructure/prun-api/data/api-messages';
@@ -42,6 +44,41 @@ const expectedSourceIds = [
   'warehouses',
   'workforces',
 ];
+
+function createSite(siteId: string, naturalId: string): PrunApi.Site {
+  return {
+    siteId,
+    address: {
+      lines: [
+        {
+          type: 'SYSTEM',
+          entity: { id: 'system-1', naturalId: 'OT', name: 'OT' },
+        },
+        {
+          type: 'PLANET',
+          entity: { id: `planet-${naturalId}`, naturalId, name: naturalId },
+        },
+      ],
+    },
+    founded: { timestamp: 0 },
+    platforms: [],
+    buildOptions: { options: [] },
+    area: 0,
+    investedPermits: 0,
+    maximumPermits: 0,
+  };
+}
+
+function dispatchBurnData(site: PrunApi.Site) {
+  dispatch({
+    type: 'WORKFORCE_WORKFORCES',
+    data: { address: site.address, siteId: site.siteId, workforces: [] },
+  });
+  dispatch({
+    type: 'PRODUCTION_SITE_PRODUCTION_LINES',
+    data: { siteId: site.siteId, productionLines: [] },
+  });
+}
 
 afterEach(() => {
   dispatch({ type: 'CLIENT_CONNECTION_OPENED' });
@@ -87,21 +124,50 @@ describe('game data sources', () => {
     const requestSpies = Object.keys(request).map(key =>
       vi.spyOn(request, key as keyof typeof request).mockImplementation(() => undefined),
     );
-    const site: PrunApi.Site = {
-      siteId: 'site-1',
-      address: { lines: [] },
-      founded: { timestamp: 0 },
-      platforms: [],
-      buildOptions: { options: [] },
-      area: 0,
-      investedPermits: 0,
-      maximumPermits: 0,
-    };
+    const site = createSite('site-1', 'OT-580b');
     dispatch({ type: 'SITE_SITES', data: { sites: [site] } });
 
     const catalog = new DataCatalog(gameDataSources);
 
-    expect(catalog.snapshot('burn').rows).toEqual([]);
+    expect(catalog.snapshot('burn')).toMatchObject({
+      source: { completeness: 'not-loaded' },
+      rows: [],
+    });
+    for (const spy of requestSpies) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('reports and snapshots passively loaded burn data', () => {
+    const requestSpies = Object.keys(request).map(key =>
+      vi.spyOn(request, key as keyof typeof request).mockImplementation(() => undefined),
+    );
+    const sites = [createSite('site-1', 'OT-580b'), createSite('site-2', 'OT-580c')];
+    const catalog = new DataCatalog(gameDataSources);
+
+    expect(catalog.snapshot('burn')).toMatchObject({
+      source: { completeness: 'not-loaded' },
+      rows: undefined,
+    });
+
+    dispatch({ type: 'SITE_SITES', data: { sites } });
+    dispatchBurnData(sites[0]);
+
+    const partial = catalog.snapshot('burn');
+    expect(partial.source.completeness).toBe('partial');
+    expect(partial.rows).toHaveLength(1);
+    const passiveBurn = getPlanetBurnPassive(sites[0]);
+    expect(passiveBurn).toBeDefined();
+    expect(passiveBurn).toEqual(getPlanetBurn(sites[0]));
+
+    dispatchBurnData(sites[1]);
+
+    const complete = catalog.snapshot('burn');
+    expect(complete.source.completeness).toBe('complete');
+    expect(complete.rows).toHaveLength(2);
+    expect(complete.rows).toEqual(
+      expect.arrayContaining([expect.objectContaining({ naturalId: 'OT-580b' })]),
+    );
     for (const spy of requestSpies) {
       expect(spy).not.toHaveBeenCalled();
     }

--- a/src/infrastructure/data-catalog/game-sources.ts
+++ b/src/infrastructure/data-catalog/game-sources.ts
@@ -1,7 +1,7 @@
 import { createCollectionSource, createRecordSource } from '@src/core/data-query/catalog';
 import { DataCompleteness, DataSourceDescriptor, DataProvenance } from '@src/core/data-query/types';
 import { getPlanetBurnPassive } from '@src/core/burn';
-import { calculateBuildingEntries, calculateShipEntries } from '@src/features/XIT/REP/entries';
+import { calculateBuildingEntries, calculateShipEntries } from '@src/core/repair';
 import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
 import { balancesStore } from '@src/infrastructure/prun-api/data/balances';
 import { blueprintsStore } from '@src/infrastructure/prun-api/data/blueprints';

--- a/src/infrastructure/data-catalog/game-sources.ts
+++ b/src/infrastructure/data-catalog/game-sources.ts
@@ -1,6 +1,6 @@
 import { createCollectionSource, createRecordSource } from '@src/core/data-query/catalog';
 import { DataCompleteness, DataSourceDescriptor, DataProvenance } from '@src/core/data-query/types';
-import { getPlanetBurn } from '@src/core/burn';
+import { getPlanetBurnPassive } from '@src/core/burn';
 import { calculateBuildingEntries, calculateShipEntries } from '@src/features/XIT/REP/entries';
 import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
 import { balancesStore } from '@src/infrastructure/prun-api/data/balances';
@@ -115,7 +115,7 @@ export const gameDataSources: DataSourceDescriptor[] = [
     description: 'Calculated burn data for the company\u2019s sites.',
     provenance: 'prun-live',
     completeness: fetchedCompleteness(sitesStore.fetched),
-    snapshot: () => sitesStore.all.value?.map(getPlanetBurn).filter(x => x !== undefined),
+    snapshot: () => sitesStore.all.value?.map(getPlanetBurnPassive).filter(x => x !== undefined),
   }),
   createRecordSource({
     id: 'company',
@@ -224,14 +224,6 @@ export const gameDataSources: DataSourceDescriptor[] = [
     description: 'PrUn material definitions.',
     store: materialsStore,
   }),
-  entitySource({
-    id: 'planets',
-    label: 'Planets',
-    description: 'FIO fallback planet reference data patched with selected live PrUn fields.',
-    provenance: 'fio-reference-with-prun-overrides',
-    warning: fioWarning,
-    store: planetsStore,
-  }),
   createRecordSource({
     id: 'planet-settings',
     label: 'Planet Settings',
@@ -252,6 +244,14 @@ export const gameDataSources: DataSourceDescriptor[] = [
         planetOverrides: userData.settings.repair.planetOverrides,
       },
     }),
+  }),
+  entitySource({
+    id: 'planets',
+    label: 'Planets',
+    description: 'FIO fallback planet reference data patched with selected live PrUn fields.',
+    provenance: 'fio-reference-with-prun-overrides',
+    warning: fioWarning,
+    store: planetsStore,
   }),
   createCollectionSource({
     id: 'production',
@@ -283,10 +283,17 @@ export const gameDataSources: DataSourceDescriptor[] = [
       }
       return sitesFetched && shipsFetched ? 'complete' : 'partial';
     },
-    snapshot: () => [
-      ...(calculateBuildingEntries(sitesStore.all.value) ?? []),
-      ...(calculateShipEntries(shipsStore.all.value) ?? []),
-    ],
+    snapshot: () => {
+      const buildingEntries = calculateBuildingEntries(sitesStore.all.value);
+      const shipEntries = calculateShipEntries(shipsStore.all.value);
+      if (buildingEntries === undefined) {
+        return shipEntries;
+      }
+      if (shipEntries === undefined) {
+        return buildingEntries;
+      }
+      return [...buildingEntries, ...shipEntries];
+    },
   }),
   entitySource({
     id: 'sectors',

--- a/src/infrastructure/data-catalog/game-sources.ts
+++ b/src/infrastructure/data-catalog/game-sources.ts
@@ -89,6 +89,22 @@ function fetchedCompleteness(fetched: Ref<boolean>, partial = false) {
 const blueprintsState = blueprintsStore.peek();
 const shipyardProjectsState = shipyardProjectsStore.peek();
 
+function getBurnRows() {
+  return sitesStore.all.value?.map(getPlanetBurnPassive).filter(x => x !== undefined);
+}
+
+function getBurnCompleteness(): DataCompleteness {
+  const sites = sitesStore.all.value;
+  if (sites === undefined) {
+    return 'not-loaded';
+  }
+  const rowCount = getBurnRows()?.length ?? 0;
+  if (sites.length > 0 && rowCount === 0) {
+    return 'not-loaded';
+  }
+  return rowCount === sites.length ? 'complete' : 'partial';
+}
+
 export const gameDataSources: DataSourceDescriptor[] = [
   entitySource({
     id: 'alerts',
@@ -114,8 +130,8 @@ export const gameDataSources: DataSourceDescriptor[] = [
     label: 'Burn',
     description: 'Calculated burn data for the company\u2019s sites.',
     provenance: 'prun-live',
-    completeness: fetchedCompleteness(sitesStore.fetched),
-    snapshot: () => sitesStore.all.value?.map(getPlanetBurnPassive).filter(x => x !== undefined),
+    completeness: getBurnCompleteness,
+    snapshot: getBurnRows,
   }),
   createRecordSource({
     id: 'company',

--- a/src/infrastructure/data-catalog/game-sources.ts
+++ b/src/infrastructure/data-catalog/game-sources.ts
@@ -1,5 +1,7 @@
 import { createCollectionSource, createRecordSource } from '@src/core/data-query/catalog';
 import { DataCompleteness, DataSourceDescriptor, DataProvenance } from '@src/core/data-query/types';
+import { getPlanetBurn } from '@src/core/burn';
+import { calculateBuildingEntries, calculateShipEntries } from '@src/features/XIT/REP/entries';
 import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
 import { balancesStore } from '@src/infrastructure/prun-api/data/balances';
 import { blueprintsStore } from '@src/infrastructure/prun-api/data/blueprints';
@@ -33,6 +35,7 @@ import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { usersStore } from '@src/infrastructure/prun-api/data/users';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { workforcesStore } from '@src/infrastructure/prun-api/data/workforces';
+import { userData } from '@src/store/user-data';
 
 const fioWarning =
   'Reference only: planet data originates from FIO fallback data and may be stale. Live PrUn messages only patch selected fields.';
@@ -105,6 +108,14 @@ export const gameDataSources: DataSourceDescriptor[] = [
     description: 'Ship blueprints loaded from PrUn.',
     store: blueprintsState,
     load: { execute: () => request.blueprints() },
+  }),
+  createCollectionSource({
+    id: 'burn',
+    label: 'Burn',
+    description: 'Calculated burn data for the company\u2019s sites.',
+    provenance: 'prun-live',
+    completeness: fetchedCompleteness(sitesStore.fetched),
+    snapshot: () => sitesStore.all.value?.map(getPlanetBurn).filter(x => x !== undefined),
   }),
   createRecordSource({
     id: 'company',
@@ -221,6 +232,27 @@ export const gameDataSources: DataSourceDescriptor[] = [
     warning: fioWarning,
     store: planetsStore,
   }),
+  createRecordSource({
+    id: 'planet-settings',
+    label: 'Planet Settings',
+    description: 'Raw global and per-planet burn and repair settings.',
+    provenance: 'prun-live',
+    completeness: () => 'complete',
+    snapshotRecord: () => ({
+      burn: {
+        red: userData.settings.burn.red,
+        yellow: userData.settings.burn.yellow,
+        resupply: userData.settings.burn.resupply,
+        planetResupply: userData.settings.burn.planetResupply,
+        planetPickup: userData.settings.burn.planetPickup,
+      },
+      repair: {
+        threshold: userData.settings.repair.threshold,
+        offset: userData.settings.repair.offset,
+        planetOverrides: userData.settings.repair.planetOverrides,
+      },
+    }),
+  }),
   createCollectionSource({
     id: 'production',
     label: 'Production',
@@ -237,6 +269,24 @@ export const gameDataSources: DataSourceDescriptor[] = [
       parameter: 'siteId',
       execute: siteId => loadSiteData(siteId, request.production),
     },
+  }),
+  createCollectionSource({
+    id: 'repair',
+    label: 'Repair',
+    description: 'Calculated building and ship repair entries.',
+    provenance: 'prun-live',
+    completeness: () => {
+      const sitesFetched = sitesStore.fetched.value;
+      const shipsFetched = shipsStore.fetched.value;
+      if (!sitesFetched && !shipsFetched) {
+        return 'not-loaded';
+      }
+      return sitesFetched && shipsFetched ? 'complete' : 'partial';
+    },
+    snapshot: () => [
+      ...(calculateBuildingEntries(sitesStore.all.value) ?? []),
+      ...(calculateShipEntries(shipsStore.all.value) ?? []),
+    ],
   }),
   entitySource({
     id: 'sectors',

--- a/src/infrastructure/prun-api/data/production.ts
+++ b/src/infrastructure/prun-api/data/production.ts
@@ -73,7 +73,7 @@ const getByShortSiteId = createGroupMapGetter(state.all, x => x.siteId.substring
 
 const getByFullSiteId = createGroupMapGetter(state.all, x => x.siteId);
 
-const getBySiteId = (value?: string | null) => {
+const passiveGetBySiteId = (value?: string | null) => {
   const result = getByFullSiteId(value) ?? getByShortSiteId(value);
   if (result) {
     return result;
@@ -85,10 +85,20 @@ const getBySiteId = (value?: string | null) => {
 
   if (fetchedAll.value || fetchedSites.has(value)) {
     return [];
-  } else {
-    request.production(value);
   }
 
+  return undefined;
+};
+
+const getBySiteId = (value?: string | null) => {
+  const result = passiveGetBySiteId(value);
+  if (result !== undefined) {
+    return result;
+  }
+  if (!value) {
+    return undefined;
+  }
+  request.production(value);
   return undefined;
 };
 
@@ -96,4 +106,5 @@ export const productionStore = {
   ...state,
   fetchedAll,
   getBySiteId,
+  passiveGetBySiteId,
 };

--- a/src/infrastructure/prun-api/data/workforces.ts
+++ b/src/infrastructure/prun-api/data/workforces.ts
@@ -20,9 +20,11 @@ onApiMessage({
   },
 });
 
-const getById = createRequestGetter(state.getById, x => request.workforce(x));
+const passiveGetById = state.getById;
+const getById = createRequestGetter(passiveGetById, x => request.workforce(x));
 
 export const workforcesStore = {
   ...state,
   getById,
+  passiveGetById,
 };


### PR DESCRIPTION
Adds three passive data sources to the game data catalog — `burn`, `repair`, and `planet-settings` — and registers them in `gameDataSources`. No UI changes; `XIT DATA` already enumerates registered sources.

Linear: [JAC-14](https://linear.app/jackinaboxdev/issue/JAC-14/rpr-add-passive-burn-repair-and-planet-settings-data-sources)
Closes #168

## What landed

- **`burn`** — one row per site via `getPlanetBurnPassive(site)`, exposing `{ naturalId, planetName, storeId, burn }`. Unresolvable sites are dropped rather than emitted as holes.
- **`repair`** — `calculateBuildingEntries` and `calculateShipEntries` concatenated unchanged, preserving all seven `RepairEntry` fields. Returns the loaded side when only one of sites/ships is available, matching the `partial` state `completeness()` advertises.
- **`planet-settings`** — exactly the eight named raw `userData.settings` fields, globals and override maps kept separate. No precedence pre-resolution, so `getRepairThreshold` / `getRepairOffset` / `getResupplyDays` remain applicable downstream.

## Two problems found during implementation

The original acceptance criteria could not be satisfied as written. Both conflicts were surfaced and ruled on before the code changed.

**1. `burn` broke the passive-read guarantee.** A passive `catalog.snapshot('burn')` dispatched live PrUn requests: `getPlanetBurn` reaches `workforcesStore.getById` and `productionStore.getBySiteId`, both request-on-miss getters via `createRequestGetter`. `docs/data-catalog.md` forbids exactly this.

The shipped passivity test did not catch it because it never seeded the sites store — `?.map()` short-circuited and the burn path was never reached. It was green and proved nothing.

Fixed by adding passive siblings (`workforcesStore.passiveGetById`, `productionStore.passiveGetBySiteId`, `getPlanetBurnPassive`) alongside the existing request-on-miss getters, whose behavior is unchanged for the ~14 UI callers that depend on it.

**2. `repair` required an `infrastructure → features` import**, forbidden by `docs/architecture.md`, with zero precedent anywhere in the codebase. The repair calculation moved to `src/core/repair.ts` beside `core/burn.ts`, re-exported from `features/XIT/REP/entries.ts` so XIT REP is untouched. The moved code is byte-identical and the re-export is the same function object.

## Deviation from the stated acceptance criteria

JAC-14 specified that `burn` use "the same `sitesStore.fetched` completeness gate as the existing `sites` source." **That criterion is not implemented as written**, deliberately.

With the source correctly passive, that gate made `burn` report `complete` while returning zero rows — the steady state until a user opens per-site tiles, since nothing would ever populate the rows on its own. A consumer reading `completeness` alone would conclude the company has no burn anywhere.

`burn` now uses the tri-state `production` already uses:

| State | completeness | rows |
|---|---|---|
| sites never fetched | `not-loaded` | `undefined` |
| fetched, zero sites | `complete` | `[]` |
| sites loaded, none resolved | `not-loaded` | `[]` |
| some sites resolved | `partial` | partial set |
| all sites resolved | `complete` | full set |

Note that `not-loaded` covers two distinguishable states — nothing fetched (`rows: undefined`) and sites fetched but no burn resolved (`rows: []`). Consumers can tell them apart via `rows`, but a consumer reading only `completeness` cannot distinguish "open a tile" from "wait for sites."

## Verification

- `pnpm run compile` — exit 0, tsc + ESLint clean
- `pnpm test` — exit 0, 9 files, 79 tests
- No `@src/features` imports remain in `src/infrastructure/` or `src/core/`
- Every passive operation (`snapshot` / `query` / `export`) across every source dispatches zero PrUn requests with stores seeded; the active `getPlanetBurn` still requests on miss
- The new passivity test was mutation-tested from two independent angles — stubbing `getPlanetBurnPassive`, and separately breaking the passive workforce accessor in `core/burn.ts` — and fails in both cases

## Documentation

`docs/data-catalog.md` records the transitive dayjs plugin requirement (`core/repair → core/buildings → infrastructure/fio/cx`) and that `burn.daysLeft` can be `Number.POSITIVE_INFINITY`, which the JSON clone path serializes to `null` and sorts as missing in both directions.
