### PR TITLE
Shift-click ship unload into local warehouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
+
 ### Fixed
 
 - `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -881,6 +881,26 @@ Neither of these solves data staleness by itself — see `docs/game/screens-comm
 a deeper case (channel data) where the server won't resend a full data set a second time
 no matter how the buffer is managed client-side.
 
+### Modifier Variants of a Native Server Action
+
+A modifier-click feature that keeps a native action but changes its destination must be
+an explicitly approved, one-purpose exception to the normal one-click-per-server-action
+rule. It is not a reusable automation surface. `ship-unload-to-warehouse` is the reference:
+
+- Listen in the capture phase to snapshot modifier state and source inventory before the
+  game's handler, but never prevent, stop, replace, or synthesize the native click.
+- Gate the follow-up synchronously on the complete source/destination context. A normal
+  click, an unsupported location, or a missing destination must leave no watcher or
+  hidden buffer behind.
+- Wait with a deadline for the API store delta that proves the native action succeeded;
+  calculate follow-up quantities from that delta so pre-existing inventory is untouched.
+- Validate that the complete delta still exists at the intermediate store and fits at the
+  destination before opening any follow-up UI.
+- Drive forced hidden buffers sequentially through the game's existing form and button,
+  wait for terminal action feedback plus the destination store update, and await window
+  removal before opening the next buffer. Handle every failure silently so the native
+  action remains the visible result.
+
 ### Submitting a Formless Input Programmatically
 
 Some game inputs (e.g. the chat channel compose box) have no `<form>` to call

--- a/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
+++ b/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
@@ -235,7 +235,7 @@ async function selectMaterial(container: Element, ticker: string) {
         ),
       container,
     );
-    if (match === undefined) {
+    if (!(match instanceof HTMLElement)) {
       return false;
     }
     await clickElement(match);

--- a/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
+++ b/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
@@ -1,0 +1,305 @@
+import {
+  getLocationLineFromAddress,
+  isPlanetLine,
+} from '@src/infrastructure/prun-api/data/addresses';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { changeInputValue, clickElement, focusElement } from '@src/util';
+import { sleep } from '@src/utils/sleep';
+import {
+  CargoAmount,
+  cargoFitsStore,
+  getCargoSnapshot,
+  getUnloadedCargo,
+  isUnloadTransferEligible,
+  storeContainsCargo,
+} from './unload-plan';
+
+const actionTimeoutMs = 15_000;
+const inProgressShipIds = new Set<string>();
+
+function onFleetTileReady(tile: PrunTile) {
+  subscribe($$(tile.anchor, C.Fleet.buttons), buttons => {
+    const fleetRow = buttons.closest('tr');
+    if (fleetRow === null) {
+      return;
+    }
+    buttons.addEventListener(
+      'click',
+      e => {
+        const target = e.target;
+        if (!(target instanceof Element)) {
+          return;
+        }
+        const button = target.closest('button');
+        if (
+          button === null ||
+          !buttons.contains(button) ||
+          button.textContent?.trim().toLowerCase() !== 'unload'
+        ) {
+          return;
+        }
+        const ship = findFleetRowShip(fleetRow);
+        if (ship !== undefined) {
+          planWarehouseUnload(ship, e.shiftKey);
+        }
+      },
+      true,
+    );
+  });
+}
+
+async function onShipInventoryTileReady(tile: PrunTile) {
+  const button = await $(tile.anchor, C.Button.primary);
+  button.addEventListener(
+    'click',
+    e => {
+      const ship = shipsStore.getByRegistration(tile.parameter);
+      if (ship !== undefined) {
+        planWarehouseUnload(ship, e.shiftKey);
+      }
+    },
+    true,
+  );
+}
+
+function findFleetRowShip(fleetRow: Element) {
+  const registrations = new Set(_$$(fleetRow, C.Link.link).map(x => x.textContent?.trim()));
+  return shipsStore.all.value?.find(x => registrations.has(x.registration));
+}
+
+function planWarehouseUnload(ship: PrunApi.Ship, shiftKey: boolean) {
+  const location = getLocationLineFromAddress(ship.address ?? undefined);
+  const landedAtPlanet = ship.flightId === null && isPlanetLine(location);
+  const planetNaturalId = landedAtPlanet ? location.entity.naturalId : undefined;
+  const site = sitesStore.getByPlanetNaturalId(planetNaturalId);
+  const baseStore = storagesStore.all.value?.find(
+    x => x.addressableId === site?.siteId && x.type === 'STORE',
+  );
+  const warehouse = warehousesStore.getByEntityNaturalId(planetNaturalId);
+  const warehouseStore = storagesStore.getById(warehouse?.storeId);
+  const shipStore = storagesStore.getById(ship.idShipStore);
+  const before = getCargoSnapshot(shipStore);
+
+  if (
+    !isUnloadTransferEligible({
+      shiftKey,
+      landedAtPlanet,
+      hasBaseStore: baseStore !== undefined,
+      hasWarehouseStore: warehouseStore !== undefined && !warehouseStore.locked,
+      hasCargo: before.length > 0,
+      inProgress: inProgressShipIds.has(ship.id),
+    })
+  ) {
+    return;
+  }
+
+  inProgressShipIds.add(ship.id);
+  void runWarehouseUnload(ship.id, ship.idShipStore, baseStore!.id, warehouseStore!.id, before);
+}
+
+async function runWarehouseUnload(
+  shipId: string,
+  shipStoreId: string,
+  baseStoreId: string,
+  warehouseStoreId: string,
+  before: CargoAmount[],
+) {
+  try {
+    await finishWarehouseUnload(shipId, shipStoreId, baseStoreId, warehouseStoreId, before);
+  } catch (e) {
+    console.error('Shift-click warehouse unload failed.', e);
+  } finally {
+    inProgressShipIds.delete(shipId);
+  }
+}
+
+async function finishWarehouseUnload(
+  shipId: string,
+  shipStoreId: string,
+  baseStoreId: string,
+  warehouseStoreId: string,
+  before: CargoAmount[],
+) {
+  const unloaded = await waitForUnloadedCargo(shipStoreId, before);
+  if (unloaded.length === 0 || !inProgressShipIds.has(shipId)) {
+    return;
+  }
+
+  const baseStore = storagesStore.getById(baseStoreId);
+  const warehouseStore = storagesStore.getById(warehouseStoreId);
+  if (
+    warehouseStore === undefined ||
+    warehouseStore.locked ||
+    !storeContainsCargo(baseStore, unloaded) ||
+    !cargoFitsStore(warehouseStore, unloaded)
+  ) {
+    return;
+  }
+
+  for (const cargo of unloaded) {
+    if (!(await transferMaterial(baseStoreId, warehouseStoreId, cargo))) {
+      return;
+    }
+  }
+}
+
+async function waitForUnloadedCargo(shipStoreId: string, before: CargoAmount[]) {
+  return await new Promise<CargoAmount[]>(resolve => {
+    const stop = watch(
+      () => getCargoSnapshot(storagesStore.getById(shipStoreId)),
+      after => {
+        const unloaded = getUnloadedCargo(before, after);
+        if (unloaded.length > 0) {
+          window.clearTimeout(timeout);
+          stop();
+          resolve(unloaded);
+        }
+      },
+      { deep: true },
+    );
+    const timeout = window.setTimeout(() => {
+      stop();
+      resolve([]);
+    }, actionTimeoutMs);
+  });
+}
+
+async function transferMaterial(fromId: string, toId: string, cargo: CargoAmount) {
+  const from = storagesStore.getById(fromId);
+  const to = storagesStore.getById(toId);
+  if (!storeContainsCargo(from, [cargo]) || to === undefined || !cargoFitsStore(to, [cargo])) {
+    return false;
+  }
+
+  const closed = ref(false);
+  const windowEl = await showBuffer(
+    `MTRA from-${fromId.substring(0, 8)} to-${toId.substring(0, 8)}`,
+    { force: true, autoClose: true, closeWhen: computed(() => closed.value) },
+  );
+  if (windowEl === undefined) {
+    return false;
+  }
+
+  try {
+    const selector = await waitForValue(() => _$(windowEl, C.MaterialSelector.container), windowEl);
+    if (selector === undefined || !(await selectMaterial(selector, cargo.ticker))) {
+      return false;
+    }
+
+    const amountInput = _$$(windowEl, 'input')[1];
+    if (amountInput === undefined) {
+      return false;
+    }
+    changeInputValue(amountInput, cargo.amount.toString());
+
+    const transfer = await waitForValue(() => _$(windowEl, C.Button.btn), windowEl);
+    if (transfer === undefined) {
+      return false;
+    }
+
+    const beforeAmount = getStoreAmount(toId, cargo.ticker);
+    await clickElement(transfer);
+    const outcome = await waitForValue(
+      () => _$(windowEl, C.ActionFeedback.success) ?? _$(windowEl, C.ActionFeedback.error),
+      windowEl,
+    );
+    if (outcome === undefined || outcome.classList.contains(C.ActionFeedback.error)) {
+      return false;
+    }
+    return await waitForStoreIncrease(toId, cargo.ticker, beforeAmount);
+  } finally {
+    closed.value = true;
+    await waitForWindowClose(windowEl);
+  }
+}
+
+async function selectMaterial(container: Element, ticker: string) {
+  const input = _$(container, 'input');
+  const suggestions = _$(container, C.MaterialSelector.suggestionsContainer);
+  if (input === undefined || suggestions === undefined) {
+    return false;
+  }
+
+  suggestions.style.display = 'none';
+  try {
+    focusElement(input);
+    changeInputValue(input, ticker);
+    const match = await waitForValue(
+      () =>
+        _$$(container, C.MaterialSelector.suggestionEntry).find(
+          x => _$(x, C.ColoredIcon.label)?.textContent === ticker,
+        ),
+      container,
+    );
+    if (match === undefined) {
+      return false;
+    }
+    await clickElement(match);
+    return true;
+  } finally {
+    suggestions.style.display = '';
+  }
+}
+
+async function waitForStoreIncrease(storeId: string, ticker: string, before: number) {
+  if (getStoreAmount(storeId, ticker) > before) {
+    return true;
+  }
+  return await new Promise<boolean>(resolve => {
+    const stop = watch(
+      () => getStoreAmount(storeId, ticker),
+      amount => {
+        if (amount > before) {
+          window.clearTimeout(timeout);
+          stop();
+          resolve(true);
+        }
+      },
+    );
+    const timeout = window.setTimeout(() => {
+      stop();
+      resolve(false);
+    }, actionTimeoutMs);
+  });
+}
+
+function getStoreAmount(storeId: string, ticker: string) {
+  return (
+    storagesStore.getById(storeId)?.items.find(x => x.quantity?.material.ticker === ticker)
+      ?.quantity?.amount ?? 0
+  );
+}
+
+async function waitForValue<T>(getValue: () => T | undefined, node: Node) {
+  const deadline = Date.now() + actionTimeoutMs;
+  while (node.isConnected && Date.now() < deadline) {
+    const value = getValue();
+    if (value !== undefined) {
+      return value;
+    }
+    await sleep(50);
+  }
+  return undefined;
+}
+
+async function waitForWindowClose(windowEl: Element) {
+  const deadline = Date.now() + actionTimeoutMs;
+  while (windowEl.isConnected && Date.now() < deadline) {
+    await sleep(50);
+  }
+}
+
+function init() {
+  tiles.observe('FLT', onFleetTileReady);
+  tiles.observe('SHPI', onShipInventoryTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'FLT/SHPI: Shift-click Unload to move landed ship cargo into the local warehouse.',
+);

--- a/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
+++ b/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
@@ -13,10 +13,12 @@ import { sleep } from '@src/utils/sleep';
 import {
   CargoAmount,
   cargoFitsStore,
-  getClampedTransferAmount,
+  getCompleteTransferAmount,
   getCargoSnapshot,
+  getFleetRowIdentifiers,
   getUnloadedCargo,
   isUnloadTransferEligible,
+  resolveWithin,
   storeContainsCargo,
 } from './unload-plan';
 
@@ -73,9 +75,10 @@ function onShipInventoryTileReady(tile: PrunTile) {
 }
 
 function findFleetRowShip(fleetRow: Element) {
-  const identifiers = new Set(_$$(fleetRow, C.Link.link).map(x => x.textContent?.trim()));
-  return shipsStore.all.value?.find(
-    x => identifiers.has(x.registration) || identifiers.has(x.name),
+  const identifiers = getFleetRowIdentifiers(_$$(fleetRow, C.Link.link).map(x => x.textContent));
+  const ships = shipsStore.all.value;
+  return (
+    ships?.find(x => identifiers.has(x.registration)) ?? ships?.find(x => identifiers.has(x.name))
   );
 }
 
@@ -194,13 +197,20 @@ async function transferMaterial(fromId: string, toId: string, cargo: CargoAmount
 
   try {
     const selector = await waitForValue(() => _$(windowEl, C.MaterialSelector.container), windowEl);
-    if (selector === undefined || !(await selectMaterial(selector, cargo.ticker))) {
+    if (selector === undefined) {
+      return false;
+    }
+    const materialSelected = await resolveWithin(
+      selectMaterial(selector, cargo.ticker),
+      actionTimeoutMs,
+    );
+    if (materialSelected !== true) {
       return false;
     }
 
     const sliderNumbers = _$$(windowEl, 'rc-slider-mark-text').map(x => Number(x.textContent ?? 0));
-    const transferAmount = getClampedTransferAmount(cargo.amount, Math.max(...sliderNumbers));
-    if (transferAmount !== cargo.amount) {
+    const transferAmount = getCompleteTransferAmount(cargo.amount, Math.max(...sliderNumbers));
+    if (transferAmount === undefined) {
       return false;
     }
 

--- a/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
+++ b/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
@@ -197,7 +197,7 @@ async function transferMaterial(fromId: string, toId: string, cargo: CargoAmount
     changeInputValue(amountInput, cargo.amount.toString());
 
     const transfer = await waitForValue(() => _$(windowEl, C.Button.btn), windowEl);
-    if (transfer === undefined) {
+    if (!(transfer instanceof HTMLElement)) {
       return false;
     }
 

--- a/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
+++ b/src/features/basic/ship-unload-to-warehouse/ship-unload-to-warehouse.ts
@@ -7,11 +7,13 @@ import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
-import { changeInputValue, clickElement, focusElement } from '@src/util';
+import { selectMaterial } from '@src/features/XIT/ACT/action-steps/cont-utils';
+import { changeInputValue, clickElement } from '@src/util';
 import { sleep } from '@src/utils/sleep';
 import {
   CargoAmount,
   cargoFitsStore,
+  getClampedTransferAmount,
   getCargoSnapshot,
   getUnloadedCargo,
   isUnloadTransferEligible,
@@ -52,23 +54,29 @@ function onFleetTileReady(tile: PrunTile) {
   });
 }
 
-async function onShipInventoryTileReady(tile: PrunTile) {
-  const button = await $(tile.anchor, C.Button.primary);
-  button.addEventListener(
-    'click',
-    e => {
-      const ship = shipsStore.getByRegistration(tile.parameter);
-      if (ship !== undefined) {
-        planWarehouseUnload(ship, e.shiftKey);
-      }
-    },
-    true,
-  );
+function onShipInventoryTileReady(tile: PrunTile) {
+  subscribe($$(tile.anchor, C.Button.primary), button => {
+    button.addEventListener(
+      'click',
+      e => {
+        if (button.textContent?.trim().toLowerCase() !== 'unload') {
+          return;
+        }
+        const ship = shipsStore.getByRegistration(tile.parameter);
+        if (ship !== undefined) {
+          planWarehouseUnload(ship, e.shiftKey);
+        }
+      },
+      true,
+    );
+  });
 }
 
 function findFleetRowShip(fleetRow: Element) {
-  const registrations = new Set(_$$(fleetRow, C.Link.link).map(x => x.textContent?.trim()));
-  return shipsStore.all.value?.find(x => registrations.has(x.registration));
+  const identifiers = new Set(_$$(fleetRow, C.Link.link).map(x => x.textContent?.trim()));
+  return shipsStore.all.value?.find(
+    x => identifiers.has(x.registration) || identifiers.has(x.name),
+  );
 }
 
 function planWarehouseUnload(ship: PrunApi.Ship, shiftKey: boolean) {
@@ -190,11 +198,17 @@ async function transferMaterial(fromId: string, toId: string, cargo: CargoAmount
       return false;
     }
 
+    const sliderNumbers = _$$(windowEl, 'rc-slider-mark-text').map(x => Number(x.textContent ?? 0));
+    const transferAmount = getClampedTransferAmount(cargo.amount, Math.max(...sliderNumbers));
+    if (transferAmount !== cargo.amount) {
+      return false;
+    }
+
     const amountInput = _$$(windowEl, 'input')[1];
     if (amountInput === undefined) {
       return false;
     }
-    changeInputValue(amountInput, cargo.amount.toString());
+    changeInputValue(amountInput, transferAmount.toString());
 
     const transfer = await waitForValue(() => _$(windowEl, C.Button.btn), windowEl);
     if (!(transfer instanceof HTMLElement)) {
@@ -214,34 +228,6 @@ async function transferMaterial(fromId: string, toId: string, cargo: CargoAmount
   } finally {
     closed.value = true;
     await waitForWindowClose(windowEl);
-  }
-}
-
-async function selectMaterial(container: Element, ticker: string) {
-  const input = _$(container, 'input');
-  const suggestions = _$(container, C.MaterialSelector.suggestionsContainer);
-  if (input === undefined || suggestions === undefined) {
-    return false;
-  }
-
-  suggestions.style.display = 'none';
-  try {
-    focusElement(input);
-    changeInputValue(input, ticker);
-    const match = await waitForValue(
-      () =>
-        _$$(container, C.MaterialSelector.suggestionEntry).find(
-          x => _$(x, C.ColoredIcon.label)?.textContent === ticker,
-        ),
-      container,
-    );
-    if (!(match instanceof HTMLElement)) {
-      return false;
-    }
-    await clickElement(match);
-    return true;
-  } finally {
-    suggestions.style.display = '';
   }
 }
 

--- a/src/features/basic/ship-unload-to-warehouse/unload-plan.test.ts
+++ b/src/features/basic/ship-unload-to-warehouse/unload-plan.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CargoAmount,
+  cargoFitsStore,
+  getCargoSnapshot,
+  getUnloadedCargo,
+  isUnloadTransferEligible,
+  storeContainsCargo,
+} from './unload-plan';
+
+const cargo: CargoAmount[] = [{ ticker: 'RAT', amount: 10, weight: 1, volume: 2 }];
+
+describe('warehouse unload eligibility', () => {
+  const eligible = {
+    shiftKey: true,
+    landedAtPlanet: true,
+    hasBaseStore: true,
+    hasWarehouseStore: true,
+    hasCargo: true,
+    inProgress: false,
+  };
+
+  it('requires a shift-click', () => {
+    expect(isUnloadTransferEligible({ ...eligible, shiftKey: false })).toBe(false);
+  });
+
+  it('does not apply to station or CX landings', () => {
+    expect(isUnloadTransferEligible({ ...eligible, landedAtPlanet: false })).toBe(false);
+  });
+
+  it('requires both the local base store and matching warehouse', () => {
+    expect(isUnloadTransferEligible({ ...eligible, hasBaseStore: false })).toBe(false);
+    expect(isUnloadTransferEligible({ ...eligible, hasWarehouseStore: false })).toBe(false);
+  });
+
+  it('ignores empty and already-running unloads', () => {
+    expect(isUnloadTransferEligible({ ...eligible, hasCargo: false })).toBe(false);
+    expect(isUnloadTransferEligible({ ...eligible, inProgress: true })).toBe(false);
+  });
+
+  it('accepts a shift-click with a complete local destination', () => {
+    expect(isUnloadTransferEligible(eligible)).toBe(true);
+  });
+});
+
+describe('warehouse unload cargo planning', () => {
+  it('snapshots inventory cargo and combines duplicate tickers', () => {
+    expect(
+      getCargoSnapshot({
+        items: [
+          { quantity: { material: { ticker: 'RAT', weight: 1, volume: 2 }, amount: 4 } },
+          { quantity: { material: { ticker: 'RAT', weight: 1, volume: 2 }, amount: 6 } },
+          { quantity: null },
+        ],
+      }),
+    ).toEqual(cargo);
+  });
+
+  it('transfers only the amount removed by the native unload', () => {
+    const before = [...cargo, { ticker: 'DW', amount: 5, weight: 0.1, volume: 0.1 }];
+    const after = [
+      { ...cargo[0]!, amount: 3 },
+      { ticker: 'DW', amount: 5, weight: 0.1, volume: 0.1 },
+    ];
+
+    expect(getUnloadedCargo(before, after)).toEqual([
+      { ticker: 'RAT', amount: 7, weight: 1, volume: 2 },
+    ]);
+  });
+
+  it('does nothing when the native unload does not change cargo', () => {
+    expect(getUnloadedCargo(cargo, cargo)).toEqual([]);
+  });
+
+  it('requires the full unloaded cargo to remain in the base store', () => {
+    const base = {
+      items: [{ quantity: { material: { ticker: 'RAT', weight: 1, volume: 2 }, amount: 10 } }],
+    };
+    expect(storeContainsCargo(base, cargo)).toBe(true);
+    expect(storeContainsCargo(base, [{ ...cargo[0]!, amount: 11 }])).toBe(false);
+  });
+
+  it('requires the complete unloaded cargo to fit the warehouse', () => {
+    const warehouse = {
+      weightCapacity: 20,
+      weightLoad: 10,
+      volumeCapacity: 30,
+      volumeLoad: 10,
+    };
+    expect(cargoFitsStore(warehouse, cargo)).toBe(true);
+    expect(cargoFitsStore({ ...warehouse, volumeLoad: 11 }, cargo)).toBe(false);
+  });
+});

--- a/src/features/basic/ship-unload-to-warehouse/unload-plan.test.ts
+++ b/src/features/basic/ship-unload-to-warehouse/unload-plan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CargoAmount,
   cargoFitsStore,
+  getClampedTransferAmount,
   getCargoSnapshot,
   getUnloadedCargo,
   isUnloadTransferEligible,
@@ -70,6 +71,12 @@ describe('warehouse unload cargo planning', () => {
 
   it('does nothing when the native unload does not change cargo', () => {
     expect(getUnloadedCargo(cargo, cargo)).toEqual([]);
+  });
+
+  it('uses only a positive amount allowed by the MTRA slider', () => {
+    expect(getClampedTransferAmount(10, 20)).toBe(10);
+    expect(getClampedTransferAmount(10, 6)).toBe(6);
+    expect(getClampedTransferAmount(10, 0)).toBe(0);
   });
 
   it('requires the full unloaded cargo to remain in the base store', () => {

--- a/src/features/basic/ship-unload-to-warehouse/unload-plan.test.ts
+++ b/src/features/basic/ship-unload-to-warehouse/unload-plan.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   CargoAmount,
   cargoFitsStore,
-  getClampedTransferAmount,
+  getCompleteTransferAmount,
   getCargoSnapshot,
+  getFleetRowIdentifiers,
   getUnloadedCargo,
   isUnloadTransferEligible,
+  resolveWithin,
   storeContainsCargo,
 } from './unload-plan';
 
@@ -73,10 +75,36 @@ describe('warehouse unload cargo planning', () => {
     expect(getUnloadedCargo(cargo, cargo)).toEqual([]);
   });
 
-  it('uses only a positive amount allowed by the MTRA slider', () => {
-    expect(getClampedTransferAmount(10, 20)).toBe(10);
-    expect(getClampedTransferAmount(10, 6)).toBe(6);
-    expect(getClampedTransferAmount(10, 0)).toBe(0);
+  it('requires the MTRA slider to allow the complete positive amount', () => {
+    expect(getCompleteTransferAmount(10, 20)).toBe(10);
+    expect(getCompleteTransferAmount(10, 6)).toBeUndefined();
+    expect(getCompleteTransferAmount(10, 0)).toBeUndefined();
+    expect(getCompleteTransferAmount(10, Number.NaN)).toBeUndefined();
+  });
+
+  it('ignores empty fleet-row ship identifiers', () => {
+    expect(getFleetRowIdentifiers([' AAA-001 ', '', '   ', null, undefined])).toEqual(
+      new Set(['AAA-001']),
+    );
+  });
+
+  it('bounds a selector promise that never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      const result = resolveWithin(new Promise<boolean>(() => {}), 15_000);
+      let settled = false;
+      let outcome: boolean | undefined;
+      const observeResult = async () => {
+        outcome = await result;
+        settled = true;
+      };
+      void observeResult();
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(settled).toBe(true);
+      expect(outcome).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('requires the full unloaded cargo to remain in the base store', () => {

--- a/src/features/basic/ship-unload-to-warehouse/unload-plan.ts
+++ b/src/features/basic/ship-unload-to-warehouse/unload-plan.ts
@@ -1,0 +1,85 @@
+interface CargoMaterial {
+  ticker: string;
+  weight: number;
+  volume: number;
+}
+
+interface CargoStore {
+  items: {
+    quantity?: {
+      material: CargoMaterial;
+      amount: number;
+    } | null;
+  }[];
+}
+
+interface StoreCapacity {
+  weightCapacity: number;
+  weightLoad: number;
+  volumeCapacity: number;
+  volumeLoad: number;
+}
+
+export interface CargoAmount extends CargoMaterial {
+  amount: number;
+}
+
+interface Eligibility {
+  shiftKey: boolean;
+  landedAtPlanet: boolean;
+  hasBaseStore: boolean;
+  hasWarehouseStore: boolean;
+  hasCargo: boolean;
+  inProgress: boolean;
+}
+
+export function isUnloadTransferEligible(eligibility: Eligibility) {
+  return (
+    eligibility.shiftKey &&
+    eligibility.landedAtPlanet &&
+    eligibility.hasBaseStore &&
+    eligibility.hasWarehouseStore &&
+    eligibility.hasCargo &&
+    !eligibility.inProgress
+  );
+}
+
+export function getCargoSnapshot(store?: CargoStore) {
+  const cargo = new Map<string, CargoAmount>();
+  for (const item of store?.items ?? []) {
+    const quantity = item.quantity;
+    if (quantity === null || quantity === undefined || quantity.amount <= 0) {
+      continue;
+    }
+    const current = cargo.get(quantity.material.ticker);
+    cargo.set(quantity.material.ticker, {
+      ticker: quantity.material.ticker,
+      weight: quantity.material.weight,
+      volume: quantity.material.volume,
+      amount: (current?.amount ?? 0) + quantity.amount,
+    });
+  }
+  return Array.from(cargo.values());
+}
+
+export function getUnloadedCargo(before: CargoAmount[], after: CargoAmount[]) {
+  const afterAmounts = new Map(after.map(x => [x.ticker, x.amount]));
+  return before
+    .map(x => ({ ...x, amount: x.amount - (afterAmounts.get(x.ticker) ?? 0) }))
+    .filter(x => x.amount > 0);
+}
+
+export function storeContainsCargo(store: CargoStore | undefined, cargo: CargoAmount[]) {
+  const available = new Map(getCargoSnapshot(store).map(x => [x.ticker, x.amount]));
+  return cargo.every(x => (available.get(x.ticker) ?? 0) >= x.amount);
+}
+
+export function cargoFitsStore(store: StoreCapacity, cargo: CargoAmount[]) {
+  const epsilon = 0.000001;
+  const weight = sumBy(cargo, x => x.amount * x.weight);
+  const volume = sumBy(cargo, x => x.amount * x.volume);
+  return (
+    weight <= store.weightCapacity - store.weightLoad + epsilon &&
+    volume <= store.volumeCapacity - store.volumeLoad + epsilon
+  );
+}

--- a/src/features/basic/ship-unload-to-warehouse/unload-plan.ts
+++ b/src/features/basic/ship-unload-to-warehouse/unload-plan.ts
@@ -69,8 +69,27 @@ export function getUnloadedCargo(before: CargoAmount[], after: CargoAmount[]) {
     .filter(x => x.amount > 0);
 }
 
-export function getClampedTransferAmount(amount: number, maxAmount: number) {
-  return maxAmount <= 0 ? 0 : Math.min(amount, maxAmount);
+export function getCompleteTransferAmount(amount: number, maxAmount: number) {
+  const clamped = maxAmount <= 0 ? 0 : Math.min(amount, maxAmount);
+  return amount > 0 && clamped === amount ? clamped : undefined;
+}
+
+export function getFleetRowIdentifiers(labels: (string | null | undefined)[]) {
+  return new Set(labels.map(x => x?.trim()).filter(x => x !== undefined && x.length > 0));
+}
+
+export async function resolveWithin<T>(value: Promise<T>, timeoutMs: number) {
+  let timeoutId: number | undefined;
+  const expired = new Promise<undefined>(resolve => {
+    timeoutId = setTimeout(resolve, timeoutMs);
+  });
+  try {
+    return await Promise.race([value, expired]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 export function storeContainsCargo(store: CargoStore | undefined, cargo: CargoAmount[]) {

--- a/src/features/basic/ship-unload-to-warehouse/unload-plan.ts
+++ b/src/features/basic/ship-unload-to-warehouse/unload-plan.ts
@@ -69,6 +69,10 @@ export function getUnloadedCargo(before: CargoAmount[], after: CargoAmount[]) {
     .filter(x => x.amount > 0);
 }
 
+export function getClampedTransferAmount(amount: number, maxAmount: number) {
+  return maxAmount <= 0 ? 0 : Math.min(amount, maxAmount);
+}
+
 export function storeContainsCargo(store: CargoStore | undefined, cargo: CargoAmount[]) {
   const available = new Map(getCargoSnapshot(store).map(x => [x.ticker, x.amount]));
   return cargo.every(x => (available.get(x.ticker) ?? 0) >= x.amount);


### PR DESCRIPTION
Closes #174

## Summary
- preserve native unload behavior for normal clicks, CX landings, and missing local warehouses
- on eligible shift-clicks, derive the actual native-unload cargo delta and transfer it through sequential hidden MTRA buffers
- reuse the proven MTRA material selector while bounding it to release hidden buffers and per-ship locks on failure
- require the complete amount allowed by the MTRA slider before transfer
- keep SHPI listeners unload-specific and replacement-safe; resolve FLT rows by non-empty registration or name, preferring registration

## Validation
At `75fbf10fac9cd2243881b777371a271c09f37658`:
- `pnpm run compile` — passed (TypeScript + ESLint)
- `pnpm test` — passed (11 files; 96 passed, 1 skipped)
- `pnpm run build:fast` — passed
- mutation proof — removing the empty-identifier filter and selector timeout made both new focused tests fail; bypassing complete-amount validation made its test fail; restored focused suite passes 13/13
- earlier mutation proof — removing eligibility/delta/storage guards made 8/10 focused tests fail
- real-game DOM shape — confirmed FLT row unload controls and SHPI primary unload control in the shared persistent session; branch-injected server-mutation flow remains unexercised because that browser is serving another active checkout

GitHub CI runs build and ESLint only; it has no test job.