### PR TITLE
Fix annoying -0.0001 showing up as 0 days of burn

### DIFF
--- a/src/core/burn.ts
+++ b/src/core/burn.ts
@@ -201,6 +201,9 @@ export function calculatePlanetBurn(
     if (mat.input > 0 && mat.dailyAmount <= 0) {
       mat.type = 'input';
     }
+    if (mat.dailyAmount > -0.01 && mat.dailyAmount < 0.01) {
+      mat.dailyAmount = 0;
+    }
     const inv = mat.remainingAllocation + mat.inventory;
     mat.daysLeft = mat.dailyAmount >= 0 ? Number.POSITIVE_INFINITY : inv / -mat.dailyAmount;
   }


### PR DESCRIPTION
This was my fix for WAI's NN sometimes getting sent or showing up at 0 days left in burn. 