### PR TITLE
[RPR] Add XIT FINCH equity growth-rate chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `XIT FINCH`: New Equity Growth chart plots how fast equity is compounding as a percentage per day, instead of its absolute value
+
 ## 1.1.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## Unreleased
 
-### Added
-
-- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
-
-### Fixed
-
-- `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.
-- `XIT BURN`: A material whose production and consumption cancel out no longer shows 0 days left, in both the per-planet rows and the Overall row.
-
 ## 1.1.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Added
 
-- `XIT FINCH`: New Equity Growth chart plots how fast equity is compounding as a percentage per day, instead of its absolute value
+- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
+
+### Fixed
+
+- `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.
+- `XIT BURN`: A material whose production and consumption cancel out no longer shows 0 days left, in both the per-planet rows and the Overall row.
 
 ## 1.1.2
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,14 @@ Stack: TypeScript, Vue 3, Vite (content scripts), CSS Modules. Package manager: 
 | `pnpm run dev` | watch-mode development build |
 | `pnpm run test` | `vitest run` |
 
+**`pnpm run compile` does not type-check `.vue` script blocks.** `tsc` cannot read SFCs and
+there is no `vue-tsc` in this repo, so a green `compile` covers `.ts` only. An identifier used
+in a `<script setup>` block but never imported passes both `tsc` and eslint and throws at
+runtime — an unimported `percent0` in `LineChart.vue` got that far during the FINCH
+growth-rate work. Move logic worth checking into a plain `.ts` module next to the component
+and unit-test it there, and verify what stays in the SFC against the live game
+(`docs/browser-testing.md`). Treat "compile is green" as saying nothing about a `.vue` change.
+
 A fresh clone has no `node_modules` — run `pnpm install --frozen-lockfile` before
 `pnpm run compile` / `pnpm run lint`, or `tsc` reports missing `chrome`/`node`/`vite/client`
 type libraries, which reads like a broken tsconfig rather than a missing install. Cloud

--- a/src/features/XIT/FINCH/HistoryChart.vue
+++ b/src/features/XIT/FINCH/HistoryChart.vue
@@ -8,6 +8,7 @@ import RangeInput from '@src/components/forms/RangeInput.vue';
 import Active from '@src/components/forms/Active.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import { ChartDef, charts } from '@src/features/XIT/FINCH/charts';
+import { ChartSeries } from '@src/features/XIT/FINCH/growth-rate';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import Passive from '@src/components/forms/Passive.vue';
 
@@ -40,37 +41,35 @@ const yLabel = computed(() => {
   }
   return label;
 });
+const unit = computed(() => selectedChartDef.value?.unit ?? 'currency');
 
-const lineChartData = computed(() => {
-  const date: number[] = [];
-  const equityValues: number[] = [];
-  if (!selectedChartDef.value) {
-    return {
-      date,
-      equity: equityValues,
-    };
+const lineChartData = computed<ChartSeries>(() => {
+  const timestamps: number[] = [];
+  const values: number[] = [];
+  const def = selectedChartDef.value;
+  if (def === undefined) {
+    return { timestamps, values };
   }
 
   for (const entry of balanceHistory.value) {
-    const value = selectedChartDef.value.getValue(entry);
+    const value = def.getValue(entry);
     if (value === undefined) {
       continue;
     }
 
-    const previousDay = date[date.length - 1];
+    const previousDay = timestamps[timestamps.length - 1];
     if (previousDay !== undefined && dayjs(previousDay).isSame(entry.timestamp, 'day')) {
-      date[date.length - 1] = entry.timestamp;
-      equityValues[equityValues.length - 1] = value;
+      timestamps[timestamps.length - 1] = entry.timestamp;
+      values[values.length - 1] = value;
     } else {
-      date.push(entry.timestamp);
-      equityValues.push(value);
+      timestamps.push(entry.timestamp);
+      values.push(value);
     }
   }
 
-  return {
-    date,
-    equity: equityValues,
-  };
+  return def.deriveSeries === undefined
+    ? { timestamps, values }
+    : def.deriveSeries({ timestamps, values });
 });
 
 function onChartClick() {
@@ -95,9 +94,10 @@ function onChartClick() {
   <LineChart
     :maintain-aspect-ratio="maintainAspectRatio"
     :average-factor="averageFactor"
-    :ydata="lineChartData.equity"
-    :xdata="lineChartData.date"
+    :ydata="lineChartData.values"
+    :xdata="lineChartData.timestamps"
     :y-label="yLabel"
+    :unit="unit"
     :pan="pan"
     :zoom="zoom"
     @click="onChartClick" />

--- a/src/features/XIT/FINCH/LineChart.vue
+++ b/src/features/XIT/FINCH/LineChart.vue
@@ -14,7 +14,7 @@ import {
   Tooltip,
 } from 'chart.js';
 import zoomPlugin from 'chartjs-plugin-zoom';
-import { fixed0, fixed01, hhmm, ddmm, ddmmyyyy, formatCurrency } from '@src/utils/format';
+import { fixed0, fixed01, hhmm, ddmm, ddmmyyyy, formatCurrency, percent2 } from '@src/utils/format';
 
 Chart.register(
   LineController,
@@ -31,6 +31,7 @@ const {
   averageFactor = 0.2,
   maintainAspectRatio,
   pan,
+  unit = 'currency',
   xdata,
   ydata,
   yLabel,
@@ -39,6 +40,7 @@ const {
   averageFactor?: number;
   maintainAspectRatio?: boolean;
   pan?: boolean;
+  unit?: 'currency' | 'percent';
   xdata: number[];
   ydata: number[];
   yLabel?: string;
@@ -46,7 +48,14 @@ const {
 }>();
 
 const sortedYData = computed(() => ydata.slice().sort((a, b) => a - b));
-const maxY = computed(() => sortedYData.value[sortedYData.value.length - 1]);
+const minY = computed(() => sortedYData.value[0] ?? 0);
+const maxY = computed(() => sortedYData.value[sortedYData.value.length - 1] ?? 0);
+
+// Growth rates sit close to zero, so two decimals keep neighbouring axis ticks
+// distinct instead of collapsing them into a run of identical labels.
+function formatValue(value: number) {
+  return unit === 'percent' ? percent2(value) : formatCurrency(value);
+}
 
 function calculateMovingAverage(data: number[], factor: number) {
   factor = Math.min(Math.max(factor, 0), 1);
@@ -155,19 +164,22 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
       ticks: {
         color: '#999',
         callback(value: string | number) {
-          if (typeof value === 'number') {
-            if (value >= 1_000_000_000) {
-              return formatY(value, 1_000_000_000, 'B');
-            }
-            if (value >= 1_000_000) {
-              return formatY(value, 1_000_000, 'M');
-            }
-            if (value >= 1_000) {
-              return formatY(value, 1_000, 'K');
-            }
-            return fixed0(value);
+          if (typeof value !== 'number') {
+            return value;
           }
-          return value;
+          if (unit === 'percent') {
+            return percent2(value);
+          }
+          if (value >= 1_000_000_000) {
+            return formatY(value, 1_000_000_000, 'B');
+          }
+          if (value >= 1_000_000) {
+            return formatY(value, 1_000_000, 'M');
+          }
+          if (value >= 1_000) {
+            return formatY(value, 1_000, 'K');
+          }
+          return fixed0(value);
         },
       },
     },
@@ -195,7 +207,7 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
           if (label) {
             label += ': ';
           }
-          label += formatCurrency(item.parsed.y);
+          label += formatValue(item.parsed.y);
           return label;
         },
       },
@@ -204,7 +216,7 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
     zoom: {
       limits: {
         x: { min: xdata[0], max: xdata[xdata.length - 1] },
-        y: { min: 0, max: maxY.value * 1.1 },
+        y: { min: Math.min(0, minY.value * 1.1), max: Math.max(0, maxY.value * 1.1) },
       },
       pan: {
         enabled: pan,

--- a/src/features/XIT/FINCH/LineChart.vue
+++ b/src/features/XIT/FINCH/LineChart.vue
@@ -110,7 +110,11 @@ const chartData = computed<ChartData<'line', number[], number | string | Date>>(
       data: ydata,
       borderColor: '#f7a600',
       fill: false,
-      pointRadius: 0.25,
+      // A rate chart carries one meaningful observation per recorded period, and reading
+      // the pace means reading those values; hiding them leaves only the line drawn
+      // between them, which implies days that were never measured. A currency series is
+      // dense enough that the same dots would just be noise.
+      pointRadius: unit === 'percent' ? 2.5 : 0.25,
       pointBackgroundColor: '#f7a600',
       showLine: false,
     },

--- a/src/features/XIT/FINCH/charts.ts
+++ b/src/features/XIT/FINCH/charts.ts
@@ -1,12 +1,19 @@
 import { PartialBalanceSheet } from '@src/core/balance/balance-sheet';
 import * as summary from '@src/core/balance/balance-sheet-summary';
 import { userData } from '@src/store/user-data';
+import { calcDailyGrowthRate, ChartSeries } from '@src/features/XIT/FINCH/growth-rate';
 
 export type ChartDef = {
   value: string;
   label: string;
   getValue: (x: PartialBalanceSheet) => number | undefined;
   less?: boolean;
+  // Rewrites the daily series into a derived one. Rate-style charts need this
+  // because their value depends on the previous data point, which a per-sheet
+  // getValue cannot see.
+  deriveSeries?: (series: ChartSeries) => ChartSeries;
+  // Unit of the plotted value. Drives axis and tooltip formatting.
+  unit?: 'currency' | 'percent';
 };
 
 export const charts = computed<ChartDef[]>(() => {
@@ -15,6 +22,13 @@ export const charts = computed<ChartDef[]>(() => {
       value: 'EQUITY',
       label: userData.fullEquityMode ? 'Equity' : 'Equity (Partial)',
       getValue: summary.calcEquity,
+    },
+    {
+      value: 'EQUITY GROWTH',
+      label: userData.fullEquityMode ? 'Equity Growth' : 'Equity Growth (Partial)',
+      getValue: summary.calcEquity,
+      deriveSeries: calcDailyGrowthRate,
+      unit: 'percent',
     },
 
     // =========================

--- a/src/features/XIT/FINCH/growth-rate.test.ts
+++ b/src/features/XIT/FINCH/growth-rate.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { calcDailyGrowthRate } from '@src/features/XIT/FINCH/growth-rate';
+
+const day = 86400000;
+const start = Date.UTC(2026, 0, 1);
+
+function at(...days: number[]) {
+  return days.map(x => start + x * day);
+}
+
+describe('calcDailyGrowthRate', () => {
+  it('reports zero growth for a flat series', () => {
+    const result = calcDailyGrowthRate({ timestamps: at(0, 1, 2), values: [1000, 1000, 1000] });
+    expect(result.values).toEqual([0, 0]);
+  });
+
+  it('anchors each rate to the later of the two points', () => {
+    const result = calcDailyGrowthRate({ timestamps: at(0, 1, 2), values: [1000, 1100, 1210] });
+    expect(result.timestamps).toEqual(at(1, 2));
+    expect(result.values[0]).toBeCloseTo(0.1, 10);
+    expect(result.values[1]).toBeCloseTo(0.1, 10);
+  });
+
+  it('reports negative growth when the value shrinks', () => {
+    const result = calcDailyGrowthRate({ timestamps: at(0, 1), values: [1000, 900] });
+    expect(result.values[0]).toBeCloseTo(-0.1, 10);
+  });
+
+  // The balance history skips days the player was not logged in, so an unnormalized
+  // rate would render four days of compounding as one 46% day.
+  it('spreads a multi-day gap across the days it covers', () => {
+    const result = calcDailyGrowthRate({ timestamps: at(0, 4), values: [1000, 1464.1] });
+    expect(result.values[0]).toBeCloseTo(0.1, 10);
+  });
+
+  it('drops points where either end is non-positive', () => {
+    const result = calcDailyGrowthRate({
+      timestamps: at(0, 1, 2, 3),
+      values: [1000, 0, -500, 1000],
+    });
+    expect(result).toEqual({ timestamps: [], values: [] });
+  });
+
+  it('drops points that did not advance in time', () => {
+    const result = calcDailyGrowthRate({ timestamps: at(0, 0), values: [1000, 1100] });
+    expect(result).toEqual({ timestamps: [], values: [] });
+  });
+
+  it('returns nothing for a series too short to have a predecessor', () => {
+    expect(calcDailyGrowthRate({ timestamps: at(0), values: [1000] })).toEqual({
+      timestamps: [],
+      values: [],
+    });
+    expect(calcDailyGrowthRate({ timestamps: [], values: [] })).toEqual({
+      timestamps: [],
+      values: [],
+    });
+  });
+});

--- a/src/features/XIT/FINCH/growth-rate.ts
+++ b/src/features/XIT/FINCH/growth-rate.ts
@@ -1,0 +1,36 @@
+import { diffDays } from '@src/utils/time-diff';
+
+export interface ChartSeries {
+  timestamps: number[];
+  values: number[];
+}
+
+// Converts a series of absolute values into the compounded rate of change per day
+// between consecutive points. The rate is normalized by the elapsed time instead of
+// being taken point to point, because the balance history only records days the
+// player was logged in: without it, a week-long gap would render its entire change
+// as a single-day spike.
+export function calcDailyGrowthRate(series: ChartSeries): ChartSeries {
+  const timestamps: number[] = [];
+  const values: number[] = [];
+
+  for (let i = 1; i < series.values.length; i++) {
+    const previous = series.values[i - 1];
+    const current = series.values[i];
+    // A percentage rate of change is undefined once either end is non-positive,
+    // so days spent at or below zero equity are dropped rather than plotted.
+    if (previous <= 0 || current <= 0) {
+      continue;
+    }
+
+    const days = diffDays(series.timestamps[i - 1], series.timestamps[i], true);
+    if (days <= 0) {
+      continue;
+    }
+
+    timestamps.push(series.timestamps[i]);
+    values.push((current / previous) ** (1 / days) - 1);
+  }
+
+  return { timestamps, values };
+}


### PR DESCRIPTION
Closes JAC-22.

## What

Adds an **Equity Growth** chart to `XIT FINCH`, next to the existing Equity chart. It plots how fast equity is compounding as a percentage per day, rather than its absolute value.

Reachable both from the chart dropdown and as its own buffer: `XIT FINCH EQUITY GROWTH`.

## Why per-day, not point-to-point

`HistoryChart` keeps one balance point per day, but the history only records days the player was logged in. A raw `current / previous - 1` would render a week-long gap as a single 46% day. The value is therefore the compounded daily rate, `(current / previous) ** (1 / daysElapsed) - 1`.

Days where either end is at or below zero equity are dropped — a percentage rate of change is not defined across a sign change.

## Shape of the change

`ChartDef` gains two optional fields so the metric stays declared in `charts.ts` alongside every other metric:

- `deriveSeries` — for values that depend on the previous data point rather than a single balance sheet, which per-sheet `getValue` cannot express.
- `unit` — switches axis and tooltip between currency and percent.

Both default to the existing behaviour, so no other chart changes.

One pre-existing constraint had to move: `LineChart`'s y zoom limit was hard-floored at `min: 0`, which would have made a shrinking-equity chart impossible to pan into. It is now `Math.min(0, minY * 1.1)` / `Math.max(0, maxY * 1.1)`, which is identical to the old behaviour for any all-positive series.

## Verification

`pnpm run compile` and `pnpm test` (10 files, 84 tests) pass at `f7d6072`.

**`tsc --noEmit` does not type-check `.vue` script blocks** and there is no `vue-tsc` in this repo, so a green `compile` says nothing about the SFC changes. This bit during development: an unimported `percent0` passed both `tsc` and eslint and would only have thrown at runtime. The `.vue` changes are therefore verified in the live game, and the series math is verified by unit tests.

`src/features/XIT/FINCH/growth-rate.test.ts` covers the pure derivation. Each guard was mutation-proven — the test named for it was shown failing once against a deliberately broken implementation:

| Mutation | Test that caught it |
|---|---|
| drop the per-day normalisation | spreads a multi-day gap across the days it covers |
| drop the non-positive guard | drops points where either end is non-positive |
| weaken the time-advance guard | drops points that did not advance in time |
| anchor the rate to the earlier point | anchors each rate to the later of the two points |
| return the ratio instead of the delta | 4 tests |

Live game check against a real account, extension loaded unpacked:

- `XIT FINCH EQUITY GROWTH` renders with y label "Equity Growth", a percentage axis (`0.05%` … `0.35%`), and a tooltip reading `12:10 AM 08/31/2026 — Equity Growth: 0.08%`.
- "Equity Growth" appears second in the dropdown of the default `XIT FINCH` view, and selecting it switches that chart to a percentage axis too.

Not exercised by live data, and reviewers should know it: the test account's history yields only two derived points and never had shrinking equity, so **negative growth rendering and the negative y pan clamp were not seen in the game** — only in unit tests and code.
