### PR TITLE
Port XIT FLOW from upstream PR #238

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- `XIT FLOW`: New buffer with one row per material across your bases, showing daily production, consumption, the net delta and what that delta is worth. Accepts `XIT BURN`'s planet parameters (`XIT FLOW <planet...>`, `XIT FLOW NOT <planet...>`), sorts by any column and copies as TSV
+- `XIT FLOW`: Click a Buy or Sell price to enter your own, e.g. for a partner deal. Overrides are marked with `*` and used only by `XIT FLOW`; `XIT FINPR`, `XIT FINBS` and `XIT MAT` keep market prices
+
 ## 1.1.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Added
 
-- `XIT FLOW`: New buffer with one row per material across your bases, showing daily production, consumption, the net delta and what that delta is worth. Accepts `XIT BURN`'s planet parameters (`XIT FLOW <planet...>`, `XIT FLOW NOT <planet...>`), sorts by any column and copies as TSV
-- `XIT FLOW`: Click a Buy or Sell price to enter your own, e.g. for a partner deal. Overrides are marked with `*` and used only by `XIT FLOW`; `XIT FINPR`, `XIT FINBS` and `XIT MAT` keep market prices
+- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
+
+### Fixed
+
+- `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.
+- `XIT BURN`: A material whose production and consumption cancel out no longer shows 0 days left, in both the per-planet rows and the Overall row.
 
 ## 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## Unreleased
 
-### Added
-
-- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
-
-### Fixed
-
-- `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.
-- `XIT BURN`: A material whose production and consumption cancel out no longer shows 0 days left, in both the per-planet rows and the Overall row.
-
 ## 1.1.2
 
 ### Added

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -416,6 +416,14 @@ GOVBURN's `planetDays(planet, config, now)` hit exactly this and had to become
 `planetDays(planet, planetConfig, now)` before `utils.ts` could be tested. `config` is the
 sharp edge, but the rule covers every name in the table above.
 
+The same class of trap reaches unit tests through ordinary imports, not just auto-imports:
+`@src/infrastructure/fio/cx` calls `dayjs.duration(...)` at module scope, and the `duration`
+plugin is registered by the app entry point, so any test that transitively imports it dies
+with `default.duration is not a function`. `@src/core/flow` imports `cx` only for
+`getMarketPrices`, which the pure `calculateMaterialFlow` never calls — `vi.mock` the `cx`
+module in the test rather than adding a vitest setup file that pulls the whole plugin
+registration into every run.
+
 ---
 
 ## `C` Object

--- a/src/core/flow.test.ts
+++ b/src/core/flow.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The cx module registers a dayjs plugin at import time that the app entry point normally
+// installs; calculateMaterialFlow takes its prices as an argument and never calls it.
+vi.mock('@src/infrastructure/fio/cx', () => ({
+  getMarketPrices: () => ({ buy: undefined, sell: undefined }),
+}));
+
+import { calculateMaterialFlow, FlowPrices } from '@src/core/flow';
+import { MaterialBurn, PlanetBurn } from '@src/core/burn';
+
+function burn(values: Partial<MaterialBurn>): MaterialBurn {
+  return {
+    input: 0,
+    output: 0,
+    workforce: 0,
+    dailyAmount: 0,
+    remainingAllocation: 0,
+    inventory: 0,
+    daysLeft: 0,
+    type: 'input',
+    ...values,
+  };
+}
+
+function planet(naturalId: string, planetName: string, values: Record<string, MaterialBurn>) {
+  return { storeId: naturalId, planetName, naturalId, burn: values } satisfies PlanetBurn;
+}
+
+function prices(table: Record<string, { buy?: number; sell?: number }>) {
+  return (ticker: string): FlowPrices => ({
+    buy: table[ticker]?.buy,
+    sell: table[ticker]?.sell,
+    buyOverride: false,
+    sellOverride: false,
+  });
+}
+
+const noPrices = prices({});
+
+describe('calculateMaterialFlow', () => {
+  it('sums production and consumption across planets, counting workforce as consumption', () => {
+    const flows = calculateMaterialFlow(
+      [
+        planet('OT-580b', 'Montem', { RAT: burn({ output: 10, workforce: 4 }) }),
+        planet('UV-351a', 'Promitor', { RAT: burn({ input: 3, workforce: 2 }) }),
+      ],
+      noPrices,
+    );
+
+    expect(flows).toHaveLength(1);
+    const rat = flows[0];
+    expect(rat.ticker).toBe('RAT');
+    expect(rat.production).toBe(10);
+    expect(rat.consumption).toBe(9);
+    expect(rat.delta).toBe(1);
+  });
+
+  it('records producers and consumers per planet, sorted by amount', () => {
+    const flows = calculateMaterialFlow(
+      [
+        planet('A', 'Small', { RAT: burn({ output: 1, input: 5 }) }),
+        planet('B', 'Big', { RAT: burn({ output: 9, input: 2 }) }),
+      ],
+      noPrices,
+    );
+
+    expect(flows[0].producers.map(x => [x.planetName, x.amount])).toEqual([
+      ['Big', 9],
+      ['Small', 1],
+    ]);
+    expect(flows[0].consumers.map(x => [x.planetName, x.amount])).toEqual([
+      ['Small', 5],
+      ['Big', 2],
+    ]);
+  });
+
+  it('omits a planet from producers or consumers when its contribution is zero', () => {
+    const flows = calculateMaterialFlow(
+      [
+        planet('A', 'Producer', { RAT: burn({ output: 4 }) }),
+        planet('B', 'Consumer', { RAT: burn({ input: 4 }) }),
+      ],
+      noPrices,
+    );
+
+    expect(flows[0].producers.map(x => x.planetName)).toEqual(['Producer']);
+    expect(flows[0].consumers.map(x => x.planetName)).toEqual(['Consumer']);
+  });
+
+  it('drops materials with neither production nor consumption', () => {
+    const flows = calculateMaterialFlow([planet('A', 'Idle', { RAT: burn({}) })], noPrices);
+    expect(flows).toEqual([]);
+  });
+
+  it('values a deficit at the buy price and a surplus at the sell price', () => {
+    const table = prices({ RAT: { buy: 100, sell: 60 }, DW: { buy: 100, sell: 60 } });
+    const flows = calculateMaterialFlow(
+      [planet('A', 'Montem', { RAT: burn({ input: 2 }), DW: burn({ output: 3 }) })],
+      table,
+    );
+
+    const rat = flows.find(x => x.ticker === 'RAT')!;
+    const dw = flows.find(x => x.ticker === 'DW')!;
+    expect(rat.delta).toBe(-2);
+    expect(rat.currencyDelta).toBe(-200);
+    expect(dw.delta).toBe(3);
+    expect(dw.currencyDelta).toBe(180);
+  });
+
+  it('values a balanced material at zero using the sell price', () => {
+    const flows = calculateMaterialFlow(
+      [
+        planet('A', 'Producer', { RAT: burn({ output: 5 }) }),
+        planet('B', 'Consumer', { RAT: burn({ input: 5 }) }),
+      ],
+      prices({ RAT: { buy: 100, sell: 60 } }),
+    );
+
+    expect(flows[0].delta).toBe(0);
+    expect(flows[0].currencyDelta).toBe(0);
+  });
+
+  it('leaves the value undefined when the relevant side has no price', () => {
+    const flows = calculateMaterialFlow(
+      [planet('A', 'Montem', { RAT: burn({ input: 2 }), DW: burn({ output: 3 }) })],
+      prices({ RAT: { sell: 60 }, DW: { buy: 100 } }),
+    );
+
+    expect(flows.find(x => x.ticker === 'RAT')!.currencyDelta).toBeUndefined();
+    expect(flows.find(x => x.ticker === 'DW')!.currencyDelta).toBeUndefined();
+  });
+
+  it('carries the override flags through to the row', () => {
+    const flows = calculateMaterialFlow(
+      [planet('A', 'Montem', { RAT: burn({ output: 1 }) })],
+      () => ({
+        buy: 1,
+        sell: 2,
+        buyOverride: false,
+        sellOverride: true,
+      }),
+    );
+
+    expect(flows[0].buyOverride).toBe(false);
+    expect(flows[0].sellOverride).toBe(true);
+  });
+});

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -1,5 +1,6 @@
 import { getPlanetBurn, PlanetBurn } from '@src/core/burn';
-import { getPrice } from '@src/infrastructure/fio/cx';
+import { getMarketPrices, MarketPrices } from '@src/infrastructure/fio/cx';
+import { userData } from '@src/store/user-data';
 
 export interface PlanetContribution {
   naturalId: string;
@@ -7,20 +8,27 @@ export interface PlanetContribution {
   amount: number;
 }
 
-export interface MaterialFlow {
+export interface FlowPrices extends MarketPrices {
+  buyOverride: boolean;
+  sellOverride: boolean;
+}
+
+export interface MaterialFlow extends FlowPrices {
   ticker: string;
   production: number;
   consumption: number;
   delta: number;
-  price: number | undefined;
+  // Surplus is valued at the sell price, deficit at the buy price.
   currencyDelta: number | undefined;
   producers: PlanetContribution[];
   consumers: PlanetContribution[];
 }
 
+export type PriceSide = 'buy' | 'sell';
+
 export function calculateMaterialFlow(
   burns: PlanetBurn[],
-  price: (ticker: string) => number | undefined,
+  prices: (ticker: string) => FlowPrices,
 ): MaterialFlow[] {
   const byTicker = new Map<string, MaterialFlow>();
   for (const planet of burns) {
@@ -33,7 +41,10 @@ export function calculateMaterialFlow(
           production: 0,
           consumption: 0,
           delta: 0,
-          price: undefined,
+          buy: undefined,
+          sell: undefined,
+          buyOverride: false,
+          sellOverride: false,
           currencyDelta: undefined,
           producers: [],
           consumers: [],
@@ -60,8 +71,13 @@ export function calculateMaterialFlow(
       continue;
     }
     flow.delta = flow.production - flow.consumption;
-    flow.price = price(flow.ticker);
-    flow.currencyDelta = flow.price === undefined ? undefined : flow.delta * flow.price;
+    const { buy, sell, buyOverride, sellOverride } = prices(flow.ticker);
+    flow.buy = buy;
+    flow.sell = sell;
+    flow.buyOverride = buyOverride;
+    flow.sellOverride = sellOverride;
+    const price = flow.delta < 0 ? flow.buy : flow.sell;
+    flow.currencyDelta = price === undefined ? undefined : flow.delta * price;
     flow.producers.sort((a, b) => b.amount - a.amount);
     flow.consumers.sort((a, b) => b.amount - a.amount);
     result.push(flow);
@@ -72,5 +88,26 @@ export function calculateMaterialFlow(
 // Sites whose production or workforce data hasn't arrived yet are omitted.
 export function getMaterialFlow(sites: PrunApi.Site[]) {
   const burns = sites.map(getPlanetBurn).filter(x => x !== undefined);
-  return calculateMaterialFlow(burns, getPrice);
+  return calculateMaterialFlow(burns, getFlowPrices);
+}
+
+export function getFlowPrices(ticker: string): FlowPrices {
+  const override = userData.settings.flow.overrides[ticker];
+  const market = getMarketPrices(ticker);
+  return {
+    buy: override?.buy ?? market.buy,
+    sell: override?.sell ?? market.sell,
+    buyOverride: override?.buy !== undefined,
+    sellOverride: override?.sell !== undefined,
+  };
+}
+
+export function setFlowPriceOverride(ticker: string, side: PriceSide, price: number | undefined) {
+  const overrides = userData.settings.flow.overrides;
+  const override = { ...overrides[ticker], [side]: price };
+  if (override.buy === undefined && override.sell === undefined) {
+    delete overrides[ticker];
+    return;
+  }
+  overrides[ticker] = override;
 }

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -1,0 +1,76 @@
+import { getPlanetBurn, PlanetBurn } from '@src/core/burn';
+import { getPrice } from '@src/infrastructure/fio/cx';
+
+export interface PlanetContribution {
+  naturalId: string;
+  planetName: string;
+  amount: number;
+}
+
+export interface MaterialFlow {
+  ticker: string;
+  production: number;
+  consumption: number;
+  delta: number;
+  price: number | undefined;
+  currencyDelta: number | undefined;
+  producers: PlanetContribution[];
+  consumers: PlanetContribution[];
+}
+
+export function calculateMaterialFlow(
+  burns: PlanetBurn[],
+  price: (ticker: string) => number | undefined,
+): MaterialFlow[] {
+  const byTicker = new Map<string, MaterialFlow>();
+  for (const planet of burns) {
+    for (const ticker of Object.keys(planet.burn)) {
+      const mat = planet.burn[ticker];
+      let flow = byTicker.get(ticker);
+      if (!flow) {
+        flow = {
+          ticker,
+          production: 0,
+          consumption: 0,
+          delta: 0,
+          price: undefined,
+          currencyDelta: undefined,
+          producers: [],
+          consumers: [],
+        };
+        byTicker.set(ticker, flow);
+      }
+
+      const contribution = { naturalId: planet.naturalId, planetName: planet.planetName };
+      if (mat.output > 0) {
+        flow.production += mat.output;
+        flow.producers.push({ ...contribution, amount: mat.output });
+      }
+      const consumed = mat.input + mat.workforce;
+      if (consumed > 0) {
+        flow.consumption += consumed;
+        flow.consumers.push({ ...contribution, amount: consumed });
+      }
+    }
+  }
+
+  const result: MaterialFlow[] = [];
+  for (const flow of byTicker.values()) {
+    if (flow.production === 0 && flow.consumption === 0) {
+      continue;
+    }
+    flow.delta = flow.production - flow.consumption;
+    flow.price = price(flow.ticker);
+    flow.currencyDelta = flow.price === undefined ? undefined : flow.delta * flow.price;
+    flow.producers.sort((a, b) => b.amount - a.amount);
+    flow.consumers.sort((a, b) => b.amount - a.amount);
+    result.push(flow);
+  }
+  return result;
+}
+
+// Sites whose production or workforce data hasn't arrived yet are omitted.
+export function getMaterialFlow(sites: PrunApi.Site[]) {
+  const burns = sites.map(getPlanetBurn).filter(x => x !== undefined);
+  return calculateMaterialFlow(burns, getPrice);
+}

--- a/src/features/XIT/FLOW/FLOW.ts
+++ b/src/features/XIT/FLOW/FLOW.ts
@@ -1,0 +1,23 @@
+import FLOW from '@src/features/XIT/FLOW/FLOW.vue';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+
+xit.add({
+  command: 'FLOW',
+  name: parameters => {
+    if (parameters[0] && !parameters[1]) {
+      const site = sitesStore.getByPlanetNaturalIdOrName(parameters[0]);
+      if (site) {
+        const name = getEntityNameFromAddress(site.address);
+        return `MATERIAL FLOW - ${name}`;
+      }
+    }
+
+    return 'MATERIAL FLOW';
+  },
+  description: 'Shows daily production, consumption and value of each material across bases.',
+  optionalParameters: 'Planet Identifier(s), NOT',
+  contextItems: () => [{ cmd: 'XIT BURN' }, { cmd: 'XIT FINPR' }, { cmd: 'XIT SET FIN' }],
+  component: () => FLOW,
+  bufferSize: [900, 500],
+});

--- a/src/features/XIT/FLOW/FLOW.ts
+++ b/src/features/XIT/FLOW/FLOW.ts
@@ -19,5 +19,5 @@ xit.add({
   optionalParameters: 'Planet Identifier(s), NOT',
   contextItems: () => [{ cmd: 'XIT BURN' }, { cmd: 'XIT FINPR' }, { cmd: 'XIT SET FIN' }],
   component: () => FLOW,
-  bufferSize: [900, 500],
+  bufferSize: [1000, 500],
 });

--- a/src/features/XIT/FLOW/FLOW.vue
+++ b/src/features/XIT/FLOW/FLOW.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import CopyButton from '@src/components/CopyButton.vue';
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import FlowRow from '@src/features/XIT/FLOW/FlowRow.vue';
+import SortHeader from '@src/features/XIT/FLOW/SortHeader.vue';
+import { useTileState } from '@src/features/XIT/FLOW/tile-state';
+import { getMaterialFlow, MaterialFlow, PlanetContribution } from '@src/core/flow';
+import { convertToPlanetNaturalId } from '@src/core/planet-natural-id';
+import { compareMaterials } from '@src/core/sort-materials';
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { findWithQuery } from '@src/utils/find-with-query';
+
+const parameters = useXitParameters();
+
+const sites = computed(() => {
+  const allSites = sitesStore.all.value;
+  if (!allSites) {
+    return undefined;
+  }
+  if (parameters.length === 0) {
+    return allSites;
+  }
+
+  const result = findWithQuery(parameters, findSites);
+  let matches = result.includeAll ? allSites : result.include;
+  if (result.excludeAll) {
+    matches = [];
+  }
+  return matches.filter(x => !result.exclude.has(x));
+});
+
+function findSites(term: string, parts: string[]) {
+  if (term === 'all') {
+    return sitesStore.all.value;
+  }
+
+  const naturalId = convertToPlanetNaturalId(term, parts);
+  return sitesStore.getByPlanetNaturalId(naturalId);
+}
+
+const flows = computed(() => (sites.value ? getMaterialFlow(sites.value) : undefined));
+
+const sort = useTileState('sort');
+const desc = useTileState('desc');
+
+const sorted = computed(() => {
+  if (!flows.value) {
+    return undefined;
+  }
+
+  const key = sort.value;
+  const direction = desc.value ? -1 : 1;
+  return flows.value.slice().sort((a, b) => {
+    // Unpriced rows always go last.
+    const aUnpriced = a.currencyDelta === undefined;
+    const bUnpriced = b.currencyDelta === undefined;
+    if (aUnpriced !== bUnpriced) {
+      return aUnpriced ? 1 : -1;
+    }
+    // Same category-then-ticker order as XIT BURN.
+    const byMaterial = compareMaterials(
+      materialsStore.getByTicker(a.ticker),
+      materialsStore.getByTicker(b.ticker),
+    );
+    if (key === 'ticker') {
+      return byMaterial * direction;
+    }
+    const diff = (a[key] ?? 0) - (b[key] ?? 0);
+    return diff === 0 ? byMaterial : diff * direction;
+  });
+});
+
+function formatFlowTable(rows: MaterialFlow[]) {
+  const round = (x: number) => Math.round(x * 1000) / 1000;
+  const planets = (contributions: PlanetContribution[]) =>
+    contributions.map(x => `${x.planetName} (${x.naturalId}): ${round(x.amount)}`).join('; ');
+  const lines = ['Ticker\tProduction\tConsumption\tDelta\tValue\tProducers\tConsumers'];
+  for (const flow of rows) {
+    const value = flow.currencyDelta === undefined ? '' : round(flow.currencyDelta);
+    lines.push(
+      [
+        flow.ticker,
+        round(flow.production),
+        round(flow.consumption),
+        round(flow.delta),
+        value,
+        planets(flow.producers),
+        planets(flow.consumers),
+      ].join('\t'),
+    );
+  }
+  return lines.join('\n');
+}
+
+function copyFlowTable() {
+  return sorted.value ? formatFlowTable(sorted.value) : '';
+}
+</script>
+
+<template>
+  <LoadingSpinner v-if="sorted === undefined" />
+  <template v-else>
+    <div :class="C.ComExOrdersPanel.filter">
+      <div :class="$style.spacer" />
+      <CopyButton :copy-fn="copyFlowTable" data-tooltip-position="bottom" />
+    </div>
+    <table :class="$style.table">
+      <thead>
+        <tr>
+          <SortHeader sort-key="ticker">Ticker</SortHeader>
+          <SortHeader sort-key="delta">Delta</SortHeader>
+          <SortHeader sort-key="production">Prod</SortHeader>
+          <SortHeader sort-key="consumption">Cons</SortHeader>
+          <SortHeader sort-key="currencyDelta">Value</SortHeader>
+          <th>Producers</th>
+          <th>Consumers</th>
+        </tr>
+      </thead>
+      <tbody>
+        <FlowRow v-for="flow in sorted" :key="flow.ticker" :flow="flow" />
+      </tbody>
+    </table>
+  </template>
+</template>
+
+<style module>
+.spacer {
+  flex: 1;
+}
+
+.table tr > :nth-child(n + 2):nth-child(-n + 5) {
+  text-align: right;
+}
+
+.table th {
+  position: sticky;
+  top: 0;
+  background-color: #222222;
+  z-index: 1;
+}
+</style>

--- a/src/features/XIT/FLOW/FLOW.vue
+++ b/src/features/XIT/FLOW/FLOW.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import CopyButton from '@src/components/CopyButton.vue';
+import InlineFlex from '@src/components/InlineFlex.vue';
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import Tooltip from '@src/components/Tooltip.vue';
 import FlowRow from '@src/features/XIT/FLOW/FlowRow.vue';
 import SortHeader from '@src/features/XIT/FLOW/SortHeader.vue';
 import { useTileState } from '@src/features/XIT/FLOW/tile-state';
@@ -74,18 +76,24 @@ const sorted = computed(() => {
 
 function formatFlowTable(rows: MaterialFlow[]) {
   const round = (x: number) => Math.round(x * 1000) / 1000;
-  const planets = (contributions: PlanetContribution[]) =>
-    contributions.map(x => `${x.planetName} (${x.naturalId}): ${round(x.amount)}`).join('; ');
-  const lines = ['Ticker\tProduction\tConsumption\tDelta\tValue\tProducers\tConsumers'];
+  function planets(contributions: PlanetContribution[]) {
+    return contributions
+      .map(x => `${x.planetName} (${x.naturalId}): ${round(x.amount)}`)
+      .join('; ');
+  }
+  const price = (value: number | undefined, override: boolean) =>
+    value === undefined ? '' : round(value) + (override ? '*' : '');
+  const lines = ['Ticker\tProduction\tConsumption\tDelta\tBuy\tSell\tValue\tProducers\tConsumers'];
   for (const flow of rows) {
-    const value = flow.currencyDelta === undefined ? '' : round(flow.currencyDelta);
     lines.push(
       [
         flow.ticker,
         round(flow.production),
         round(flow.consumption),
         round(flow.delta),
-        value,
+        price(flow.buy, flow.buyOverride),
+        price(flow.sell, flow.sellOverride),
+        price(flow.currencyDelta, false),
         planets(flow.producers),
         planets(flow.consumers),
       ].join('\t'),
@@ -113,13 +121,29 @@ function copyFlowTable() {
           <SortHeader sort-key="delta">Delta</SortHeader>
           <SortHeader sort-key="production">Prod</SortHeader>
           <SortHeader sort-key="consumption">Cons</SortHeader>
-          <SortHeader sort-key="currencyDelta">Value</SortHeader>
+          <th>Buy</th>
+          <th>Sell</th>
+          <SortHeader sort-key="currencyDelta">
+            <InlineFlex>
+              Value
+              <Tooltip
+                position="bottom"
+                tooltip="Surplus valued at the sell price, deficit at the buy price.
+                 Click a Buy or Sell price to override it, e.g. for a partner deal."
+                :class="$style.tooltip"
+                @click.stop />
+            </InlineFlex>
+          </SortHeader>
           <th>Producers</th>
           <th>Consumers</th>
         </tr>
       </thead>
       <tbody>
-        <FlowRow v-for="flow in sorted" :key="flow.ticker" :flow="flow" />
+        <FlowRow
+          v-for="(flow, i) in sorted"
+          :key="flow.ticker"
+          :flow="flow"
+          :last="i === sorted.length - 1" />
       </tbody>
     </table>
   </template>
@@ -130,8 +154,13 @@ function copyFlowTable() {
   flex: 1;
 }
 
-.table tr > :nth-child(n + 2):nth-child(-n + 5) {
+.table tr > :nth-child(n + 2):nth-child(-n + 7) {
   text-align: right;
+}
+
+/* The sort header is nowrap; let the tooltip text wrap. */
+.tooltip {
+  white-space: normal;
 }
 
 .table th {

--- a/src/features/XIT/FLOW/FLOW.vue
+++ b/src/features/XIT/FLOW/FLOW.vue
@@ -132,8 +132,7 @@ function copyFlowTable() {
                 position="bottom"
                 tooltip="Surplus valued at the sell price, deficit at the buy price.
                  Click a Buy or Sell price to override it, e.g. for a partner deal."
-                :class="$style.tooltip"
-                @click.stop />
+                :class="$style.tooltip" />
             </InlineFlex>
           </SortHeader>
           <th>Producers</th>

--- a/src/features/XIT/FLOW/FLOW.vue
+++ b/src/features/XIT/FLOW/FLOW.vue
@@ -55,11 +55,13 @@ const sorted = computed(() => {
   const key = sort.value;
   const direction = desc.value ? -1 : 1;
   return flows.value.slice().sort((a, b) => {
-    // Unpriced rows always go last.
-    const aUnpriced = a.currencyDelta === undefined;
-    const bUnpriced = b.currencyDelta === undefined;
-    if (aUnpriced !== bUnpriced) {
-      return aUnpriced ? 1 : -1;
+    if (key === 'currencyDelta') {
+      // Unpriced rows always go last.
+      const aUnpriced = a.currencyDelta === undefined;
+      const bUnpriced = b.currencyDelta === undefined;
+      if (aUnpriced !== bUnpriced) {
+        return aUnpriced ? 1 : -1;
+      }
     }
     // Same category-then-ticker order as XIT BURN.
     const byMaterial = compareMaterials(

--- a/src/features/XIT/FLOW/FlowRow.vue
+++ b/src/features/XIT/FLOW/FlowRow.vue
@@ -2,7 +2,8 @@
 import { MaterialFlow, PlanetContribution } from '@src/core/flow';
 import MaterialIcon from '@src/components/MaterialIcon.vue';
 import PriceCell from '@src/features/XIT/FLOW/PriceCell.vue';
-import { fixed0, fixed01, fixed02, fixed1, fixed2, formatCurrency } from '@src/utils/format';
+import { formatPrice } from '@src/features/XIT/FLOW/format';
+import { fixed0, fixed1, fixed2 } from '@src/utils/format';
 
 const { flow, last } = defineProps<{ flow: MaterialFlow; last?: boolean }>();
 
@@ -11,23 +12,18 @@ const tooltipPosition = computed(() => (last ? 'top' : 'bottom'));
 
 function formatAmount(value: number) {
   const abs = Math.abs(value);
-  return abs >= 1000 ? fixed0(value) : abs >= 100 ? fixed1(value) : fixed2(value);
+  let format = fixed2;
+  if (abs >= 1000) {
+    format = fixed0;
+  } else if (abs >= 100) {
+    format = fixed1;
+  }
+  return format(value);
 }
 
-const valueText = computed(() => {
-  const value = flow.currencyDelta;
-  if (value === undefined) {
-    return '--';
-  }
-  const abs = Math.abs(value);
-  let format = fixed02;
-  if (abs >= 100) {
-    format = fixed0;
-  } else if (abs >= 10) {
-    format = fixed01;
-  }
-  return formatCurrency(value, format);
-});
+const valueText = computed(() =>
+  flow.currencyDelta === undefined ? '--' : formatPrice(flow.currencyDelta),
+);
 
 function signClass(value: number | undefined) {
   return {

--- a/src/features/XIT/FLOW/FlowRow.vue
+++ b/src/features/XIT/FLOW/FlowRow.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { MaterialFlow, PlanetContribution } from '@src/core/flow';
+import MaterialIcon from '@src/components/MaterialIcon.vue';
+import { fixed0, fixed01, fixed02, fixed1, fixed2, formatCurrency } from '@src/utils/format';
+
+const { flow } = defineProps<{ flow: MaterialFlow }>();
+
+function formatAmount(value: number) {
+  const abs = Math.abs(value);
+  return abs >= 1000 ? fixed0(value) : abs >= 100 ? fixed1(value) : fixed2(value);
+}
+
+const valueText = computed(() => {
+  const value = flow.currencyDelta;
+  if (value === undefined) {
+    return '--';
+  }
+  const abs = Math.abs(value);
+  let format = fixed02;
+  if (abs >= 100) {
+    format = fixed0;
+  } else if (abs >= 10) {
+    format = fixed01;
+  }
+  return formatCurrency(value, format);
+});
+
+function signClass(value: number | undefined) {
+  return {
+    [C.ColoredValue.positive]: value !== undefined && value > 0,
+    [C.ColoredValue.negative]: value !== undefined && value < 0,
+  };
+}
+
+function formatContribution(contribution: PlanetContribution) {
+  const { planetName, naturalId, amount } = contribution;
+  const name = planetName === naturalId ? naturalId : `${planetName} (${naturalId})`;
+  return `${name}: ${formatAmount(amount)}`;
+}
+</script>
+
+<template>
+  <tr>
+    <td :class="$style.materialContainer">
+      <MaterialIcon size="inline-table" :ticker="flow.ticker" />
+    </td>
+    <td :class="signClass(flow.delta)">{{ formatAmount(flow.delta) }}</td>
+    <td>{{ formatAmount(flow.production) }}</td>
+    <td>{{ formatAmount(flow.consumption) }}</td>
+    <td :class="signClass(flow.currencyDelta)">{{ valueText }}</td>
+    <td :class="$style.planets">
+      <div v-for="x in flow.producers" :key="x.naturalId">{{ formatContribution(x) }}</div>
+    </td>
+    <td :class="$style.planets">
+      <div v-for="x in flow.consumers" :key="x.naturalId">{{ formatContribution(x) }}</div>
+    </td>
+  </tr>
+</template>
+
+<style module>
+.materialContainer {
+  width: 32px;
+  padding: 0;
+}
+
+.planets {
+  white-space: nowrap;
+}
+</style>

--- a/src/features/XIT/FLOW/FlowRow.vue
+++ b/src/features/XIT/FLOW/FlowRow.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import { MaterialFlow, PlanetContribution } from '@src/core/flow';
 import MaterialIcon from '@src/components/MaterialIcon.vue';
+import PriceCell from '@src/features/XIT/FLOW/PriceCell.vue';
 import { fixed0, fixed01, fixed02, fixed1, fixed2, formatCurrency } from '@src/utils/format';
 
-const { flow } = defineProps<{ flow: MaterialFlow }>();
+const { flow, last } = defineProps<{ flow: MaterialFlow; last?: boolean }>();
+
+// Tooltips on the last row open upwards so they don't extend the table.
+const tooltipPosition = computed(() => (last ? 'top' : 'bottom'));
 
 function formatAmount(value: number) {
   const abs = Math.abs(value);
@@ -47,6 +51,18 @@ function formatContribution(contribution: PlanetContribution) {
     <td :class="signClass(flow.delta)">{{ formatAmount(flow.delta) }}</td>
     <td>{{ formatAmount(flow.production) }}</td>
     <td>{{ formatAmount(flow.consumption) }}</td>
+    <PriceCell
+      :ticker="flow.ticker"
+      side="buy"
+      :price="flow.buy"
+      :override="flow.buyOverride"
+      :tooltip-position="tooltipPosition" />
+    <PriceCell
+      :ticker="flow.ticker"
+      side="sell"
+      :price="flow.sell"
+      :override="flow.sellOverride"
+      :tooltip-position="tooltipPosition" />
     <td :class="signClass(flow.currencyDelta)">{{ valueText }}</td>
     <td :class="$style.planets">
       <div v-for="x in flow.producers" :key="x.naturalId">{{ formatContribution(x) }}</div>

--- a/src/features/XIT/FLOW/PriceCell.vue
+++ b/src/features/XIT/FLOW/PriceCell.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { PriceSide, setFlowPriceOverride } from '@src/core/flow';
-import { fixed0, fixed01, fixed02, formatCurrency } from '@src/utils/format';
+import { formatPrice } from '@src/features/XIT/FLOW/format';
 
 const {
   ticker,
@@ -20,18 +20,9 @@ const editing = ref(false);
 const draft = ref('');
 const input = useTemplateRef<HTMLInputElement>('input');
 
-const text = computed(() => {
-  if (price === undefined) {
-    return '--';
-  }
-  let format = fixed02;
-  if (price >= 100) {
-    format = fixed0;
-  } else if (price >= 10) {
-    format = fixed01;
-  }
-  return formatCurrency(price, format) + (override ? '*' : '');
-});
+const text = computed(() =>
+  price === undefined ? '--' : formatPrice(price) + (override ? '*' : ''),
+);
 
 const tooltip = computed(() =>
   override ? 'Override. Click to edit, clear to reset.' : 'Click to override.',
@@ -51,7 +42,7 @@ function commit() {
     return;
   }
   editing.value = false;
-  const value = String(draft.value).trim();
+  const value = draft.value.trim();
   if (value === '') {
     setFlowPriceOverride(ticker, side, undefined);
     return;
@@ -71,7 +62,7 @@ function cancel() {
 <template>
   <td :class="$style.cell" @click="startEditing">
     <span
-      :class="{ [$style.hiddenText]: editing }"
+      :class="{ [$style.text]: editing }"
       :data-tooltip="editing ? undefined : tooltip"
       :data-tooltip-position="tooltipPosition">
       {{ text }}
@@ -102,7 +93,7 @@ function cancel() {
 }
 
 /* The text keeps sizing the cell while the editor is open. */
-.hiddenText {
+.text {
   visibility: hidden;
 }
 

--- a/src/features/XIT/FLOW/PriceCell.vue
+++ b/src/features/XIT/FLOW/PriceCell.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { PriceSide, setFlowPriceOverride } from '@src/core/flow';
+import { fixed0, fixed01, fixed02, formatCurrency } from '@src/utils/format';
+
+const {
+  ticker,
+  side,
+  price,
+  override,
+  tooltipPosition = 'bottom',
+} = defineProps<{
+  ticker: string;
+  side: PriceSide;
+  price: number | undefined;
+  override: boolean;
+  tooltipPosition?: 'top' | 'bottom';
+}>();
+
+const editing = ref(false);
+const draft = ref('');
+const input = useTemplateRef<HTMLInputElement>('input');
+
+const text = computed(() => {
+  if (price === undefined) {
+    return '--';
+  }
+  let format = fixed02;
+  if (price >= 100) {
+    format = fixed0;
+  } else if (price >= 10) {
+    format = fixed01;
+  }
+  return formatCurrency(price, format) + (override ? '*' : '');
+});
+
+const tooltip = computed(() =>
+  override ? 'Override. Click to edit, clear to reset.' : 'Click to override.',
+);
+
+function startEditing() {
+  if (editing.value) {
+    return;
+  }
+  draft.value = override && price !== undefined ? price.toString() : '';
+  editing.value = true;
+  nextTick(() => input.value?.focus());
+}
+
+function commit() {
+  if (!editing.value) {
+    return;
+  }
+  editing.value = false;
+  const value = String(draft.value).trim();
+  if (value === '') {
+    setFlowPriceOverride(ticker, side, undefined);
+    return;
+  }
+  const parsed = Number(value);
+  if (!isFinite(parsed) || parsed < 0) {
+    return;
+  }
+  setFlowPriceOverride(ticker, side, parsed);
+}
+
+function cancel() {
+  editing.value = false;
+}
+</script>
+
+<template>
+  <td :class="$style.cell" @click="startEditing">
+    <span
+      :class="{ [$style.hiddenText]: editing }"
+      :data-tooltip="editing ? undefined : tooltip"
+      :data-tooltip-position="tooltipPosition">
+      {{ text }}
+    </span>
+    <div v-if="editing" :class="[C.forms.input, $style.input]">
+      <div>
+        <input
+          ref="input"
+          v-model="draft"
+          type="text"
+          inputmode="decimal"
+          autocomplete="off"
+          data-1p-ignore="true"
+          data-lpignore="true"
+          @keydown.enter="commit"
+          @keydown.esc="cancel"
+          @blur="commit" />
+      </div>
+    </div>
+  </td>
+</template>
+
+<style module>
+.cell {
+  position: relative;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* The text keeps sizing the cell while the editor is open. */
+.hiddenText {
+  visibility: hidden;
+}
+
+/* Overlay the editor on the cell so opening it never changes the table layout. */
+.input {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: stretch;
+
+  & > div {
+    display: flex;
+    width: 100%;
+  }
+
+  & input {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    text-align: right;
+  }
+}
+</style>

--- a/src/features/XIT/FLOW/PriceCell.vue
+++ b/src/features/XIT/FLOW/PriceCell.vue
@@ -63,7 +63,7 @@ function cancel() {
   <td :class="$style.cell" @click="startEditing">
     <span
       :class="{ [$style.text]: editing }"
-      :data-tooltip="editing ? undefined : tooltip"
+      :data-tooltip="tooltip"
       :data-tooltip-position="tooltipPosition">
       {{ text }}
     </span>
@@ -92,7 +92,10 @@ function cancel() {
   white-space: nowrap;
 }
 
-/* The text keeps sizing the cell while the editor is open. */
+/* The text keeps sizing the cell while the editor is open. Hiding it rather than
+   removing it also keeps the game's [data-tooltip] padding, so the column does not
+   resize; visibility: hidden takes it out of hit testing, so no tooltip appears
+   over the editor. */
 .text {
   visibility: hidden;
 }

--- a/src/features/XIT/FLOW/SortHeader.vue
+++ b/src/features/XIT/FLOW/SortHeader.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { SortKey, useTileState } from '@src/features/XIT/FLOW/tile-state';
+
+const { sortKey } = defineProps<{ sortKey: SortKey }>();
+
+const sort = useTileState('sort');
+const desc = useTileState('desc');
+
+const isActive = computed(() => sort.value === sortKey);
+
+function onClick() {
+  if (isActive.value) {
+    desc.value = !desc.value;
+    return;
+  }
+  sort.value = sortKey;
+  desc.value = false;
+}
+</script>
+
+<template>
+  <th :class="$style.header" @click="onClick">
+    <slot />
+    <span v-if="isActive">{{ desc ? ' ▼' : ' ▲' }}</span>
+  </th>
+</template>
+
+<style module>
+.header {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+</style>

--- a/src/features/XIT/FLOW/format.ts
+++ b/src/features/XIT/FLOW/format.ts
@@ -1,0 +1,12 @@
+import { fixed0, fixed01, fixed02, formatCurrency } from '@src/utils/format';
+
+export function formatPrice(value: number) {
+  const abs = Math.abs(value);
+  let format = fixed02;
+  if (abs >= 100) {
+    format = fixed0;
+  } else if (abs >= 10) {
+    format = fixed01;
+  }
+  return formatCurrency(value, format);
+}

--- a/src/features/XIT/FLOW/tile-state.ts
+++ b/src/features/XIT/FLOW/tile-state.ts
@@ -1,0 +1,8 @@
+import { createTileStateHook } from '@src/store/user-data-tiles';
+
+export type SortKey = 'ticker' | 'delta' | 'production' | 'consumption' | 'currencyDelta';
+
+export const useTileState = createTileStateHook({
+  sort: 'currencyDelta' as SortKey,
+  desc: false,
+});

--- a/src/infrastructure/fio/cx.ts
+++ b/src/infrastructure/fio/cx.ts
@@ -165,6 +165,36 @@ export function getPrice(ticker?: string | null) {
   return undefined;
 }
 
+export interface MarketPrices {
+  // What you would pay for the material.
+  buy: number | undefined;
+  // What you would get for the material.
+  sell: number | undefined;
+}
+
+// Buy is the Ask, sell is the Bid. MM materials sell at the MM bid and buy at the
+// cheaper of the Ask and the MM ask (most MM materials only have an MM bid).
+// A side with no market data falls back to getPrice.
+export function getMarketPrices(ticker: string): MarketPrices {
+  const upper = ticker.toUpperCase();
+  if (ignored.value.has(upper)) {
+    return { buy: 0, sell: 0 };
+  }
+
+  const fallback = getPrice(ticker);
+  const info = cxStore.fetched
+    ? cxStore.prices.get(userData.settings.pricing.exchange)?.get(upper)
+    : undefined;
+  if (!info) {
+    return { buy: fallback, sell: fallback };
+  }
+  if (mmMaterials.value.has(upper)) {
+    const asks = [info.Ask, info.MMSell].filter(isPresent);
+    return { buy: asks.length > 0 ? Math.min(...asks) : fallback, sell: info.MMBuy ?? fallback };
+  }
+  return { buy: info.Ask ?? fallback, sell: info.Bid ?? fallback };
+}
+
 export function getMaterialPrice(material: PrunApi.Material) {
   return getPrice(material.ticker);
 }

--- a/src/store/user-data-migrations.ts
+++ b/src/store/user-data-migrations.ts
@@ -17,6 +17,12 @@ function isCheckpoint(entry: MigrationEntry): entry is Checkpoint {
 // The date is for reference only, and it does not affect migration order.
 const migrations: MigrationEntry[] = [
   [
+    '25.08.2026 Add flow price overrides',
+    userData => {
+      userData.settings.flow = { overrides: {} };
+    },
+  ],
+  [
     '09.08.2026 Add govburn slot picks',
     userData => {
       userData.govburn.config.slots = {};

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -31,6 +31,9 @@ export const initialUserData = deepFreeze({
       // Planet natural id -> ship-size label from core/ship-sizes.
       planetPickup: {} as Record<string, string>,
     },
+    flow: {
+      overrides: {} as Record<string, UserData.PriceOverride>,
+    },
     repair: {
       threshold: 60,
       offset: 10,

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -9,6 +9,11 @@ declare namespace UserData {
 
   export type Exchange = 'AI1' | 'CI1' | 'CI2' | 'IC1' | 'NC1' | 'NC2';
 
+  interface PriceOverride {
+    buy?: number;
+    sell?: number;
+  }
+
   interface StoreSortingData {
     modes: SortingMode[];
     active?: string;


### PR DESCRIPTION
Ports [refined-prun/refined-prun#238](https://github.com/refined-prun/refined-prun/pull/238) (`XIT FLOW`, by @erendrake) onto this fork.

## What it adds

`XIT FLOW` — one row per material across your bases: daily production, consumption (including workforce), the net delta, what that delta is worth, and which bases produce/consume it. `XIT FINPR` shows per-base profit; this shows *which goods* the money flows through.

- Rates come from `core/burn.ts` unchanged, so Prod/Cons reconcile with `XIT BURN OVERALL`.
- Value: net deficit × Buy (Ask), net surplus × Sell (Bid). MM materials sell at the MM bid and buy at the cheaper of Ask and MM ask. Ignored materials value at 0; a ticker with no market data falls back to the regular price, so `--` only appears before price data loads.
- Click a Buy or Sell price to type your own (partner deals). Marked `*`, stored in `settings.flow.overrides`, **FLOW-only** — FINPR/FINBS/MAT untouched.
- `XIT FLOW <planet…>` / `XIT FLOW NOT <planet…>` use BURN's parameter grammar. Sortable, sticky headers, COPY → TSV.

Outside the feature: `getMarketPrices` in `cx.ts`, `settings.flow.overrides` plus one migration. No existing behaviour changes.

## How it was ported

The four upstream commits cherry-picked onto `main` with original authorship preserved. Two conflicts, both from this fork being ahead of the PR's base:

- `src/store/user-data-migrations.ts` — the flow migration goes at the top of the list, above this fork's `09.08.2026 Add govburn slot picks`. It is the newest entry, so no checkpoint can skip it.
- `src/store/user-data.types.d.ts` — `PriceOverride` landed where this fork had added `Exchange`; kept both.

`src/infrastructure/fio/cx.ts` and `src/store/user-data.ts` merged cleanly. The resulting diff is byte-identical in size to the upstream PR (608 insertions across the same 12 files).

Two commits on top are mine, not the upstream author's:

- **CHANGELOG + tests.** Upstream deliberately left `CHANGELOG.md` alone; this fork requires a bullet under `## Unreleased` (`docs/contributing.md`). `calculateMaterialFlow` takes its price lookup as an argument, so `src/core/flow.test.ts` covers the aggregation rules with no store mocking: workforce counts as consumption, per-planet contributions are recorded and sorted, materials with no flow are dropped, deficits value at Buy and surpluses at Sell, and a missing price on the relevant side leaves the value undefined.
- **A distilled doc note** on the `dayjs.duration` module-scope trap that made the test file fail to import at all.

## Verification

- `pnpm run compile` — clean.
- `pnpm run test` — 85 passed (10 files), 8 of them new.
- The 8 new assertions were each shown failing once against a deliberately mutated `core/flow.ts` (workforce dropped from consumption, price side always Sell, zero-flow rows kept, contribution sort removed, override flag hard-coded). None of them is vacuous.
- `tsc --noEmit` does **not** check `.vue` script blocks, so the four new SFCs would otherwise be unverified. Ran `vue-tsc` separately against the repo's pinned TypeScript: 6 errors repo-wide, all pre-existing in DISPATCH/GOVBURN/REP/STO/TODO, **none in FLOW**. (vue-tsc was installed temporarily; `package.json` and the lockfile are unchanged.)
- `pnpm run build:fast` — clean, `dist/virtual/FLOW.js` present.

## Live game verification

Driven through the nest's `run-windows` harness against the owner's real game session with this build loaded unpacked. No server-mutating action was taken; the only writes were FLOW's own local price overrides, all reverted.

- **Reconciles with BURN.** All **73/73** tickers match `XIT BURN OVERALL` exactly on Prod, Cons and Delta — none present in one and not the other. (Checked machine-to-machine, not by eye.)
- Renders 73 rows, no `undefined`/`NaN` in any of the 7 value columns. Sticky header confirmed by computed style and by scroll position (row 1 at y=−1406 while the header held at y=132).
- Every sort header re-sorts and the arrow follows. `XIT FLOW ZV-307e` → `MATERIAL FLOW - ASTRAEUS`, 73 → 22 rows; `XIT FLOW NOT ZV-307e` drops exactly that planet's contribution (AIR prod 39.88 → 34.11, DW cons 1,438 → 1,379).
- Overrides: commit on Enter with `*`, cancel on Esc, clear on empty, and Value recomputes (AIR Sell halved → Value 7,976,613 → 3,988,307; SAR Buy 35,080 → 20,000 → Value −1,164,466 → −663,892, i.e. the deficit correctly uses Buy). They survive a reload.
- **FLOW-only holds at runtime**, not just by inspection: with a SAR Buy override active, `MAT SAR` still read 31,960 AIC and `XIT FINPR` was character-for-character identical to its pre-override state.
- Value-header tooltip renders and wraps; the last row's price tooltip opens upward rather than clipping.

### One bug found and fixed
`PriceCell.vue` claimed the editor "never changes the table layout". It did — editing the widest cell in a column (AIR Buy) shrank it 83.91 → 77.84 px and shifted every column right of it 6.06 px left, because `:data-tooltip="editing ? undefined : tooltip"` dropped the game's `[data-tooltip] { padding: 0 4px 0 }`. The span is already `visibility: hidden` while editing, so the attribute never needed removing. Now bound unconditionally; re-measured in-game, widths and positions are identical to three decimals before, during and after editing, and hovering the open editor shows no tooltip.

### Second fix: the Value header now sorts from any point on it
The ⓘ carried `@click.stop`, so a click landing on the icon did not sort — a dead zone in the middle of the header a user is most likely to click. `Tooltip.vue` is hover-driven with no click handler of its own, so the modifier only ever suppressed sorting. Dropped at the repo owner's direction.

Verified in-game by clicking the icon itself rather than the word: `Value ▲` (SAR −1,164,466 / NN / FIM) → click ⓘ → `Value ▼` (AIR 7,976,613 / RDE / ABH) → click ⓘ → back to ▲. Also proved it *sets* the key rather than only toggling: from `Ticker ▲` with no arrow on Value, one click on the ⓘ jumped the sort to `Value ▲`. The tooltip still opens on hover, and hovering does not sort.

### Console errors: now verified, and the harness gained the capability to do it
Previously unverifiable — the `run-windows` harness had no console capture. It now has `console-log` and `console-clear` actions backed by `page.on('console')` / `page.on('pageerror')` listeners attached before the first navigation (no eval escape hatch, consistent with that skill's boundary).

The capture was proven live before being trusted, because an always-empty buffer is indistinguishable from "no errors": a fresh launch held 157 entries, `console-clear` took it to 0, and a reload brought it back 0 → 1 → 157 with correctly attributed sources.

With that established: `console-clear`, then FLOW opened, every header sorted including the ⓘ, `XIT FLOW LS-300c` and `XIT FLOW NOT LS-300c`, a price editor opened and cancelled, tooltips hovered, the page reloaded and FLOW reopened. Result: **`matched: 0` for `error,warning`, `droppedOldest: 0`.** All 157 captured entries are level `log` — 156 are the extension's own startup feature registrations, 1 is the game's welcome banner. FLOW contributes no console output at all.

**Scope of that claim:** page-level only. Playwright exposes MV3 service workers with no console event, so a throw in the background script would leave no trace here. That caveat is documented next to the action rather than left for the next person to discover.

### One thing still unproven
The `--`-last sort rule remains unexercised: all 73 tickers had CX prices, so no unpriced row existed to sort. That branch lives in `FLOW.vue` rather than `core/flow.ts`, so no unit test covers it either.

