### PR TITLE
[RPR] XIT ACT: one-click SFC stage, move agent-post gap between posts

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -216,19 +216,33 @@ SKIP, or a self-skip from a reactive watcher) never resumes, and everything afte
 ### Reminder Pauses in ACT Steps
 
 When a step needs the player to do something manually in a companion buffer before the
-run continues (repair buildings in BRA, submit the flight in SFC, adjust a transfer
-amount in MTRA), call `waitAct(status, { actDelayMs: 2000 })`. The step machine grays
-the ACT button for the delay while SKIP/CANCEL stay live, then re-arms ACT — see
-`OPEN_BRA.ts` / `OPEN_SFC.ts` / `MTRA_TRANSFER.ts`'s `playerReview` mode (which reads
-the player-adjusted input value after the pause instead of rewriting it).
+run continues (repair buildings in BRA, adjust a transfer amount in MTRA), call
+`waitAct(status, { actDelayMs: 2000 })`. The step machine grays the ACT button for the
+delay while SKIP/CANCEL stay live, then re-arms ACT — see `OPEN_BRA.ts` /
+`MTRA_TRANSFER.ts`'s `playerReview` mode (which reads the player-adjusted input value
+after the pause instead of rewriting it).
 Don't add a bare `sleep()` for this; the delay belongs in `waitAct` so skipping/canceling
 during the pause is handled.
+
+**Put a pause that spaces two steps in front of the second one, not behind the first.**
+A pause that exists only to separate a step from the previous step of its kind — the gap
+between agent-channel posts (`POST_AGENT`, flood protection), the window to submit one
+ship's flight before the next ship's SFC opens (`OPEN_SFC`) — is a pre-ACT delay on the
+step that follows. Trailing it off the earlier step instead makes the player wait after
+the *last* one for nothing. Guard it with `ctx.isFirstOfType`, which the step machine sets
+false once an earlier step of the same type has started in this run: the first post/SFC
+has nothing to be spaced from, so it arms ACT immediately. `isFirstOfType` is per run and
+per step type, so it survives extra steps appended after generation (`extraSteps`) and
+in-step retry loops — `POST_AGENT` re-arms the gap on retries by `&&`-ing in `attempt === 1`.
 
 ### ACT Step Behaviors Worth Knowing
 
 - **Per-open click gate lives in `requestTile`.** A step that opens a buffer via
   `ctx.requestTile(cmd)` already makes the player click ACT for that open — don't add
-  another `waitAct` around it.
+  another `waitAct` around it. The one exception is a step that must gate itself (to carry
+  a spacing delay, or to keep a post-open server lookup behind the click even when the tile
+  is already open): call `waitAct` first, then `requestTile(cmd, { actGate: false })` so the
+  open doesn't cost a second click. `OPEN_SFC` does exactly this.
 - **Steps can self-skip without a click.** Calling `ctx.skip()` and returning before any
   `waitAct` consumes the step silently (logs a SKIP line). Used by `OPEN_POPID` to walk a
   fixed 14-building step list while only present buildings cost a click — a static step
@@ -705,6 +719,10 @@ in one call, scoped to a raw `document.documentElement` lookup that could grab t
 tile's input if more than one `AddressSelector` was open. Scope to the tile instead
 (`await $(tile.anchor, C.AddressSelector.container)`) and call `selectAddress` directly — no
 pause needed, since filling the field isn't a server-mutating action worth a reminder click.
+It does still have to sit behind a click, though, because typing fires the address lookup:
+`OPEN_SFC` gates the whole step up front and passes `{ actGate: false }` to `requestTile`,
+so opening the buffer and filling the destination are one click even when the SFC tile for
+that ship was already open.
 
 ---
 

--- a/src/features/XIT/ACT/action-steps/OPEN_SFC.ts
+++ b/src/features/XIT/ACT/action-steps/OPEN_SFC.ts
@@ -10,6 +10,12 @@ interface Data {
   destination?: string;
 }
 
+// Spacing between consecutive SFC opens. One ACT click opens the buffer and fills the
+// destination; the player submits that flight themselves while the next ship's SFC keeps
+// ACT grayed for this long. The run's first SFC has no preceding flight to wait on, and
+// nothing pauses after the last one.
+const flightSubmitGapMs = 2000;
+
 export const OPEN_SFC = act.addActionStep<Data>({
   type: 'OPEN_SFC',
   description: data => {
@@ -20,13 +26,19 @@ export const OPEN_SFC = act.addActionStep<Data>({
       : `Open SFC for ${shipLabel}`;
   },
   execute: async ctx => {
-    const { data, log, waitAct, requestTile, complete } = ctx;
+    const { data, log, isFirstOfType, waitAct, requestTile, complete } = ctx;
     const assert: AssertFn = ctx.assert;
 
     const ship = shipsStore.getById(data.shipId);
     assert(ship, 'Ship not found');
 
-    const tile = await requestTile(`SFC ${ship.registration}`);
+    // One click for the whole step — it opens SFC and fills the destination. requestTile's
+    // own per-open gate is suppressed so the open doesn't cost a second click, and gating
+    // here rather than there also keeps selectAddress's server lookup behind a player click
+    // when the ship's SFC tile happens to be open already.
+    await waitAct(undefined, { actDelayMs: isFirstOfType ? 0 : flightSubmitGapMs });
+
+    const tile = await requestTile(`SFC ${ship.registration}`, { actGate: false });
     if (!tile) {
       return;
     }
@@ -37,9 +49,11 @@ export const OPEN_SFC = act.addActionStep<Data>({
       const container = await $(tile.anchor, C.AddressSelector.container);
       const naturalId = convertToPlanetNaturalId(data.destination) ?? data.destination;
       if (await selectAddress(container, naturalId)) {
-        log.info(`Destination set: ${destinationName}`);
+        log.info(`Destination set: ${destinationName} — submit the flight in SFC`);
       } else {
-        log.warning(`Could not set destination to ${destinationName} — select manually`);
+        log.warning(
+          `Could not set destination to ${destinationName} — select it manually, then submit the flight`,
+        );
       }
     }
 
@@ -51,12 +65,6 @@ export const OPEN_SFC = act.addActionStep<Data>({
     if (bodyEl) {
       bodyEl.style.width = '975px';
       bodyEl.style.height = '750px';
-    }
-    if (data.destination) {
-      // Reminder pause: keep ACT grayed so the player submits the flight first.
-      await waitAct(`Submit flight to ${destinationName} in SFC, then continue`, {
-        actDelayMs: 2000,
-      });
     }
     complete();
   },

--- a/src/features/XIT/ACT/action-steps/POST_AGENT.ts
+++ b/src/features/XIT/ACT/action-steps/POST_AGENT.ts
@@ -9,20 +9,25 @@ interface Data {
 }
 
 const maxPostAttempts = 3;
+// Chained runs post several packages to the same chat channel back-to-back, which can trip
+// the game's flood protection. The gap belongs *between* posts, so it grays ACT ahead of
+// every post except the run's first — that one has nothing to be spaced from, and pausing
+// before it just makes the player wait. Nothing pauses after the last post either. Retries
+// always keep the gap; they are what actually recovers, since the throttle window isn't
+// something a fixed delay can outwait.
+const postGapMs = 2000;
 
 export const POST_AGENT = act.addActionStep<Data>({
   type: 'POST_AGENT',
   description: data => `Post [${data.pkg.global.name}] package to the agent channel`,
   execute: async ctx => {
-    const { data, waitAct, complete, skip, log } = ctx;
+    const { data, isFirstOfType, waitAct, complete, skip, log } = ctx;
     const { id, text } = await buildAgentPackageMessage(data.pkg, data.id);
     const name = data.pkg.global.name ?? 'package';
-    // Chained runs post several packages to the same chat channel back-to-back, which can
-    // trip the game's flood protection. The gap helps; ACT-driven retries are what actually
-    // recovers, since the throttle window isn't something a fixed delay can outwait.
     for (let attempt = 1; attempt <= maxPostAttempts; attempt++) {
+      const isRunFirstPost = isFirstOfType && attempt === 1;
       await waitAct(attempt === 1 ? undefined : `Retry posting [${name}] as [${id}]`, {
-        actDelayMs: 2000,
+        actDelayMs: isRunFirstPost ? 0 : postGapMs,
       });
       try {
         await postAgentMessage(text);

--- a/src/features/XIT/ACT/runner/step-machine.ts
+++ b/src/features/XIT/ACT/runner/step-machine.ts
@@ -25,6 +25,10 @@ const actionFeedbackTimeoutMs = 30_000;
 export class StepMachine {
   private next?: ActionStep;
   private nextAct?: () => void;
+  // Step types that have already started in this run. A pause that only spaces a step from
+  // the previous step of its kind (agent posts, SFC opens) reads this so the first of a
+  // kind doesn't gray ACT waiting on something that hasn't happened yet.
+  private startedStepTypes = new Set<string>();
 
   constructor(
     private steps: ActionStep[],
@@ -92,6 +96,8 @@ export class StepMachine {
     }
     const next = this.steps.shift()!;
     this.next = next;
+    const isFirstOfType = !this.startedStepTypes.has(next.type);
+    this.startedStepTypes.add(next.type);
     const info = act.getActionStepInfo(next.type);
     let description: string | undefined;
     const log = this.options.log;
@@ -99,6 +105,7 @@ export class StepMachine {
       await info.execute({
         data: next,
         log,
+        isFirstOfType,
         setStatus: status => this.options.onStatusChanged(status),
         waitAct: async (status, opts) => {
           status ??= description ?? info.description(next);
@@ -140,7 +147,7 @@ export class StepMachine {
             throw AssertionError;
           }
         },
-        requestTile: async command => await this.requestTile(command),
+        requestTile: async (command, opts) => await this.requestTile(command, opts),
       });
     } catch (e) {
       if (e === ExecutionStopped) {
@@ -153,12 +160,16 @@ export class StepMachine {
     }
   }
 
-  private async requestTile(command: string) {
+  private async requestTile(command: string, opts?: { actGate?: boolean }) {
     let tile = tiles.find(command, true)[0];
     if (tile !== undefined) {
       return tile;
     }
-    await this.waitAct(`Open ${command}`);
+    // Steps that already gated themselves pass actGate: false, so the open doesn't cost a
+    // second click.
+    if (opts?.actGate !== false) {
+      await this.waitAct(`Open ${command}`);
+    }
     this.options.onStatusChanged(`Opening ${command}...`);
     tile = await this.options.tileAllocator.requestTile(command);
     if (tile === undefined) {

--- a/src/features/XIT/ACT/shared-types.ts
+++ b/src/features/XIT/ACT/shared-types.ts
@@ -49,6 +49,10 @@ export interface ActionStepGenerateContext<TConfig>
 }
 
 export interface ActionStepExecuteContext<T> extends ActionRunnerContext<T> {
+  // False once an earlier step of the same type has started in this run. Only for pauses
+  // that space a step from the previous one of its kind — there is nothing to space the
+  // first one from.
+  isFirstOfType: boolean;
   setStatus: (status: string) => void;
   waitAct: (status?: string, opts?: { actDelayMs?: number }) => Promise<void>;
   waitActionFeedback: (tile: PrunTile) => Promise<void>;
@@ -57,7 +61,9 @@ export interface ActionStepExecuteContext<T> extends ActionRunnerContext<T> {
   skip: (opts?: { silent?: boolean }) => void;
   fail: (message?: string) => void;
   assert: AssertFn;
-  requestTile: (Command: string) => Promise<PrunTile | undefined>;
+  // Opening a buffer costs the player an ACT click (actGate defaults to true). Pass false
+  // when the step has already gated itself and the open must not cost a second one.
+  requestTile: (command: string, opts?: { actGate?: boolean }) => Promise<PrunTile | undefined>;
 }
 
 export const configurableValue = 'Configure on Execution';


### PR DESCRIPTION
Closes JAC-23.

## 1. Agent comm-message delay was on the wrong side of the post

`POST_AGENT` called `waitAct(..., { actDelayMs: 2000 })` on every attempt, including the first attempt of the run's first post. That gap exists to space consecutive posts past the game's chat flood protection, so before the first post it bought nothing and just grayed ACT for 2s.

Now the gap applies to posts 2..N and to every retry. That is the same wall clock as "a pause after each comm message except the last", implemented as a pre-ACT delay on the following post so nothing pauses at the end of the run.

## 2. The auto SFC stage cost two ACT clicks per ship

`OPEN_SFC` gated once inside `requestTile` (open the SFC buffer), auto-filled the destination, then gated again on a trailing `waitAct('Submit flight ... then continue', { actDelayMs: 2000 })`.

It now gates itself once up front and passes `{ actGate: false }` to `requestTile`. One ACT click opens the correct SFC buffer **and** selects the destination. The 2s pause moves to the front of the *next* SFC — that is the window the player uses to submit the previous ship's flight. The run's first SFC has no pre-pause, and nothing pauses after the last.

Affects XIT DISPATCHACT (one SFC per ship: 2N clicks -> N), and BURNACT / REPAIRACT / GOVBURNACT / the XIT AGENT chain (2 clicks -> 1).

Side benefit: gating before the open keeps `selectAddress`'s `NOMENCLATURE_QUERY_ADDRESSES` lookup behind a player click even when that ship's SFC tile happened to be open already — previously `requestTile` returned early with no gate and the lookup fired unclicked.

## Mechanism

Both read `ctx.isFirstOfType`, new on the step execute context: `false` once an earlier step of the same type has started in this run. It is tracked in `StepMachine`, so it is per run and per step type and survives `extraSteps` appended after generation and in-step retry loops.

## Deliberate behavior changes worth a look

- `OPEN_SFC` now always costs exactly one ACT click. Previously, if the ship's SFC tile was already open **and** the step had no destination, it completed with zero clicks. Rare, and one consistent click reads better than a step that silently self-completes — but say the word and I'll make the gate conditional on `data.destination`.
- If the player SKIPs an agent post or an SFC, the next one of that kind still gets the 2s gap even though nothing preceded it. Accepted: 2s, no correctness impact.
- The "Submit flight to X in SFC, then continue" status line is gone along with its click. The instruction now rides on the log line: `Destination set: X — submit the flight in SFC`.

## Verification

At `4ca85eb`, clean tree:

- `pnpm run compile` (tsc + eslint) — exit 0
- `pnpm run test` — 11 files, 91 passed / 1 skipped, exit 0

Not verified in the live game: this session has no PrUn login or staged dispatch, and the repo has no DOM test environment (`jsdom`/`happy-dom` are not installed), so `StepMachine` cannot be imported under vitest — importing it dies on `location is not defined` in `screens.ts`. The click counts above come from reading every function on the path (`StepMachine.requestTile`, `TileAllocator.requestTile`, `selectAddress`) and confirming no other `waitAct` is reachable per step. **A real DISPATCHACT run with 2+ ships is the check that matters.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
