### PR TITLE
NumberInput: opt-in float parsing for day, threshold and price fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Added
-
-- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
-
 ### Fixed
 
 - `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
+
 ### Fixed
 
-- `XIT REP`, `XIT PLANETS`, `XIT DISPATCH`, `XIT GOVBURN`, `XIT SET`, `XIT TODO`, `XIT ACT`: Day, threshold and price fields keep fractional values instead of silently truncating them to whole numbers.
 - `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.
 - `XIT BURN`: A material whose production and consumption cancel out no longer shows 0 days left, in both the per-planet rows and the Overall row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `XIT REP`, `XIT PLANETS`, `XIT DISPATCH`, `XIT GOVBURN`, `XIT SET`, `XIT TODO`, `XIT ACT`: Day, threshold and price fields keep fractional values instead of silently truncating them to whole numbers.
 - `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.
 - `XIT BURN`: A material whose production and consumption cancel out no longer shows 0 days left, in both the per-planet rows and the Overall row.
 

--- a/src/components/forms/NumberInput.vue
+++ b/src/components/forms/NumberInput.vue
@@ -1,21 +1,20 @@
 <script setup lang="ts">
-const { optional } = defineProps<{ optional?: boolean }>();
+const { optional, float } = defineProps<{ optional?: boolean; float?: boolean }>();
 
 const model = defineModel<number | undefined>();
 
+// Vue casts a type="number" input through looseToNumber before the setter runs, so the
+// incoming value is already a number unless the field is empty or unparseable.
 const inputModel = computed({
   get: () => model.value,
-  set: (value: string) => {
-    if (value !== '') {
-      model.value = parseInt(value, 10);
-      return;
-    }
-    if (optional) {
-      model.value = undefined;
+  set: (value: number | string) => {
+    const parsed = value === '' ? NaN : Number(value);
+    if (isNaN(parsed)) {
+      model.value = optional ? undefined : 0;
       return;
     }
 
-    model.value = 0;
+    model.value = float ? parsed : Math.trunc(parsed);
   },
 });
 </script>
@@ -25,6 +24,7 @@ const inputModel = computed({
     <input
       v-model="inputModel"
       type="number"
+      :step="float ? 'any' : 1"
       autocomplete="off"
       data-1p-ignore="true"
       data-lpignore="true" />

--- a/src/features/XIT/ACT/Quickstart.vue
+++ b/src/features/XIT/ACT/Quickstart.vue
@@ -119,7 +119,7 @@ const ExchangeTickers = {
         <SelectInput v-model="planet" :options="planets" />
       </Active>
       <Active label="Resupply Days">
-        <NumberInput v-model="days" />
+        <NumberInput v-model="days" float />
       </Active>
       <Commands>
         <PrunButton primary @click="onCreateClick">CREATE</PrunButton>

--- a/src/features/XIT/ACT/actions/cx-buy/EditPriceLimits.vue
+++ b/src/features/XIT/ACT/actions/cx-buy/EditPriceLimits.vue
@@ -27,7 +27,7 @@ function onAddClick() {
           <TextInput v-model="pair[0]" />
         </Active>
         <Active :label="`Price Limit #${i + 1}`">
-          <NumberInput v-model="pair[1]" />
+          <NumberInput v-model="pair[1]" float />
         </Active>
       </template>
       <Commands>

--- a/src/features/XIT/ACT/material-groups/repair/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/repair/Configure.vue
@@ -47,13 +47,13 @@ if (data.advanceDays === configurableValue && config.advanceDays === undefined) 
       v-if="data.days === configurableValue"
       label="Day Threshold"
       tooltip="All buildings older than this threshold will be repaired.">
-      <NumberInput v-model="config.days" />
+      <NumberInput v-model="config.days" float />
     </Active>
     <Active
       v-if="data.advanceDays === configurableValue"
       label="Time Offset"
       tooltip="The number of days in the future this repair will be conducted.">
-      <NumberInput v-model="config.advanceDays" />
+      <NumberInput v-model="config.advanceDays" float />
     </Active>
   </form>
 </template>

--- a/src/features/XIT/ACT/material-groups/repair/Edit.vue
+++ b/src/features/XIT/ACT/material-groups/repair/Edit.vue
@@ -56,12 +56,12 @@ defineExpose({ validate, save });
     label="Day Threshold"
     tooltip="All buildings older than this threshold will be repaired.
      If no number is provided all buildings are repaired.">
-    <NumberInput v-model="days" optional />
+    <NumberInput v-model="days" optional float />
   </Active>
   <Active
     label="Time Offset"
     tooltip="The number of days in the future this repair will be conducted."
     :error="advanceDaysError">
-    <NumberInput v-model="advanceDays" />
+    <NumberInput v-model="advanceDays" float />
   </Active>
 </template>

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -146,7 +146,7 @@ const shipName = computed(() => {
       v-if="data.days === configurableValue"
       label="Days"
       tooltip="The number of days of supplies to refill the planet with.">
-      <NumberInput v-model="config.days" />
+      <NumberInput v-model="config.days" float />
     </Active>
   </form>
   <Active label="Materials" tooltip="Which materials to include in the resupply group.">

--- a/src/features/XIT/ACT/material-groups/resupply/Edit.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Edit.vue
@@ -71,7 +71,7 @@ defineExpose({ validate, save });
     label="Days"
     tooltip="The number of days of supplies to refill the planet with."
     :error="daysError">
-    <NumberInput v-if="!configureDaysOnExecution" v-model="days" />
+    <NumberInput v-if="!configureDaysOnExecution" v-model="days" float />
     <RadioItem v-model="configureDaysOnExecution">configure on execution</RadioItem>
   </Active>
   <Active

--- a/src/features/XIT/DISPATCH/PlanetRow.vue
+++ b/src/features/XIT/DISPATCH/PlanetRow.vue
@@ -186,13 +186,13 @@ function clearShip() {
       <PrunButton dark inline :disabled="!canFit" @click="emit('fit')">FIT</PrunButton>
     </td>
     <td :class="$style.inputCell">
-      <NumberInput v-model="config.days" :class="$style.faintInput" />
+      <NumberInput v-model="config.days" :class="$style.faintInput" float />
     </td>
     <td :class="$style.inputCell">
-      <NumberInput v-model="config.repThreshold" :class="$style.faintInput" />
+      <NumberInput v-model="config.repThreshold" :class="$style.faintInput" float />
     </td>
     <td :class="$style.inputCell">
-      <NumberInput v-model="config.repAdvance" :class="$style.faintInput" />
+      <NumberInput v-model="config.repAdvance" :class="$style.faintInput" float />
     </td>
     <td :class="$style.advToggleCell">
       <RadioItem v-model="config.cxBuy" horizontal>BUY</RadioItem>

--- a/src/features/XIT/GOVBURN/GovBurnConfig.vue
+++ b/src/features/XIT/GOVBURN/GovBurnConfig.vue
@@ -98,10 +98,10 @@ function onInputKeydown(ev: KeyboardEvent) {
     <SectionHeader>Thresholds</SectionHeader>
     <form @submit.prevent>
       <Active label="Red (days)">
-        <NumberInput v-model="userData.govburn.config.red" />
+        <NumberInput v-model="userData.govburn.config.red" float />
       </Active>
       <Active label="Yellow (days)">
-        <NumberInput v-model="userData.govburn.config.yellow" />
+        <NumberInput v-model="userData.govburn.config.yellow" float />
       </Active>
     </form>
 

--- a/src/features/XIT/PLANETS/PLANETS.vue
+++ b/src/features/XIT/PLANETS/PLANETS.vue
@@ -155,6 +155,7 @@ function setRepairField(
             <NumberInput
               :model-value="getResupplyOverride(row.naturalId)"
               optional
+              float
               @update:model-value="setResupplyOverride(row.naturalId, $event)" />
           </td>
           <td :class="$style.pickup">
@@ -169,12 +170,14 @@ function setRepairField(
             <NumberInput
               :model-value="getRepairOverride(row.naturalId)?.threshold"
               optional
+              float
               @update:model-value="setRepairField(row.naturalId, 'threshold', $event)" />
           </td>
           <td :class="$style.input">
             <NumberInput
               :model-value="getRepairOverride(row.naturalId)?.offset"
               optional
+              float
               @update:model-value="setRepairField(row.naturalId, 'offset', $event)" />
           </td>
         </tr>

--- a/src/features/XIT/REP/REP.vue
+++ b/src/features/XIT/REP/REP.vue
@@ -125,10 +125,10 @@ const singleSiteInfo = computed(() => {
     </div>
     <form v-else>
       <Active label="Age Threshold">
-        <NumberInput v-model="userData.settings.repair.threshold" />
+        <NumberInput v-model="userData.settings.repair.threshold" float />
       </Active>
       <Active label="Time Offset">
-        <NumberInput v-model="userData.settings.repair.offset" />
+        <NumberInput v-model="userData.settings.repair.offset" float />
       </Active>
     </form>
     <SectionHeader>Shopping Cart</SectionHeader>

--- a/src/features/XIT/SET/GAME.vue
+++ b/src/features/XIT/SET/GAME.vue
@@ -214,18 +214,18 @@ function confirmResetAllData(ev: Event) {
     <Active
       label="Red"
       tooltip="Threshold for red consumable level in burn calculations (in days).">
-      <NumberInput v-model="userData.settings.burn.red" />
+      <NumberInput v-model="userData.settings.burn.red" float />
     </Active>
     <Active
       label="Yellow"
       tooltip="Threshold for yellow consumable level in burn calculations (in days).">
-      <NumberInput v-model="userData.settings.burn.yellow" />
+      <NumberInput v-model="userData.settings.burn.yellow" float />
     </Active>
     <Active
       label="Resupply"
       tooltip="Default target amount of supplied days for the 'Need' column in XIT BURN.
        Can be overridden per planet in XIT PLANETS.">
-      <NumberInput v-model="userData.settings.burn.resupply" />
+      <NumberInput v-model="userData.settings.burn.resupply" float />
     </Active>
   </form>
   <SectionHeader>

--- a/src/features/XIT/TODO/EditTask.vue
+++ b/src/features/XIT/TODO/EditTask.vue
@@ -172,7 +172,7 @@ function onDeleteClick() {
           <SelectInput v-model="planet" :options="planets" />
         </Active>
         <Active label="Days" tooltip="The number of days of supplies.">
-          <NumberInput v-model="days" />
+          <NumberInput v-model="days" float />
         </Active>
       </template>
       <template v-if="type === 'Repair'">
@@ -180,7 +180,7 @@ function onDeleteClick() {
           <SelectInput v-model="planet" :options="planets" />
         </Active>
         <Active label="Building age" tooltip="The minimum building age to be included in the list.">
-          <NumberInput v-model="buildingAge" />
+          <NumberInput v-model="buildingAge" float />
         </Active>
       </template>
       <Commands>


### PR DESCRIPTION
Reworks [lilbit-prun@788f6254](https://github.com/lilbit-prun/refined-prun/commit/788f62547be5e51085ae25fcb57efaa186b94b79) ("allow floats in days") into an opt-in prop.

## Why the one-line version isn't safe

`NumberInput` backs 30 fields. Flipping `parseInt` → `parseFloat` inside it makes every one of them accept fractions, including several with integer semantics:

- **`XIT HQUC` From/To.** `calculateHQUpgradeMaterials(1.5, 2.5)` misses the level lookup table, falls into the level-21+ formula with `x = -17.5`, returns nine rows of negative material amounts, and writes the result back onto the module-level `hqUpgradeMaterials` array under a `2.5` key — poisoned for the rest of the session.
- **`XIT ACT` manual material-group amounts.** These feed `MTRA_TRANSFER({ amount })` and CX bid amounts, so a fraction reaches a game action. `manual.ts` renders them through `fixed0()`, so `1.5` displays as `2` while `1.5` is what executes.
- **`XIT DATA` result limit, `XIT SET BFR` buffer sizes, `XIT TODO` recurring period.**

The upstream patch also writes `parseFloat(value, 10)`. The second argument is meaningless — `parseFloat` takes one. It passes `pnpm run compile` because plain `tsc` never type-checks `.vue` script blocks and no ESLint rule checks arity, so it would only surface if the project ever adopts `vue-tsc`.

## What this does instead

`NumberInput` gains a `float` prop that keeps the fractional value and sets `step="any"` on the input. Without it the field truncates as before.

Two details worth noting:

- Vue casts a `type="number"` input through `looseToNumber` (itself a `parseFloat`) before the model setter runs, so the setter already receives a **number**, not the `string` the old signature claimed. The component's own parse was re-parsing an already-parsed value; `Number(value)` is enough.
- The integer path now uses `Math.trunc` rather than `parseInt`. `parseInt` stringifies first, so it returned `1` for `0.0000001` (`"1e-7"`) and for `1e21`. `Math.trunc` gives `0` and `1e21`.

`float` is applied to the day-, threshold- and price-valued fields only: `XIT REP`, `XIT PLANETS`, `XIT DISPATCH`, `XIT GOVBURN`, `XIT SET GAME`, `XIT TODO` (days / building age), and the `XIT ACT` repair, resupply, Quickstart and CX-buy price editors. Those paths were already written for fractional values — `repair.ts` does `parseFloat(rawDays!)`, `resupply.ts` does `parseFloat(data.days as string)`, and `computeRepairBill` compares `date + advanceDays < thresholdDays` on a fractional day count. Only the widget was truncating.

## Verification

`pnpm run compile` and `pnpm test` (92 tests) pass, but neither covers this: `tsc` skips `.vue` script blocks and there are no component tests. Checked in the browser against the live game with the extension loaded unpacked.

**Float path — `XIT REP` Time Offset.** The building list filters on `age > threshold - offset`. With threshold 60 and nine buildings at 57.2, one at 56.3 and nine at 52.2, entering an offset of `3.9` gives a 56.1 boundary and should keep 10 rows; truncating to `3` gives a 57 boundary and keeps 9.

| Build | Entered | Rows kept |
|---|---|---|
| this branch | `3.9` | 10 — `56.3` included |
| `NumberInput.vue` reverted to `parseInt`, same input | `3.9` | 9 — `56.3` dropped |

The check was mutation-proven: it fails on the pre-fix component, so it is not vacuous.

**Integer path — `XIT HQUC`.** Entering From `1.5` / To `3.5` produced the level 2 + 3 bill (MCG 48, TRU 16, BBH 22, BDE 16, BSE 16, BTA 8, OFF 20), i.e. truncated to 1 / 3, with no negative amounts.

**Attribute placement.** `feature-patterns.md` warns that attrs passed to `NumberInput` land on its wrapper `div`, so `step` is bound inside the component. Confirmed live: float fields match `input[step="any"]`, `XIT HQUC` matches `input[type=number][step="1"]`, and both selectors return empty on a build without the change.

No extension console errors during the run.

## Not fixed here

`TODO/EditTask.vue:116` pluralizes the building-age description with `task.days === 1` instead of `task.buildingAge === 1`. Pre-existing and unrelated.
