### PR TITLE
Stop requiring changelog edits in individual PRs

### DIFF
--- a/.claude/harness-notes.md
+++ b/.claude/harness-notes.md
@@ -39,7 +39,7 @@ dozen more as untracked, and `git add -A` then aborted with
 `error: .bash_profile: can only add regular files, symbolic links or git-directories`,
 staging nothing. They are not real files (`git status` unsandboxed shows only your actual
 changes) and `git fetch` warning `unable to access '.gitmodules': Permission denied` is the
-same illusion. Stage explicit paths (`git add src/ CHANGELOG.md`) and the problem
+same illusion. Stage explicit paths (`git add src/ docs/`) and the problem
 disappears — no bypass needed.
 
 A sandboxed command can also fail spuriously with

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -121,7 +121,7 @@ Check these categories. For each, the source of truth is the doc file, not this 
 - **Feature Design** — one-responsibility, dependencies, settings philosophy from contributing.md
 - **UI/UX** — element justification, PrUn palette, tooltips, server comm rules from contributing.md
 - **Game Knowledge** — no undocumented game mechanic assumptions; commands match `docs/game/commands.csv`
-- **Workflow** — changelog, import sorting, component reuse from contributing.md
+- **Workflow** — import sorting and component reuse from contributing.md
 - **PR Quality** — descriptive title, body explains "why", focused scope
 - **Code Quality** — no over-engineering, no security issues, resources cleaned up
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,3 @@
 - [ ] Feature has single responsibility, no cross-feature deps
 - [ ] CSS class names describe WHERE, not WHAT
 - [ ] Uses `C.Component.className` not hardcoded hashed classes
-- [ ] CHANGELOG.md updated under `## Unreleased` (or N/A — no user-facing change)

--- a/.github/scripts/pr-review.sh
+++ b/.github/scripts/pr-review.sh
@@ -32,8 +32,6 @@ Check for these specific violations:
 10. CSS CLASS NAMES describe WHERE they apply (e.g., .sortControls), not WHAT they do (e.g., .flexRow).
 11. Use C.Component.className instead of hardcoded hashed CSS class strings.
 12. STYLE: early returns to reduce nesting, single-param lambdas use x, no unnecessary type annotations, comments on separate lines starting with capital letter.
-13. CHANGELOG.md: a PR with a user-facing change (feature, behavior change, player-visible bug fix) should add a bullet under the `## Unreleased` heading. Flag if such a change has no corresponding entry. Also flag if the diff edits anything other than the `## Unreleased` section (renaming it, or editing an already-released version) — that's release automation's job, not a PR's.
-
 Instructions:
 - Only flag genuine violations of the rules above. Do not flag style preferences beyond what the docs specify.
 - Be concise. For each violation, state the rule number, the file and approximate location, and what is wrong.

--- a/docs-jack/agent-docs-backlog.md
+++ b/docs-jack/agent-docs-backlog.md
@@ -26,7 +26,7 @@ the repo owner should make. Delete an entry once it is done or rejected.
   `game-concepts.md` repeats CoGC facts owned by `planetary-governance.md`. Cut to
   cross-references.
 - **`docs/contributing.md`** mixes agent-actionable code rules with human process
-  (changelog, editor import sorting, the Discord ≥75% approval poll). The human process
+  (editor import sorting and the Discord ≥75% approval poll). The human process
   could live in a human-facing contributing guide instead.
 
 ## `.claude/` surface

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -171,31 +171,6 @@ The extension does make some background server requests (e.g., `XIT BURN` opens 
 
 ## Workflow
 
-### Changelog
-
-If a PR has a user-facing change (a feature, a behavior change, a bug fix a player would notice),
-add a bullet under the `## Unreleased` → `### Added`/`### Changed`/`### Fixed`/`### Removed`
-heading in `CHANGELOG.md` (create the subheading if it's not there yet). Follow the existing
-entry style: `` `feature-id-or-XIT-CMD`: Sentence describing the change. `` Skip it for
-non-user-facing changes (refactors, docs, CI, tests).
-
-Release automation renames `## Unreleased` to the shipped version number and opens a fresh
-`## Unreleased` section — don't rename it yourself, and don't touch anything above the current
-`## Unreleased` heading. `XIT WHATSNEW` (`src/features/XIT/WHATSNEW/`) reads `CHANGELOG.md` at
-build time to show players what changed since they last looked.
-
-This reintroduces the merge-conflict surface the old "maintainer edits it once before
-merging" policy existed to avoid: two branches both adding a bullet under `## Unreleased`
-can conflict where they land near each other. Resolution is normally trivial (keep both
-bullets) — accept it as the tradeoff for PRs writing their own entries.
-
-One resolution is not trivial: if a release shipped between when the bullet was written and
-when the branch is rebased or cherry-picked onto `main`, the conflict hunk sits under the
-*new version's* `### Added` heading, because the old `## Unreleased` was renamed underneath
-it. Keeping "both sides" there silently backdates the entry into a version that already
-shipped. Move the bullet up under the fresh empty `## Unreleased` instead, and re-create the
-`### Added` subheading there.
-
 ### Editing a PR with `gh`
 
 If `gh pr edit` fails with a Projects (classic) deprecation notice naming

--- a/grok-code-review.md
+++ b/grok-code-review.md
@@ -60,7 +60,6 @@ For **every** code review, verify compliance with:
 
 ### 5. Documentation & Workflow
 - Always check relevant docs first (`docs/README.md` lists them).
-- User-facing changes add a bullet under `## Unreleased` in `CHANGELOG.md`; don't touch anything above it (that's release automation's job).
 - Follow exact patterns from `docs/feature-patterns.md` for registration, XIT commands, Vue mounting, reactive DOM, etc.
 
 ---


### PR DESCRIPTION
## Summary

- Remove the instruction that individual pull requests update `CHANGELOG.md`.
- Remove the corresponding checklist and automated-review checks.
- Keep release-time changelog automation and `XIT WHATSNEW` behavior unchanged.

## Verification

- `pnpm run compile`