### PR TITLE
[RPR] XIT BS: burn-cell click expands base burn rows inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
 
+### Changed
+
+- `XIT BS`: Clicking a base's burn days expands that base's burn rows inline; shift-click opens `XIT BURN` in a new buffer.
+
 ### Fixed
 
 - `XIT AGENT`: Loads action packages from the refined-agent channel even when other comms buffers restore first.

--- a/src/features/XIT/BS/BaseRow.vue
+++ b/src/features/XIT/BS/BaseRow.vue
@@ -2,9 +2,12 @@
 import PrunLink from '@src/components/PrunLink.vue';
 import PrunButton from '@src/components/PrunButton.vue';
 import InvBar from '@src/features/XIT/BS/InvBar.vue';
+import MaterialList from '@src/features/XIT/BURN/MaterialList.vue';
+import { burnCellBufferCommand, toggleExpandedBurn } from '@src/features/XIT/BS/burn-cell-click';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { getPlanetBurn } from '@src/core/burn';
 import { countDays } from '@src/features/XIT/BURN/utils';
+import { useTileState } from '@src/store/user-data-tiles';
 import { getPickupAlarm, getStorageAlarmLevel } from '@src/core/storage-analysis';
 import { fixed1 } from '@src/utils/format';
 import { getPlanetProduction } from '@src/core/production';
@@ -42,6 +45,28 @@ const {
 
 const burn = computed(() => getPlanetBurn(siteId));
 const days = computed(() => (burn.value ? countDays(burn.value.burn) : undefined));
+const expandedBurns = useTileState('expandedBurns', [] as string[]);
+const isBurnExpanded = computed(() => expandedBurns.value.includes(naturalId));
+const columnCount = computed(
+  () =>
+    1 +
+    Number(showCmds) +
+    Number(showBurn) +
+    Number(showProd) +
+    Number(showRepair) +
+    Number(showInv) +
+    Number(showWar),
+);
+
+function onBurnDaysClick(e: MouseEvent) {
+  const command = burnCellBufferCommand(e, naturalId);
+  if (command !== undefined) {
+    e.preventDefault();
+    showBuffer(command);
+    return;
+  }
+  expandedBurns.value = toggleExpandedBurn(expandedBurns.value, naturalId);
+}
 
 const burnBgClass = computed(() => {
   if (days.value === undefined) {
@@ -161,9 +186,7 @@ const warehouseStore = computed(() =>
     </td>
     <td v-if="showBurn" :class="$style.statusCell">
       <div :class="[$style.statusContent, burnBgClass]">
-        <span :class="$style.statusNum" @click="showBuffer(`XIT BURN ${naturalId}`)">{{
-          daysText ?? '-'
-        }}</span>
+        <span :class="$style.statusNum" @click="onBurnDaysClick">{{ daysText ?? '-' }}</span>
         <PrunButton dark inline @click="showBuffer(`XIT BURNACT ${naturalId}`)">RES</PrunButton>
       </div>
     </td>
@@ -212,6 +235,25 @@ const warehouseStore = computed(() =>
         v-if="warehouseStore"
         :store-id="warehouseStore.id"
         :on-click-cmd="`INV ${warehouseStore.id.substring(0, 8)}`" />
+    </td>
+  </tr>
+  <tr v-if="showBurn && isBurnExpanded && burn">
+    <td :colspan="columnCount" :class="$style.burnExpandCell">
+      <table :class="$style.burnExpandTable">
+        <thead>
+          <tr>
+            <th />
+            <th>Inv</th>
+            <th>Burn</th>
+            <th>Need</th>
+            <th>Days</th>
+            <th>CMD</th>
+          </tr>
+        </thead>
+        <tbody>
+          <MaterialList :burn="burn" />
+        </tbody>
+      </table>
     </td>
   </tr>
 </template>
@@ -319,5 +361,13 @@ const warehouseStore = computed(() =>
   margin: 0;
   font-size: 10px;
   line-height: 1;
+}
+
+.burnExpandCell {
+  padding: 0 4px 4px 24px;
+}
+
+.burnExpandTable {
+  border-collapse: collapse;
 }
 </style>

--- a/src/features/XIT/BS/burn-cell-click.test.ts
+++ b/src/features/XIT/BS/burn-cell-click.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { burnCellBufferCommand, toggleExpandedBurn } from './burn-cell-click';
+
+describe('burnCellBufferCommand', () => {
+  it('does not open a buffer on a plain click', () => {
+    expect(burnCellBufferCommand({ shiftKey: false }, 'OT-580b')).toBeUndefined();
+  });
+
+  it('opens the base burn buffer on shift-click', () => {
+    expect(burnCellBufferCommand({ shiftKey: true }, 'OT-580b')).toBe('XIT BURN OT-580b');
+  });
+});
+
+describe('toggleExpandedBurn', () => {
+  it('expands a collapsed base', () => {
+    expect(toggleExpandedBurn([], 'OT-580b')).toEqual(['OT-580b']);
+  });
+
+  it('collapses an expanded base', () => {
+    expect(toggleExpandedBurn(['OT-580b'], 'OT-580b')).toEqual([]);
+  });
+
+  it('leaves other expanded bases in place', () => {
+    expect(toggleExpandedBurn(['UV-351a'], 'OT-580b')).toEqual(['UV-351a', 'OT-580b']);
+  });
+});

--- a/src/features/XIT/BS/burn-cell-click.ts
+++ b/src/features/XIT/BS/burn-cell-click.ts
@@ -1,0 +1,16 @@
+export function burnCellBufferCommand(
+  event: { shiftKey: boolean },
+  naturalId: string,
+): string | undefined {
+  if (!event.shiftKey) {
+    return undefined;
+  }
+  return `XIT BURN ${naturalId}`;
+}
+
+export function toggleExpandedBurn(expanded: readonly string[], naturalId: string): string[] {
+  if (expanded.includes(naturalId)) {
+    return expanded.filter(x => x !== naturalId);
+  }
+  return [...expanded, naturalId];
+}


### PR DESCRIPTION
Closes JAC-27.

In XIT BS, a plain click on a base's burn-days number now toggles that base's burn material rows inline under the row in the same buffer (same `MaterialList` as clicking the base in XIT BURN). Shift-click keeps the old behavior and opens `XIT BURN <naturalId>` in a new buffer. The RES button and other BS cells are unchanged.

## Verification

At `af9a2639620d3f6d4f304459e28b7e21fbe4d6f4`, same shell:

- `pnpm run compile` → exit 0
- `pnpm run test` → exit 0 (19 files, 156 passed / 1 skipped)

The "does not open a buffer on a plain click" test fails when `burnCellBufferCommand` is mutated to return `XIT BURN …` without `shiftKey`.
