### PR TITLE
XIT ACT: harden CONT Ship/Trade and rework the Paste parser

### DIFF
--- a/src/features/XIT/ACT/action-steps/CONT_SEND.ts
+++ b/src/features/XIT/ACT/action-steps/CONT_SEND.ts
@@ -1,10 +1,11 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
-import { fixed0 } from '@src/utils/format';
-import { changeInputValue, changeSelectIndex, focusElement } from '@src/util';
+import { fixed0, fixed2 } from '@src/utils/format';
+import { changeSelectIndex, selectAndChangeInputValue } from '@src/util';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 import { selectAddress } from '@src/infrastructure/prun-ui/utils/select-address';
+import { AssertFn } from '@src/features/XIT/ACT/shared-types';
 import {
-  waitFor,
+  pollUntil,
   createNewDraft,
   setDraftNameAndPreamble,
   saveDraftDetails,
@@ -15,7 +16,6 @@ import {
   setDeadline,
   applyTemplate,
   saveConditions,
-  ContDraftContext,
 } from '@src/features/XIT/ACT/action-steps/cont-utils';
 
 interface Data {
@@ -30,6 +30,19 @@ interface Data {
   autoProvisionStoreId?: string;
 }
 
+// The SHIP template has a single price field outside the commodity groups.
+// Prefer name="price", then fall back to the decimal input outside the groups.
+function findPriceInput(anchor: Element) {
+  const named = anchor.querySelector<HTMLInputElement>('input[name="price"]');
+  if (named !== null) {
+    return named;
+  }
+  const groups = _$$(anchor, C.TemplateSelection.group);
+  return _$$(anchor, 'input[inputmode="decimal"]').find(
+    x => !groups.some(group => group.contains(x)),
+  ) as HTMLInputElement | undefined;
+}
+
 export const CONT_SEND = act.addActionStep<Data>({
   type: 'CONT_SEND',
   totalMaterials: data =>
@@ -40,16 +53,16 @@ export const CONT_SEND = act.addActionStep<Data>({
     return `Create contract draft (${materialCount} materials)${payment}`;
   },
   execute: async ctx => {
-    const { data, log, setStatus, requestTile, waitAct, complete, fail } = ctx;
+    const { data, log, setStatus, requestTile, waitAct, complete } = ctx;
+    const assert: AssertFn = ctx.assert;
 
     // Calculate total tonnage for the preamble and payment logging.
     // material.weight is in the same unit as weightCapacity (tonnes).
     let totalTonnage = 0;
-    const materialDetails: Array<{ ticker: string; amount: number; tonnage: number }> = [];
+    const materialDetails: Array<{ ticker: string; amount: number }> = [];
 
-    for (const [ticker, rawAmount] of Object.entries(data.materials)) {
-      const qty = rawAmount as number;
-      if (qty <= 0) {
+    for (const [ticker, amount] of Object.entries(data.materials)) {
+      if (amount <= 0) {
         continue;
       }
       const material = materialsStore.getByTicker(ticker);
@@ -57,156 +70,125 @@ export const CONT_SEND = act.addActionStep<Data>({
         log.warning(`Material ${ticker} not found, skipping`);
         continue;
       }
-      const t = material.weight * qty;
-      totalTonnage += t;
-      materialDetails.push({ ticker, amount: qty, tonnage: t });
+      totalTonnage += material.weight * amount;
+      materialDetails.push({ ticker, amount });
     }
+
+    assert(materialDetails.length > 0, 'Material group has no materials to ship');
 
     if (data.payment > 0 && totalTonnage > 0) {
       log.info(
-        `Total: ${totalTonnage.toFixed(2)}t, ${data.payment} ${data.currency} (${Math.round(data.payment / totalTonnage)} ${data.currency}/t)`,
+        `Total: ${fixed2(totalTonnage)}t, ${fixed0(data.payment)} ${data.currency} (${fixed0(data.payment / totalTonnage)} ${data.currency}/t)`,
       );
     }
 
-    // Step 1: Create new draft
+    // Step 1: Create new draft. The open is gated by this step's own ACT click,
+    // so it must not cost a second one.
     await waitAct('Create new draft?');
-    const listTile = await requestTile('CONTD');
+    const listTile = await requestTile('CONTD', { actGate: false });
     if (!listTile) {
       return;
     }
 
-    const draftCtx: ContDraftContext = { draftTile: listTile, log, setStatus, fail };
-
-    const newDraft = await createNewDraft(draftCtx);
-    if (!newDraft) {
-      return;
-    }
+    const newDraft = await createNewDraft(ctx);
 
     setStatus(`Loading draft ${newDraft.naturalId}...`);
     const draftTile = await requestTile(`CONTD ${newDraft.naturalId}`);
     if (!draftTile) {
       return;
     }
-
-    // Update context to point at the actual draft tile.
-    const ctx2: ContDraftContext = { draftTile, log, setStatus, fail };
+    const anchor = draftTile.anchor;
 
     const now = new Date();
     const dateStr = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     const contractName = `${data.packageName} - ${data.contDest ?? ''} - ${dateStr}`;
 
-    const materialsList = materialDetails.map(m => `${m.ticker} x${m.amount}`).join(', ');
+    const materialsList = materialDetails.map(x => `${x.ticker} x${fixed0(x.amount)}`).join(', ');
     const preambleText =
       data.contractNote ??
-      `Shipping contract for ${totalTonnage.toFixed(2)}t.\n` +
+      `Shipping contract for ${fixed2(totalTonnage)}t.\n` +
         `Materials: ${materialsList}\n` +
         (data.payment > 0
-          ? `Payment: ${data.payment} ${data.currency} (${Math.round(data.payment / totalTonnage)} ${data.currency}/t)\n`
+          ? `Payment: ${fixed0(data.payment)} ${data.currency} (${fixed0(data.payment / totalTonnage)} ${data.currency}/t)\n`
           : '') +
-        (data.daysToFulfill > 0 ? `Delivery within ${data.daysToFulfill} days` : '');
+        (data.daysToFulfill > 0 ? `Delivery within ${fixed0(data.daysToFulfill)} days` : '');
 
-    await setDraftNameAndPreamble(ctx2, contractName, preambleText);
+    await setDraftNameAndPreamble(ctx, anchor, contractName, preambleText);
 
     // Step 2: Save draft details (name/preamble)
     await waitAct('Save draft details?');
-    await saveDraftDetails(ctx2);
+    await saveDraftDetails(ctx, anchor, newDraft.naturalId);
 
-    const templateSelect = await openTemplate(ctx2);
-    if (!templateSelect) {
-      return;
-    }
+    const templateSelect = await openTemplate(ctx, anchor);
+    selectTemplateType(ctx, templateSelect, 'SHIP');
+    await setCurrency(ctx, anchor, data.currency);
 
-    selectTemplateType(ctx2, templateSelect, 'SHIP');
-    await setCurrency(ctx2, data.currency);
-
-    await addMaterials(
-      ctx2,
-      materialDetails.map(m => ({ ticker: m.ticker, amount: m.amount })),
-    );
+    await addMaterials(ctx, anchor, materialDetails);
 
     // The SHIP template price field is per-commodity — the game charges this
     // amount for each commodity row. Divide total payment by number of commodities.
-    if (data.payment > 0 && materialDetails.length > 0) {
+    if (data.payment > 0) {
       const pricePerCommodity = Math.round(data.payment / materialDetails.length);
-      // The SHIP template has a single price field outside the commodity groups.
-      // Try name="price" first, then fall back to the decimal input outside groups.
-      const priceInput = (draftTile.anchor.querySelector('input[name="price"]') ??
-        (() => {
-          const groups = new Set(_$$(draftTile.anchor, C.TemplateSelection.group));
-          return _$$(draftTile.anchor, 'input[inputmode="decimal"]').find(
-            el => !Array.from(groups).some(g => g.contains(el)),
-          );
-        })()) as HTMLInputElement | null;
-      if (priceInput) {
-        focusElement(priceInput);
-        priceInput.select();
-        changeInputValue(priceInput, String(pricePerCommodity));
-        log.info(
-          `Price set: ${pricePerCommodity} ${data.currency}/commodity x${materialDetails.length} = ${pricePerCommodity * materialDetails.length} ${data.currency} total`,
-        );
-      } else {
-        log.warning('Could not find price input');
-      }
+      const priceInput = findPriceInput(anchor);
+      assert(priceInput, 'Could not find price input');
+      selectAndChangeInputValue(priceInput, String(pricePerCommodity));
+      log.info(
+        `Price set: ${fixed0(pricePerCommodity)} ${data.currency}/commodity x${materialDetails.length} = ${fixed0(pricePerCommodity * materialDetails.length)} ${data.currency} total`,
+      );
     }
 
     // Step 3: Set origin address
-    const addressContainers = _$$(draftTile.anchor, C.AddressSelector.container) as HTMLElement[];
+    const addressContainers = _$$(anchor, C.AddressSelector.container) as HTMLElement[];
 
-    if (addressContainers.length >= 1 && data.contOrigin) {
-      await waitAct(`Set origin to ${data.contOrigin}?`);
-      const ok = await selectAddress(addressContainers[0], data.contOrigin);
-      if (ok) {
-        log.info(`Origin set: ${data.contOrigin}`);
-      } else {
-        log.warning(`Could not select origin: ${data.contOrigin}`);
-      }
-    }
+    assert(
+      addressContainers.length >= 1 && data.contOrigin !== undefined,
+      'Could not find origin control',
+    );
+    await waitAct(`Set origin to ${data.contOrigin}?`);
+    const originSet = await selectAddress(addressContainers[0], data.contOrigin);
+    assert(originSet, `Could not select origin: ${data.contOrigin}`);
+    log.info(`Origin set: ${data.contOrigin}`);
 
     // Step 4: Set destination address
-    if (addressContainers.length >= 2 && data.contDest) {
-      await waitAct(`Set destination to ${data.contDest}?`);
-      const ok = await selectAddress(addressContainers[1], data.contDest);
-      if (ok) {
-        log.info(`Destination set: ${data.contDest}`);
-      } else {
-        log.warning(`Could not select destination: ${data.contDest}`);
-      }
-    }
+    assert(
+      addressContainers.length >= 2 && data.contDest !== undefined,
+      'Could not find destination control',
+    );
+    await waitAct(`Set destination to ${data.contDest}?`);
+    const destSet = await selectAddress(addressContainers[1], data.contDest);
+    assert(destSet, `Could not select destination: ${data.contDest}`);
+    log.info(`Destination set: ${data.contDest}`);
 
-    if (data.autoProvisionStoreId) {
+    if (data.autoProvisionStoreId !== undefined) {
       setStatus('Setting auto-provision store...');
-      const storeSelectReady = await waitFor(() => {
-        const sel = _$(draftTile.anchor, C.StoreSelect.container) as HTMLSelectElement | null;
-        return !!sel && sel.options.length > 1;
+      // The store options only populate once the origin address resolves.
+      const storeSelect = await pollUntil(() => {
+        const select = _$(anchor, C.StoreSelect.container) as HTMLSelectElement | undefined;
+        return select !== undefined && select.options.length > 1 ? select : undefined;
       }, 5000);
-      if (storeSelectReady) {
-        const storeSelect = _$(draftTile.anchor, C.StoreSelect.container) as HTMLSelectElement;
-        const normalizedId = data.autoProvisionStoreId!.replaceAll('-', '');
-        const optionIndex = Array.from(storeSelect.options).findIndex(
-          o => o.value === data.autoProvisionStoreId || o.value === normalizedId,
-        );
-        if (optionIndex >= 0) {
-          changeSelectIndex(storeSelect, optionIndex);
-          log.info(`Auto-provision store set: ${storeSelect.options[optionIndex].text}`);
-        } else {
-          log.warning(`Could not find auto-provision store option: ${data.autoProvisionStoreId}`);
-        }
-      } else {
-        log.warning('Auto-provision store select did not appear');
-      }
+      assert(storeSelect, 'Auto-provision store select did not appear');
+
+      const normalizedId = data.autoProvisionStoreId.replaceAll('-', '');
+      const optionIndex = Array.from(storeSelect.options).findIndex(
+        x => x.value === data.autoProvisionStoreId || x.value === normalizedId,
+      );
+      assert(
+        optionIndex >= 0,
+        `Could not find auto-provision store option: ${data.autoProvisionStoreId}`,
+      );
+      changeSelectIndex(storeSelect, optionIndex);
+      log.info(`Auto-provision store set: ${storeSelect.options[optionIndex].text}`);
     }
 
-    setDeadline(ctx2, data.daysToFulfill);
+    setDeadline(ctx, anchor, data.daysToFulfill);
 
     // Step 5: Apply template
     await waitAct('Apply template?');
-    const applied = await applyTemplate(ctx2);
-    if (!applied) {
-      return;
-    }
+    await applyTemplate(ctx, anchor, newDraft.naturalId);
 
-    // Step 6: Save conditions
-    await saveConditions(ctx2, waitAct);
+    // Step 6: Save conditions, after the player has reviewed them.
+    await waitAct('Save conditions?');
+    await saveConditions(ctx, anchor, newDraft.naturalId);
 
     log.success(`Contract draft ${newDraft.naturalId} ready to send`);
     complete();

--- a/src/features/XIT/ACT/action-steps/CONT_TRADE.ts
+++ b/src/features/XIT/ACT/action-steps/CONT_TRADE.ts
@@ -1,7 +1,9 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
 import { fixed0 } from '@src/utils/format';
-import { changeInputValue, focusElement } from '@src/util';
+import { selectAndChangeInputValue } from '@src/util';
 import { selectAddress } from '@src/infrastructure/prun-ui/utils/select-address';
+import { AssertFn } from '@src/features/XIT/ACT/shared-types';
+import { isValidContractPrice } from '@src/features/XIT/ACT/actions/cont-limits';
 import {
   createNewDraft,
   setDraftNameAndPreamble,
@@ -13,7 +15,6 @@ import {
   setDeadline,
   applyTemplate,
   saveConditions,
-  ContDraftContext,
 } from '@src/features/XIT/ACT/action-steps/cont-utils';
 
 interface Data {
@@ -36,31 +37,27 @@ export const CONT_TRADE = act.addActionStep<Data>({
     return `Create ${typeLabel} contract draft (${materialCount} materials)`;
   },
   execute: async ctx => {
-    const { data, log, setStatus, requestTile, waitAct, complete, fail } = ctx;
+    const { data, log, setStatus, requestTile, waitAct, complete } = ctx;
+    const assert: AssertFn = ctx.assert;
 
     const typeLabel = data.tradeType === 'BUYING' ? 'Buy' : 'Sell';
 
-    // Step 1: Create new draft
+    // Step 1: Create new draft. The open is gated by this step's own ACT click,
+    // so it must not cost a second one.
     await waitAct('Create new draft?');
-    const listTile = await requestTile('CONTD');
+    const listTile = await requestTile('CONTD', { actGate: false });
     if (!listTile) {
       return;
     }
 
-    const draftCtx: ContDraftContext = { draftTile: listTile, log, setStatus, fail };
-
-    const newDraft = await createNewDraft(draftCtx);
-    if (!newDraft) {
-      return;
-    }
+    const newDraft = await createNewDraft(ctx);
 
     setStatus(`Loading draft ${newDraft.naturalId}...`);
     const draftTile = await requestTile(`CONTD ${newDraft.naturalId}`);
     if (!draftTile) {
       return;
     }
-
-    const ctx2: ContDraftContext = { draftTile, log, setStatus, fail };
+    const anchor = draftTile.anchor;
 
     // Set contract name.
     const now = new Date();
@@ -71,77 +68,64 @@ export const CONT_TRADE = act.addActionStep<Data>({
     const materialsList = Object.entries(data.materials)
       .map(([ticker, amount]) => {
         const price = data.prices[ticker];
-        return price !== undefined && price > 0
-          ? `${ticker} x${amount} @ ${fixed0(price)}/u`
-          : `${ticker} x${amount}`;
+        return price !== undefined
+          ? `${ticker} x${fixed0(amount)} @ ${price}/u`
+          : `${ticker} x${fixed0(amount)}`;
       })
       .join(', ');
     const preambleText =
       `${typeLabel} contract.\n` +
       `Materials: ${materialsList}\n` +
-      (data.daysToFulfill > 0 ? `Fulfill within ${data.daysToFulfill} days` : '');
+      (data.daysToFulfill > 0 ? `Fulfill within ${fixed0(data.daysToFulfill)} days` : '');
 
-    await setDraftNameAndPreamble(ctx2, contractName, preambleText);
+    await setDraftNameAndPreamble(ctx, anchor, contractName, preambleText);
 
     // Step 2: Save draft details (name/preamble)
     await waitAct('Save draft details?');
-    await saveDraftDetails(ctx2);
+    await saveDraftDetails(ctx, anchor, newDraft.naturalId);
 
-    const templateSelect = await openTemplate(ctx2);
-    if (!templateSelect) {
-      return;
-    }
-
-    selectTemplateType(ctx2, templateSelect, data.tradeType);
-    await setCurrency(ctx2, data.currency);
+    const templateSelect = await openTemplate(ctx, anchor);
+    selectTemplateType(ctx, templateSelect, data.tradeType);
+    await setCurrency(ctx, anchor, data.currency);
 
     // Add materials with per-material prices.
     const materialEntries = Object.entries(data.materials)
       .filter(([, amount]) => amount > 0)
       .map(([ticker, amount]) => ({ ticker, amount }));
 
-    await addMaterials(ctx2, materialEntries, {
+    await addMaterials(ctx, anchor, materialEntries, {
       setPrice: (group, ticker) => {
+        // A row left without a price would go out as a free trade, so this is a
+        // hard failure rather than a skipped field.
         const price = data.prices[ticker];
-        if (price !== undefined && price > 0) {
-          const priceInput = group.querySelector(
-            'input[inputmode="decimal"]',
-          ) as HTMLInputElement | null;
-          if (priceInput) {
-            focusElement(priceInput);
-            priceInput.select();
-            changeInputValue(priceInput, String(price));
-            log.info(`Price for ${ticker}: ${price} ${data.currency}`);
-          } else {
-            log.warning(`Could not find price input for ${ticker}`);
-          }
-        }
+        assert(isValidContractPrice(price), `Invalid price for ${ticker}`);
+        const priceInput = group.querySelector<HTMLInputElement>('input[inputmode="decimal"]');
+        assert(priceInput, `Could not find price input for ${ticker}`);
+        selectAndChangeInputValue(priceInput, String(price));
+        log.info(`Price for ${ticker}: ${price} ${data.currency}`);
       },
     });
 
     // Step 3: Set location address
-    const addressContainers = _$$(draftTile.anchor, C.AddressSelector.container) as HTMLElement[];
-    if (addressContainers.length >= 1 && data.location) {
-      await waitAct(`Set location to ${data.location}?`);
-      const ok = await selectAddress(addressContainers[0], data.location);
-      if (ok) {
-        log.info(`Location set: ${data.location}`);
-      } else {
-        log.warning(`Could not select location: ${data.location}`);
-      }
-    }
+    const addressContainers = _$$(anchor, C.AddressSelector.container) as HTMLElement[];
+    assert(
+      addressContainers.length >= 1 && data.location.length > 0,
+      'Could not find trade location control',
+    );
+    await waitAct(`Set location to ${data.location}?`);
+    const locationSet = await selectAddress(addressContainers[0], data.location);
+    assert(locationSet, `Could not select location: ${data.location}`);
+    log.info(`Location set: ${data.location}`);
 
-    setDeadline(ctx2, data.daysToFulfill);
+    setDeadline(ctx, anchor, data.daysToFulfill);
 
     // Step 4: Apply template
     await waitAct('Apply template?');
-    const applied = await applyTemplate(ctx2);
-    if (!applied) {
-      return;
-    }
+    await applyTemplate(ctx, anchor, newDraft.naturalId);
 
-    // Step 5: Save conditions
-    await saveConditions(ctx2, waitAct);
+    // Step 5: Save conditions, after the player has reviewed them.
+    await waitAct('Save conditions?');
+    await saveConditions(ctx, anchor, newDraft.naturalId);
 
     log.success(`Contract draft ${newDraft.naturalId} ready to send`);
     complete();

--- a/src/features/XIT/ACT/action-steps/cont-utils.ts
+++ b/src/features/XIT/ACT/action-steps/cont-utils.ts
@@ -4,26 +4,54 @@ import {
   changeTextAreaValue,
   clickElement,
   focusElement,
+  selectAndChangeInputValue,
 } from '@src/util';
 import { sleep } from '@src/utils/sleep';
 import { $ } from '@src/utils/select-dom';
+import { fixed0 } from '@src/utils/format';
 import { contractDraftsStore } from '@src/infrastructure/prun-api/data/contract-drafts';
+import { ActionStepExecuteContext, AssertFn } from '@src/features/XIT/ACT/shared-types';
+import { maxContractDays, minContractDays } from '@src/features/XIT/ACT/actions/cont-limits';
 
-export async function waitFor(
-  condition: () => boolean,
-  timeout = 5000,
+// The game's own form limits. Generated text is truncated to fit rather than
+// silently rejected by the field.
+const maxNameLength = 50;
+const maxPreambleLength = 250;
+
+// Polls until the callback returns something truthy, then hands that value back.
+// Returning the value avoids the find-twice pattern a boolean version forces.
+export async function pollUntil<T>(
+  produce: () => T,
+  timeout: number,
   interval = 100,
-): Promise<boolean> {
+): Promise<T | undefined> {
   const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    if (condition()) {
-      return true;
+  for (;;) {
+    const result = produce();
+    if (result) {
+      return result;
+    }
+    if (Date.now() >= deadline) {
+      return undefined;
     }
     await sleep(interval);
   }
-  return false;
 }
 
+const hasText = (text: string) => (x: Element) => x.textContent?.trim().toLowerCase() === text;
+
+function findButton(anchor: Element, text: string) {
+  return _$$(anchor, C.Button.btn).find(hasText(text));
+}
+
+function truncate(text: string, limit: number) {
+  return text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+}
+
+/**
+ * Types a ticker into a MaterialSelector and clicks the matching suggestion.
+ * Also used by MTRA_TRANSFER and the ship-unload feature.
+ */
 export async function selectMaterial(container: Element, ticker: string) {
   const input = (await $(container, C.MaterialSelector.input)) as HTMLInputElement | null;
   if (!input) {
@@ -63,60 +91,38 @@ export async function selectMaterial(container: Element, ticker: string) {
   return true;
 }
 
-// --- Shared contract draft helpers ---
-
-export interface ContDraftContext {
-  draftTile: { anchor: Element };
-  log: { info: (msg: string) => void; warning: (msg: string) => void };
-  setStatus: (msg: string) => void;
-  fail: (msg: string) => void;
-}
-
 /**
- * Finds "Create New" button in any CONTD tile, clicks it, and waits for the
- * new draft to appear in the store. Returns the new draft or undefined on failure.
+ * Finds the "Create New" button in any CONTD tile, clicks it, and waits for the
+ * new draft to appear in the store.
  */
-export async function createNewDraft(
-  ctx: ContDraftContext,
-): Promise<PrunApi.ContractDraft | undefined> {
-  const { log, setStatus, fail } = ctx;
+export async function createNewDraft(ctx: ActionStepExecuteContext<unknown>) {
+  const assert: AssertFn = ctx.assert;
+  const { log, setStatus } = ctx;
 
   setStatus('Looking for Create New button...');
 
-  const isCreateNew = (btn: Element) => btn.textContent?.trim().toLowerCase() === 'create new';
-
-  const findContdButton = () => {
+  const findCreateButton = () => {
     for (const tile of tiles.find('CONTD', true)) {
-      const btn = _$$(tile.anchor, C.Button.btn).find(isCreateNew);
-      if (btn) {
-        return { tile, btn };
+      const button = findButton(tile.anchor, 'create new');
+      if (button) {
+        return button;
       }
     }
     return undefined;
   };
 
-  const createBtnReady = await waitFor(() => !!findContdButton(), 10000);
-  if (!createBtnReady) {
-    fail('Could not find "Create New" button');
-    return undefined;
-  }
+  const createBtn = await pollUntil(findCreateButton, 10000);
+  assert(createBtn, 'Could not find "Create New" button');
 
-  const { btn: createBtn } = findContdButton()!;
-
-  const beforeIds = new Set((contractDraftsStore.all.value ?? []).map(d => d.naturalId));
+  const beforeIds = new Set((contractDraftsStore.all.value ?? []).map(x => x.naturalId));
   await clickElement(createBtn);
 
   setStatus('Waiting for draft to be created...');
-  const draftAppeared = await waitFor(
-    () => (contractDraftsStore.all.value ?? []).some(d => !beforeIds.has(d.naturalId)),
+  const newDraft = await pollUntil(
+    () => (contractDraftsStore.all.value ?? []).find(x => !beforeIds.has(x.naturalId)),
     8000,
   );
-  if (!draftAppeared) {
-    fail('Timed out waiting for new contract draft');
-    return undefined;
-  }
-
-  const newDraft = (contractDraftsStore.all.value ?? []).find(d => !beforeIds.has(d.naturalId))!;
+  assert(newDraft, 'Timed out waiting for new contract draft');
   log.info(`New draft created: ${newDraft.naturalId}`);
   return newDraft;
 }
@@ -125,83 +131,84 @@ export async function createNewDraft(
  * Sets the contract name (first input) and preamble (textarea) in the draft tile.
  */
 export async function setDraftNameAndPreamble(
-  ctx: ContDraftContext,
+  ctx: ActionStepExecuteContext<unknown>,
+  anchor: Element,
   name: string,
   preamble: string,
-): Promise<void> {
-  const { draftTile, log, setStatus } = ctx;
+) {
+  const assert: AssertFn = ctx.assert;
+  const { log, setStatus } = ctx;
 
   setStatus('Setting contract name...');
 
-  const nameInput = (await $(draftTile.anchor, 'input')) as HTMLInputElement | null;
-  if (nameInput) {
-    focusElement(nameInput);
-    nameInput.select();
-    changeInputValue(nameInput, name);
-    log.info(`Name set: ${name}`);
-  } else {
-    log.warning('Could not find name input');
-  }
+  // Poll rather than `await $()`, which has no timeout and would hang the run
+  // instead of failing it when the form never renders.
+  const nameInput = await pollUntil(() => _$(anchor, 'input'), 5000);
+  assert(nameInput, 'Could not find name input');
+  selectAndChangeInputValue(nameInput, truncate(name, maxNameLength));
+  log.info(`Name set: ${name}`);
 
-  const preambleInput = _$(draftTile.anchor, 'textarea') as HTMLTextAreaElement | null;
-  if (preambleInput) {
-    focusElement(preambleInput);
-    changeTextAreaValue(preambleInput, preamble);
-    log.info('Preamble set');
-  }
+  const preambleInput = _$(anchor, 'textarea');
+  assert(preambleInput, 'Could not find preamble input');
+  focusElement(preambleInput);
+  changeTextAreaValue(preambleInput, truncate(preamble, maxPreambleLength));
+  log.info('Preamble set');
 }
 
 /**
- * Clicks the first "save" button (draft details / preamble save).
+ * Clicks the draft-details save button and waits for the server to echo the
+ * saved name and preamble back into the store.
  */
-export async function saveDraftDetails(ctx: ContDraftContext): Promise<void> {
-  const { draftTile, log, setStatus } = ctx;
+export async function saveDraftDetails(
+  ctx: ActionStepExecuteContext<unknown>,
+  anchor: Element,
+  draftId: string,
+) {
+  const assert: AssertFn = ctx.assert;
+  const { log, setStatus } = ctx;
 
   setStatus('Saving draft details...');
 
-  const saveBtn = _$$(draftTile.anchor, C.Button.btn).find(
-    (btn: HTMLElement) => btn.textContent?.trim().toLowerCase() === 'save',
-  ) as HTMLElement | undefined;
-  if (saveBtn) {
-    await clickElement(saveBtn);
-    log.info('Draft details saved');
-  } else {
-    log.warning('Could not find save button for draft details');
-  }
+  const before = contractDraftsStore.getByNaturalId(draftId);
+  // Read back what the form holds rather than what we meant to write, so a
+  // field the game reformatted still compares equal.
+  const name = _$(anchor, 'input')?.value;
+  const preamble = _$(anchor, 'textarea')?.value;
+  const saveBtn = findButton(anchor, 'save');
+  assert(
+    saveBtn !== undefined && !saveBtn.classList.contains(C.Button.disabled),
+    'Draft details save button is missing or disabled',
+  );
+  await clickElement(saveBtn);
+
+  const saved = await pollUntil(() => {
+    const draft = contractDraftsStore.getByNaturalId(draftId);
+    return (
+      draft !== undefined && draft !== before && draft.name === name && draft.preamble === preamble
+    );
+  }, 8000);
+  assert(saved, 'Draft details were not saved');
+  log.info('Draft details saved');
 }
 
 /**
- * Waits for and clicks the "Select Template" button, then returns the
- * template type <select> element.
+ * Clicks "Select Template" and returns the template type <select>.
  */
-export async function openTemplate(ctx: ContDraftContext): Promise<HTMLSelectElement | undefined> {
-  const { draftTile, setStatus, fail } = ctx;
+export async function openTemplate(ctx: ActionStepExecuteContext<unknown>, anchor: Element) {
+  const assert: AssertFn = ctx.assert;
+  const { setStatus } = ctx;
 
   setStatus('Opening template selection...');
 
-  const selectTemplateBtnReady = await waitFor(
-    () =>
-      _$$(draftTile.anchor, 'button').some(
-        btn => btn.textContent?.trim().toLowerCase() === 'select template',
-      ),
-    5000,
-  );
-  if (!selectTemplateBtnReady) {
-    fail('Could not find "Select Template" button');
-    return undefined;
-  }
-  const selectTemplateBtn = _$$(draftTile.anchor, 'button').find(
-    btn => btn.textContent?.trim().toLowerCase() === 'select template',
-  )!;
-  await clickElement(selectTemplateBtn);
+  const templateBtn = await pollUntil(() => findButton(anchor, 'select template'), 5000);
+  assert(templateBtn, 'Could not find "Select Template" button');
+  await clickElement(templateBtn);
 
-  const templateTypeContainer = await $(draftTile.anchor, C.TemplateSelection.templateTypeSelect);
-  const templateSelect = _$(templateTypeContainer, 'select') as HTMLSelectElement | null;
-  if (!templateSelect) {
-    fail('Could not find template type select');
-    return undefined;
-  }
-
+  const templateSelect = await pollUntil(() => {
+    const container = _$(anchor, C.TemplateSelection.templateTypeSelect);
+    return container === undefined ? undefined : _$(container, 'select');
+  }, 5000);
+  assert(templateSelect, 'Could not find template type select');
   return templateSelect;
 }
 
@@ -215,42 +222,37 @@ const templateValueMap: Record<string, string> = {
  * Selects a template type (e.g. 'SHIP', 'BUYING', 'SELLING') in the template dropdown.
  */
 export function selectTemplateType(
-  ctx: ContDraftContext,
+  ctx: ActionStepExecuteContext<unknown>,
   templateSelect: HTMLSelectElement,
   templateValue: string,
-): void {
+) {
+  const assert: AssertFn = ctx.assert;
   const mapped = templateValueMap[templateValue] ?? templateValue;
-  const idx = Array.from(templateSelect.options).findIndex(o => o.value === mapped);
-  if (idx >= 0) {
-    changeSelectIndex(templateSelect, idx);
-  }
+  const index = Array.from(templateSelect.options).findIndex(x => x.value === mapped);
+  assert(index >= 0, `Template "${templateValue}" not found in the template select`);
+  changeSelectIndex(templateSelect, index);
   ctx.log.info(`Selected "${templateValue}" template`);
 }
 
 /**
  * Finds the currency <select> and sets it to the given currency code.
  */
-export async function setCurrency(ctx: ContDraftContext, currency: string): Promise<void> {
-  const { draftTile, log } = ctx;
+export async function setCurrency(
+  ctx: ActionStepExecuteContext<unknown>,
+  anchor: Element,
+  currency: string,
+) {
+  const assert: AssertFn = ctx.assert;
+  const { log } = ctx;
 
-  const currencySelectFound = await waitFor(() => {
-    const selects = _$$(draftTile.anchor, 'select') as HTMLSelectElement[];
-    return selects.some(s => Array.from(s.options).some(o => o.value === currency));
-  }, 3000);
-
-  if (currencySelectFound) {
-    const selects = _$$(draftTile.anchor, 'select') as HTMLSelectElement[];
-    const currencySelect = selects.find(s =>
-      Array.from(s.options).some(o => o.value === currency),
-    )!;
-    const currencyIndex = Array.from(currencySelect.options).findIndex(o => o.value === currency);
-    if (currencyIndex >= 0) {
-      changeSelectIndex(currencySelect, currencyIndex);
-    }
-    log.info(`Currency set to ${currency}`);
-  } else {
-    log.warning(`Could not find currency select for ${currency}`);
-  }
+  const currencySelect = await pollUntil(
+    () => _$$(anchor, 'select').find(x => Array.from(x.options).some(o => o.value === currency)),
+    3000,
+  );
+  assert(currencySelect, `Could not find currency select for ${currency}`);
+  const index = Array.from(currencySelect.options).findIndex(x => x.value === currency);
+  changeSelectIndex(currencySelect, index);
+  log.info(`Currency set to ${currency}`);
 }
 
 export interface MaterialEntry {
@@ -268,135 +270,128 @@ export interface AddMaterialsOptions {
  * for rows after the first, sets amount and selects material for each.
  *
  * Same job as importMaterials() in src/features/basic/contd-paste-import/draft-form.ts
- * (the CONTD paste-import feature), kept separate since this one is coupled to ACT's
- * ContDraftContext.
+ * (the CONTD paste-import feature), kept separate since this one drives an ACT step.
  */
 export async function addMaterials(
-  ctx: ContDraftContext,
+  ctx: ActionStepExecuteContext<unknown>,
+  anchor: Element,
   materials: MaterialEntry[],
   options?: AddMaterialsOptions,
-): Promise<void> {
-  const { draftTile, log, setStatus } = ctx;
+) {
+  const assert: AssertFn = ctx.assert;
+  const { log, setStatus } = ctx;
 
   setStatus('Adding materials to template...');
 
+  const findAddButton = () =>
+    _$$(anchor, 'button').find(x => hasText('add shipment')(x) || hasText('add commodity')(x));
+
   for (let i = 0; i < materials.length; i++) {
-    const mat = materials[i];
+    const material = materials[i];
 
     if (i > 0) {
-      const addBtn = _$$(draftTile.anchor, 'button').find(btn => {
-        const t = btn.textContent?.trim().toLowerCase();
-        return t === 'add shipment' || t === 'add commodity';
-      });
-      if (!addBtn) {
-        log.warning(`Could not find add button for ${mat.ticker}`);
-        continue;
-      }
+      const addBtn = findAddButton();
+      assert(addBtn, `Could not find add button for ${material.ticker}`);
       await clickElement(addBtn);
-      await waitFor(() => _$$(draftTile.anchor, C.TemplateSelection.group).length >= i + 1, 2000);
     }
 
-    const groups = _$$(draftTile.anchor, C.TemplateSelection.group);
-    const group = groups.at(-1);
-    if (!group) {
-      log.warning(`Could not find group for ${mat.ticker}`);
-      continue;
-    }
+    // Index the row rather than taking the last one: the template may render
+    // rows we did not add, and every entry would then overwrite the same row.
+    const group = await pollUntil(() => _$$(anchor, C.TemplateSelection.group).at(i), 2000);
+    assert(group, `Could not find group for ${material.ticker}`);
 
-    const amountInput = group.querySelector(
-      'input[inputmode="numeric"]',
-    ) as HTMLInputElement | null;
-    if (amountInput) {
-      focusElement(amountInput);
-      amountInput.select();
-      changeInputValue(amountInput, String(mat.amount));
-    }
+    const amountInput = group.querySelector<HTMLInputElement>('input[inputmode="numeric"]');
+    assert(amountInput, `Could not find amount input for ${material.ticker}`);
+    selectAndChangeInputValue(amountInput, String(material.amount));
 
-    const matSelectorContainer = _$(group, C.MaterialSelector.container);
-    if (matSelectorContainer) {
-      const ok = await selectMaterial(matSelectorContainer, mat.ticker);
-      if (ok) {
-        log.info(`Added: ${mat.ticker} x${mat.amount}`);
-      } else {
-        log.warning(`Could not select material ${mat.ticker}`);
-      }
-    }
+    const matSelector = _$(group, C.MaterialSelector.container);
+    assert(matSelector, `Could not find material selector for ${material.ticker}`);
+    const selected = await selectMaterial(matSelector, material.ticker);
+    assert(selected, `Could not select material ${material.ticker}`);
+    log.info(`Added: ${material.ticker} x${fixed0(material.amount)}`);
 
-    options?.setPrice?.(group, mat.ticker);
+    options?.setPrice?.(group, material.ticker);
   }
 }
 
 /**
  * Sets the deadline (days to fulfill) input.
  */
-export function setDeadline(ctx: ContDraftContext, days: number): void {
-  const { draftTile, log } = ctx;
+export function setDeadline(ctx: ActionStepExecuteContext<unknown>, anchor: Element, days: number) {
+  const assert: AssertFn = ctx.assert;
+  const { log } = ctx;
 
-  if (days <= 0) {
-    return;
-  }
+  assert(
+    Number.isInteger(days) && days >= minContractDays && days <= maxContractDays,
+    `Deadline must be from ${minContractDays} to ${maxContractDays} days`,
+  );
 
-  const deadlineInput = draftTile.anchor.querySelector(
-    'input[name="deadline"]',
-  ) as HTMLInputElement | null;
-  if (deadlineInput) {
-    focusElement(deadlineInput);
-    deadlineInput.select();
-    changeInputValue(deadlineInput, String(days));
-    log.info(`Deadline set: ${days} days`);
-  }
+  const deadlineInput = anchor.querySelector<HTMLInputElement>('input[name="deadline"]');
+  assert(deadlineInput, 'Could not find deadline input');
+  selectAndChangeInputValue(deadlineInput, String(days));
+  log.info(`Deadline set: ${fixed0(days)} days`);
 }
 
 /**
- * Waits for "Apply Template" button, clicks it, and waits for the
- * disabled→enabled round-trip confirming the server processed it.
+ * Clicks "Apply Template" and waits for the server to rewrite the draft's
+ * conditions. The button's disabled class flickers on any re-render, so it is
+ * not evidence that the template was accepted.
  */
-export async function applyTemplate(ctx: ContDraftContext): Promise<boolean> {
-  const { draftTile, log, setStatus, fail } = ctx;
+export async function applyTemplate(
+  ctx: ActionStepExecuteContext<unknown>,
+  anchor: Element,
+  draftId: string,
+) {
+  const assert: AssertFn = ctx.assert;
+  const { log, setStatus } = ctx;
 
   setStatus('Applying template...');
 
-  const applyBtnReady = await waitFor(
-    () =>
-      _$$(draftTile.anchor, 'button').some(
-        btn => btn.textContent?.trim().toLowerCase() === 'apply template',
-      ),
-    5000,
-  );
-  if (!applyBtnReady) {
-    fail('Could not find "Apply Template" button');
-    return false;
-  }
-  const applyBtn = _$$(draftTile.anchor, 'button').find(
-    btn => btn.textContent?.trim().toLowerCase() === 'apply template',
-  )!;
+  const applyBtn = await pollUntil(() => findButton(anchor, 'apply template'), 5000);
+  assert(applyBtn, 'Could not find "Apply Template" button');
+  assert(!applyBtn.classList.contains(C.Button.disabled), 'Template form is invalid');
 
+  const before = contractDraftsStore.getByNaturalId(draftId);
   await clickElement(applyBtn);
-  await waitFor(() => applyBtn.classList.contains(C.Button.disabled), 3000);
-  await waitFor(() => !applyBtn.classList.contains(C.Button.disabled), 5000);
+
+  const applied = await pollUntil(() => {
+    const draft = contractDraftsStore.getByNaturalId(draftId);
+    return draft !== undefined && draft !== before && draft.conditions.length > 0;
+  }, 8000);
+  assert(applied, 'Template conditions were not received');
   log.info('Template applied');
-  return true;
 }
 
 /**
- * Pauses for user review, then clicks the last "save" button (conditions save).
+ * Clicks the conditions save button and waits for the draft to come back valid.
  */
 export async function saveConditions(
-  ctx: ContDraftContext,
-  waitAct: (status?: string) => Promise<void>,
-): Promise<void> {
-  const { draftTile, log, setStatus } = ctx;
+  ctx: ActionStepExecuteContext<unknown>,
+  anchor: Element,
+  draftId: string,
+) {
+  const assert: AssertFn = ctx.assert;
+  const { log, setStatus } = ctx;
 
-  await waitAct('Save conditions?');
   setStatus('Saving conditions...');
 
-  const condSaveBtn = _$$(draftTile.anchor, C.Button.btn).findLast(
-    (btn: HTMLElement) => btn.textContent?.trim().toLowerCase() === 'save',
-  ) as HTMLElement | undefined;
-  if (condSaveBtn && !condSaveBtn.classList.contains(C.Button.disabled)) {
-    await clickElement(condSaveBtn);
-    log.info('Conditions saved');
-  } else {
-    log.warning('Conditions save button not found or disabled');
-  }
+  const before = contractDraftsStore.getByNaturalId(draftId);
+  const condSaveBtn = _$$(anchor, C.Button.btn).findLast(hasText('save'));
+  assert(
+    condSaveBtn !== undefined && !condSaveBtn.classList.contains(C.Button.disabled),
+    'Conditions save button is missing or disabled',
+  );
+  await clickElement(condSaveBtn);
+
+  const saved = await pollUntil(() => {
+    const draft = contractDraftsStore.getByNaturalId(draftId);
+    return (
+      draft !== undefined &&
+      draft !== before &&
+      draft.status === 'VALID' &&
+      draft.conditions.length > 0
+    );
+  }, 8000);
+  assert(saved, 'Contract conditions were not saved');
+  log.info('Conditions saved');
 }

--- a/src/features/XIT/ACT/actions/cont-limits.ts
+++ b/src/features/XIT/ACT/actions/cont-limits.ts
@@ -1,0 +1,19 @@
+// Field limits shared by the CONT actions and their steps.
+// The contract template's price-per-unit field. Bounds match the game's own
+// order limits; a trade contract with a missing or zero price would be sent as
+// a giveaway, so every traded material has to carry one.
+export const minContractPrice = 0.01;
+export const maxContractPrice = 100000000;
+
+// The deadline field's range, in days.
+export const minContractDays = 1;
+export const maxContractDays = 99;
+
+export function isValidContractPrice(price: number | undefined): price is number {
+  return (
+    price !== undefined &&
+    Number.isFinite(price) &&
+    price >= minContractPrice &&
+    price <= maxContractPrice
+  );
+}

--- a/src/features/XIT/ACT/actions/cont-locations.ts
+++ b/src/features/XIT/ACT/actions/cont-locations.ts
@@ -1,0 +1,65 @@
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { comparePlanets } from '@src/util';
+import { configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
+
+/**
+ * Every location the player holds stock at — the contract endpoints they can
+ * ship from or trade at. Shared by both CONT actions and their configure forms.
+ */
+export function useContLocations() {
+  return computed(() => {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const store of storagesStore.nonFuelStores.value ?? []) {
+      let address: PrunApi.Address | undefined;
+      if (store.type === 'STORE') {
+        address = sitesStore.getById(store.addressableId)?.address;
+      } else if (store.type === 'WAREHOUSE_STORE') {
+        address = warehousesStore.getById(store.addressableId)?.address;
+      } else {
+        continue;
+      }
+      const name = getEntityNameFromAddress(address);
+      if (name !== undefined && !seen.has(name)) {
+        seen.add(name);
+        result.push(name);
+      }
+    }
+    return result.sort(comparePlanets);
+  });
+}
+
+/**
+ * Resolves a stored location value to a planet name: a literal name passes
+ * through, `configurableValue` reads the run's configure dialog, and a
+ * `group:` reference follows the named material group's target planet.
+ */
+export function resolveLocation(
+  value: string | undefined,
+  configValue: string | undefined,
+  getMaterialGroupPlanet: (name: string) => string | undefined,
+) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === configurableValue) {
+    return configValue;
+  }
+  if (value.startsWith(groupTargetPrefix)) {
+    return getMaterialGroupPlanet(value.slice(groupTargetPrefix.length));
+  }
+  return value;
+}
+
+export function displayLocationValue(value: string | undefined) {
+  if (value === undefined || value.length === 0) {
+    return '--';
+  }
+  if (value.startsWith(groupTargetPrefix)) {
+    return `[${value.slice(groupTargetPrefix.length)}] target`;
+  }
+  return value;
+}

--- a/src/features/XIT/ACT/actions/cont-ship/Configure.vue
+++ b/src/features/XIT/ACT/actions/cont-ship/Configure.vue
@@ -7,32 +7,16 @@ import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
-import { comparePlanets } from '@src/util';
-import { configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import {
+  useContLocations,
+  displayLocationValue,
+} from '@src/features/XIT/ACT/actions/cont-locations';
 import { serializeStorage } from '@src/features/XIT/ACT/actions/utils';
 
 const { data, config } = defineProps<{ data: UserData.ActionData; config: Config }>();
 
-const locations = computed(() => {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const store of storagesStore.nonFuelStores.value ?? []) {
-    let address: PrunApi.Address | undefined;
-    if (store.type === 'STORE') {
-      address = sitesStore.getById(store.addressableId)?.address;
-    } else if (store.type === 'WAREHOUSE_STORE') {
-      address = warehousesStore.getById(store.addressableId)?.address;
-    } else {
-      continue;
-    }
-    const name = getEntityNameFromAddress(address);
-    if (name && !seen.has(name)) {
-      seen.add(name);
-      result.push(name);
-    }
-  }
-  return result.sort(comparePlanets);
-});
+const locations = useContLocations();
 
 if (data.contOrigin === configurableValue && !config.origin && locations.value.length > 0) {
   config.origin = locations.value[0];
@@ -107,16 +91,6 @@ watchEffect(() => {
     }
   }
 });
-
-function displayValue(value: string | undefined) {
-  if (!value) {
-    return '--';
-  }
-  if (value.startsWith(groupTargetPrefix)) {
-    return `[${value.slice(groupTargetPrefix.length)}] target`;
-  }
-  return value;
-}
 </script>
 
 <template>
@@ -125,13 +99,13 @@ function displayValue(value: string | undefined) {
       <SelectInput v-model="config.origin" :options="locations" />
     </Active>
     <Passive v-else label="From">
-      <span>{{ displayValue(data.contOrigin) }}</span>
+      <span>{{ displayLocationValue(data.contOrigin) }}</span>
     </Passive>
     <Active v-if="data.contDest === configurableValue" label="To">
       <SelectInput v-model="config.destination" :options="locations" />
     </Active>
     <Passive v-else label="To">
-      <span>{{ displayValue(data.contDest) }}</span>
+      <span>{{ displayLocationValue(data.contDest) }}</span>
     </Passive>
     <Active v-if="data.autoProvision" label="Auto-provision">
       <SelectInput v-model="config.autoProvisionStoreId" :options="storeOptions" />

--- a/src/features/XIT/ACT/actions/cont-ship/Edit.vue
+++ b/src/features/XIT/ACT/actions/cont-ship/Edit.vue
@@ -3,12 +3,10 @@ import Active from '@src/components/forms/Active.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import NumericInput from '@src/components/forms/NumericInput.vue';
 import RadioItem from '@src/components/forms/RadioItem.vue';
-import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
-import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
-import { comparePlanets } from '@src/util';
 import { configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
+import { useContLocations } from '@src/features/XIT/ACT/actions/cont-locations';
+import { balancesStore } from '@src/infrastructure/prun-api/data/balances';
+import { maxContractDays, minContractDays } from '@src/features/XIT/ACT/actions/cont-limits';
 
 const { action, pkg } = defineProps<{
   action: UserData.ActionData;
@@ -18,30 +16,12 @@ const { action, pkg } = defineProps<{
 const materialGroups = computed(() => pkg.groups.map(x => x.name!).filter(x => x));
 const materialGroup = ref(action.group ?? materialGroups.value[0]);
 
-const staticLocations = computed(() => {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const store of storagesStore.nonFuelStores.value ?? []) {
-    let address: PrunApi.Address | undefined;
-    if (store.type === 'STORE') {
-      address = sitesStore.getById(store.addressableId)?.address;
-    } else if (store.type === 'WAREHOUSE_STORE') {
-      address = warehousesStore.getById(store.addressableId)?.address;
-    } else {
-      continue;
-    }
-    const name = getEntityNameFromAddress(address);
-    if (name && !seen.has(name)) {
-      seen.add(name);
-      result.push(name);
-    }
-  }
-  return result.sort(comparePlanets);
-});
+const staticLocations = useContLocations();
 
+// A group with no planet resolves to nothing at run time, so it is not offered.
 const groupTargetOptions = computed(() =>
   pkg.groups
-    .filter(x => x.name)
+    .filter(x => x.name && x.planet)
     .map(x => ({
       label: `[${x.name}] target`,
       value: `${groupTargetPrefix}${x.name}`,
@@ -54,11 +34,12 @@ const locationOptions = computed(() => [
   ...staticLocations.value,
 ]);
 
-const currencies = ['NCC', 'CIS', 'AIC', 'ICA'];
+// The currencies the player actually holds a balance in.
+const currencies = computed(() => balancesStore.currencies.value ?? []);
 
 const contOrigin = ref(action.contOrigin ?? staticLocations.value[0] ?? '');
 const contDest = ref(action.contDest ?? staticLocations.value[0] ?? '');
-const currency = ref(action.currency ?? 'NCC');
+const currency = ref(action.currency ?? currencies.value[0] ?? 'NCC');
 const paymentPerTon = ref(action.paymentPerTon ?? 0);
 const daysToFulfill = ref(action.daysToFulfill ?? 3);
 const autoProvision = ref(action.autoProvision ?? false);
@@ -67,10 +48,17 @@ function validate() {
   if (!materialGroup.value) {
     return false;
   }
-  if (daysToFulfill.value < 1) {
+  // A location saved before the player sold that base is no longer selectable.
+  const locations = locationOptions.value.map(x => (typeof x === 'string' ? x : x.value));
+  if (!locations.includes(contOrigin.value) || !locations.includes(contDest.value)) {
     return false;
   }
-  if (paymentPerTon.value < 0) {
+  const days = Number(daysToFulfill.value);
+  if (!Number.isInteger(days) || days < minContractDays || days > maxContractDays) {
+    return false;
+  }
+  const payment = Number(paymentPerTon.value);
+  if (String(paymentPerTon.value).trim() === '' || !Number.isFinite(payment) || payment < 0) {
     return false;
   }
   return true;
@@ -81,8 +69,8 @@ function save() {
   action.contOrigin = contOrigin.value;
   action.contDest = contDest.value;
   action.currency = currency.value;
-  action.paymentPerTon = paymentPerTon.value;
-  action.daysToFulfill = daysToFulfill.value;
+  action.paymentPerTon = Number(paymentPerTon.value);
+  action.daysToFulfill = Number(daysToFulfill.value);
   action.autoProvision = autoProvision.value;
   delete action.contractNote;
 }
@@ -112,7 +100,7 @@ defineExpose({ validate, save });
   </Active>
 
   <Active label="Days to Fulfill">
-    <NumericInput v-model="daysToFulfill" :min="1" :max="30" :step="1" />
+    <NumericInput v-model="daysToFulfill" :min="minContractDays" :max="maxContractDays" :step="1" />
   </Active>
 
   <Active label="Auto-provision">

--- a/src/features/XIT/ACT/actions/cont-ship/cont-ship.ts
+++ b/src/features/XIT/ACT/actions/cont-ship/cont-ship.ts
@@ -3,34 +3,12 @@ import Edit from '@src/features/XIT/ACT/actions/cont-ship/Edit.vue';
 import Configure from '@src/features/XIT/ACT/actions/cont-ship/Configure.vue';
 import { CONT_SEND } from '@src/features/XIT/ACT/action-steps/CONT_SEND';
 import { Config } from '@src/features/XIT/ACT/actions/cont-ship/config';
-import { AssertFn, configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
+import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
-
-function resolveLocation(
-  value: string | undefined,
-  config: Config | undefined,
-  field: 'origin' | 'destination',
-  getMaterialGroupPlanet: (name: string | undefined) => string | undefined,
-): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  if (value === configurableValue) {
-    return config?.[field];
-  }
-  if (value.startsWith(groupTargetPrefix)) {
-    const groupName = value.slice(groupTargetPrefix.length);
-    return getMaterialGroupPlanet(groupName);
-  }
-  return value;
-}
-
-function displayLocation(value: string) {
-  if (value.startsWith(groupTargetPrefix)) {
-    return `[${value.slice(groupTargetPrefix.length)}] target`;
-  }
-  return value;
-}
+import {
+  displayLocationValue,
+  resolveLocation,
+} from '@src/features/XIT/ACT/actions/cont-locations';
 
 act.addAction<Config>({
   type: 'CONT Ship',
@@ -43,11 +21,11 @@ act.addAction<Config>({
     const origin =
       action.contOrigin === configurableValue
         ? (config?.origin ?? 'configured location')
-        : displayLocation(action.contOrigin);
+        : displayLocationValue(action.contOrigin);
     const dest =
       action.contDest === configurableValue
         ? (config?.destination ?? 'configured location')
-        : displayLocation(action.contDest);
+        : displayLocationValue(action.contDest);
 
     const payment = action.paymentPerTon ?? 0;
     const paymentStr = payment > 0 ? ` @ ${payment}/t` : '';
@@ -56,7 +34,11 @@ act.addAction<Config>({
   },
   editComponent: Edit,
   configureComponent: Configure,
-  needsConfigure: () => true,
+  // Only ask for a configure dialog when something in it is actually settable.
+  needsConfigure: data =>
+    data.contOrigin === configurableValue ||
+    data.contDest === configurableValue ||
+    data.autoProvision === true,
   isValidConfig: (data, config) => {
     return (
       (data.contOrigin !== configurableValue || config.origin !== undefined) &&
@@ -71,10 +53,10 @@ act.addAction<Config>({
     const materials = await getMaterialGroup(data.group);
     assert(materials, 'Invalid material group');
 
-    const contOrigin = resolveLocation(data.contOrigin, config, 'origin', getMaterialGroupPlanet);
+    const contOrigin = resolveLocation(data.contOrigin, config?.origin, getMaterialGroupPlanet);
     assert(contOrigin, 'Invalid origin');
 
-    const contDest = resolveLocation(data.contDest, config, 'destination', getMaterialGroupPlanet);
+    const contDest = resolveLocation(data.contDest, config?.destination, getMaterialGroupPlanet);
     assert(contDest, 'Invalid destination');
 
     const paymentPerTon = Number(data.paymentPerTon ?? 0);

--- a/src/features/XIT/ACT/actions/cont-trade/Configure.vue
+++ b/src/features/XIT/ACT/actions/cont-trade/Configure.vue
@@ -3,35 +3,15 @@ import Active from '@src/components/forms/Active.vue';
 import Passive from '@src/components/forms/Passive.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import { Config } from '@src/features/XIT/ACT/actions/cont-trade/config';
-import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
-import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
-import { comparePlanets } from '@src/util';
-import { configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import {
+  useContLocations,
+  displayLocationValue,
+} from '@src/features/XIT/ACT/actions/cont-locations';
 
 const { data, config } = defineProps<{ data: UserData.ActionData; config: Config }>();
 
-const locations = computed(() => {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const store of storagesStore.nonFuelStores.value ?? []) {
-    let address: PrunApi.Address | undefined;
-    if (store.type === 'STORE') {
-      address = sitesStore.getById(store.addressableId)?.address;
-    } else if (store.type === 'WAREHOUSE_STORE') {
-      address = warehousesStore.getById(store.addressableId)?.address;
-    } else {
-      continue;
-    }
-    const name = getEntityNameFromAddress(address);
-    if (name && !seen.has(name)) {
-      seen.add(name);
-      result.push(name);
-    }
-  }
-  return result.sort(comparePlanets);
-});
+const locations = useContLocations();
 
 if (data.contLocation === configurableValue && !config.location && locations.value.length > 0) {
   config.location = locations.value[0];
@@ -47,16 +27,6 @@ watchEffect(() => {
     }
   }
 });
-
-function displayValue(value: string | undefined) {
-  if (!value) {
-    return '--';
-  }
-  if (value.startsWith(groupTargetPrefix)) {
-    return `[${value.slice(groupTargetPrefix.length)}] target`;
-  }
-  return value;
-}
 </script>
 
 <template>
@@ -65,7 +35,7 @@ function displayValue(value: string | undefined) {
       <SelectInput v-model="config.location" :options="locations" />
     </Active>
     <Passive v-else label="Location">
-      <span>{{ displayValue(data.contLocation) }}</span>
+      <span>{{ displayLocationValue(data.contLocation) }}</span>
     </Passive>
   </form>
 </template>

--- a/src/features/XIT/ACT/actions/cont-trade/Edit.vue
+++ b/src/features/XIT/ACT/actions/cont-trade/Edit.vue
@@ -2,12 +2,10 @@
 import Active from '@src/components/forms/Active.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import NumericInput from '@src/components/forms/NumericInput.vue';
-import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
-import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
-import { comparePlanets } from '@src/util';
 import { configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
+import { useContLocations } from '@src/features/XIT/ACT/actions/cont-locations';
+import { balancesStore } from '@src/infrastructure/prun-api/data/balances';
+import { maxContractDays, minContractDays } from '@src/features/XIT/ACT/actions/cont-limits';
 
 const { action, pkg } = defineProps<{
   action: UserData.ActionData;
@@ -29,30 +27,12 @@ const valueToTradeType: Record<string, string> = {
 
 const tradeType = ref(valueToTradeType[action.contTradeType ?? 'BUYING'] ?? 'Buy');
 
-const staticLocations = computed(() => {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const store of storagesStore.nonFuelStores.value ?? []) {
-    let address: PrunApi.Address | undefined;
-    if (store.type === 'STORE') {
-      address = sitesStore.getById(store.addressableId)?.address;
-    } else if (store.type === 'WAREHOUSE_STORE') {
-      address = warehousesStore.getById(store.addressableId)?.address;
-    } else {
-      continue;
-    }
-    const name = getEntityNameFromAddress(address);
-    if (name && !seen.has(name)) {
-      seen.add(name);
-      result.push(name);
-    }
-  }
-  return result.sort(comparePlanets);
-});
+const staticLocations = useContLocations();
 
+// A group with no planet resolves to nothing at run time, so it is not offered.
 const groupTargetOptions = computed(() =>
   pkg.groups
-    .filter(x => x.name)
+    .filter(x => x.name && x.planet)
     .map(x => ({
       label: `[${x.name}] target`,
       value: `${groupTargetPrefix}${x.name}`,
@@ -65,17 +45,24 @@ const locationOptions = computed(() => [
   ...staticLocations.value,
 ]);
 
-const currencies = ['NCC', 'CIS', 'AIC', 'ICA'];
+// The currencies the player actually holds a balance in.
+const currencies = computed(() => balancesStore.currencies.value ?? []);
 
 const contLocation = ref(action.contLocation ?? staticLocations.value[0] ?? '');
-const currency = ref(action.currency ?? 'NCC');
+const currency = ref(action.currency ?? currencies.value[0] ?? 'NCC');
 const daysToFulfill = ref(action.daysToFulfill ?? 3);
 
 function validate() {
   if (!materialGroup.value) {
     return false;
   }
-  if (daysToFulfill.value < 1) {
+  // A location saved before the player sold that base is no longer selectable.
+  const locations = locationOptions.value.map(x => (typeof x === 'string' ? x : x.value));
+  if (!locations.includes(contLocation.value)) {
+    return false;
+  }
+  const days = Number(daysToFulfill.value);
+  if (!Number.isInteger(days) || days < minContractDays || days > maxContractDays) {
     return false;
   }
   return true;
@@ -86,7 +73,7 @@ function save() {
   action.contTradeType = tradeTypeToValue[tradeType.value];
   action.contLocation = contLocation.value;
   action.currency = currency.value;
-  action.daysToFulfill = daysToFulfill.value;
+  action.daysToFulfill = Number(daysToFulfill.value);
 }
 
 defineExpose({ validate, save });
@@ -110,6 +97,6 @@ defineExpose({ validate, save });
   </Active>
 
   <Active label="Days to Fulfill">
-    <NumericInput v-model="daysToFulfill" :min="1" :max="30" :step="1" />
+    <NumericInput v-model="daysToFulfill" :min="minContractDays" :max="maxContractDays" :step="1" />
   </Active>
 </template>

--- a/src/features/XIT/ACT/actions/cont-trade/cont-trade.ts
+++ b/src/features/XIT/ACT/actions/cont-trade/cont-trade.ts
@@ -3,32 +3,16 @@ import Edit from '@src/features/XIT/ACT/actions/cont-trade/Edit.vue';
 import Configure from '@src/features/XIT/ACT/actions/cont-trade/Configure.vue';
 import { CONT_TRADE } from '@src/features/XIT/ACT/action-steps/CONT_TRADE';
 import { Config } from '@src/features/XIT/ACT/actions/cont-trade/config';
-import { AssertFn, configurableValue, groupTargetPrefix } from '@src/features/XIT/ACT/shared-types';
-
-function resolveLocation(
-  value: string | undefined,
-  config: Config | undefined,
-  getMaterialGroupPlanet: (name: string | undefined) => string | undefined,
-): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  if (value === configurableValue) {
-    return config?.location;
-  }
-  if (value.startsWith(groupTargetPrefix)) {
-    const groupName = value.slice(groupTargetPrefix.length);
-    return getMaterialGroupPlanet(groupName);
-  }
-  return value;
-}
-
-function displayLocation(value: string) {
-  if (value.startsWith(groupTargetPrefix)) {
-    return `[${value.slice(groupTargetPrefix.length)}] target`;
-  }
-  return value;
-}
+import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
+import {
+  displayLocationValue,
+  resolveLocation,
+} from '@src/features/XIT/ACT/actions/cont-locations';
+import {
+  isValidContractPrice,
+  maxContractPrice,
+  minContractPrice,
+} from '@src/features/XIT/ACT/actions/cont-limits';
 
 act.addAction<Config>({
   type: 'CONT Trade',
@@ -42,7 +26,7 @@ act.addAction<Config>({
     const location =
       action.contLocation === configurableValue
         ? (config?.location ?? 'configured location')
-        : displayLocation(action.contLocation);
+        : displayLocationValue(action.contLocation);
 
     return `${tradeLabel} contract for [${action.group}] at ${location}`;
   },
@@ -69,13 +53,19 @@ act.addAction<Config>({
     const materials = await getMaterialGroup(data.group);
     assert(materials, 'Invalid material group');
 
-    const prices = getMaterialGroupPrices(data.group);
+    const traded = Object.keys(materials).filter(x => materials[x] > 0);
+    assert(traded.length > 0, 'Material group has no materials to trade');
+
+    // Every traded material needs its own price: a blank one on the template
+    // would go out as a free trade. Checked here so the package fails before
+    // the run touches a draft.
+    const prices = getMaterialGroupPrices(data.group) ?? {};
     assert(
-      prices,
-      `Material group [${data.group}] has no prices. Use a Paste group with 3 columns (ticker, amount, price).`,
+      traded.every(x => isValidContractPrice(prices[x])),
+      `Each material in [${data.group}] needs a price from ${minContractPrice} to ${maxContractPrice}. Use a Paste group with 3 columns (ticker, amount, price).`,
     );
 
-    const location = resolveLocation(data.contLocation, config, getMaterialGroupPlanet);
+    const location = resolveLocation(data.contLocation, config?.location, getMaterialGroupPlanet);
     assert(location, 'Invalid location');
 
     const tradeType = data.contTradeType ?? 'BUYING';

--- a/src/features/XIT/ACT/material-groups/paste/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/paste/Configure.vue
@@ -1,17 +1,37 @@
 <script setup lang="ts">
 import Active from '@src/components/forms/Active.vue';
 import { Config } from '@src/features/XIT/ACT/material-groups/paste/config';
-import { parseMaterials } from '@src/features/XIT/ACT/material-groups/paste/paste';
+import { resolveTicker } from '@src/features/XIT/ACT/material-groups/paste/paste';
+import { parsePaste } from '@src/features/XIT/ACT/material-groups/paste/paste-parse';
 
 const { config } = defineProps<{ data: UserData.MaterialGroupData; config: Config }>();
 
-const text = ref(config.materials ?? '');
-const hasError = ref(false);
+const result = computed(() => parsePaste(config.materials, resolveTicker));
+const rowCount = computed(() => result.value.rows.length);
+const hasError = computed(
+  () => result.value.fatal !== undefined || result.value.errors.length > 0 || rowCount.value === 0,
+);
 
-watch(text, value => {
-  config.materials = value;
-  const parsed = parseMaterials(value);
-  hasError.value = parsed === undefined;
+// "N of M rows" counts only rows the player actually typed.
+const filledRowCount = computed(
+  () => (config.materials ?? '').split(/\r\n|\r|\n/).filter(x => x.trim().length > 0).length,
+);
+
+const summary = computed(() => {
+  if ((config.materials ?? '').trim().length === 0) {
+    return undefined;
+  }
+  if (result.value.fatal !== undefined) {
+    return result.value.fatal;
+  }
+  const errorCount = result.value.errors.length;
+  if (errorCount > 0) {
+    return `${errorCount} of ${filledRowCount.value} rows have errors`;
+  }
+  if (rowCount.value === 0) {
+    return 'No materials parsed';
+  }
+  return `${rowCount.value} material${rowCount.value === 1 ? '' : 's'} ready`;
 });
 </script>
 
@@ -19,11 +39,20 @@ watch(text, value => {
   <form>
     <Active label="Materials" :error="hasError">
       <textarea
-        v-model="text"
+        v-model="config.materials"
         :class="$style.textarea"
-        :placeholder="`Paste from spreadsheet or type manually\nTICKER  AMOUNT  PRICE\nRAT     100     50.25\n\nPrice column is optional.\nSupports tab or comma separated values.`"
+        :placeholder="`Paste from spreadsheet or type manually\nTICKER  AMOUNT  PRICE\nRAT     100     530\n\nPrice column is optional; at most 3 significant figures.\nOne delimiter per paste: tab, comma or semicolon.`"
         spellcheck="false" />
     </Active>
+    <div v-if="summary" :class="[$style.summary, hasError ? $style.bad : $style.good]">
+      {{ summary }}
+    </div>
+    <ul v-if="result.fatal === undefined && result.errors.length > 0" :class="$style.errors">
+      <li v-for="error in result.errors" :key="error.line">
+        <span :class="$style.line">Row {{ error.line }}</span>
+        {{ error.reason }}
+      </li>
+    </ul>
   </form>
 </template>
 
@@ -41,5 +70,40 @@ watch(text, value => {
 
 .textarea:focus {
   outline: none;
+}
+
+.summary {
+  margin-top: 4px;
+  font-size: 11px;
+}
+
+.good {
+  color: var(--rp-color-green);
+}
+
+.bad {
+  color: var(--rp-color-red);
+}
+
+/* Cap the height so a paste with many bad rows scrolls instead of growing the
+   dialog past the window. */
+.errors {
+  max-height: 160px;
+  overflow-y: auto;
+  margin: 4px 0 0;
+  padding-left: 0;
+  list-style: none;
+  font-size: 11px;
+  color: var(--rp-color-red);
+}
+
+.errors li {
+  padding: 1px 0;
+}
+
+.line {
+  display: inline-block;
+  min-width: 52px;
+  font-weight: bold;
 }
 </style>

--- a/src/features/XIT/ACT/material-groups/paste/paste-parse.test.ts
+++ b/src/features/XIT/ACT/material-groups/paste/paste-parse.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { parseMaterials, parsePaste } from './paste-parse';
+
+const known = ['RAT', 'DW', 'OVE', 'FEO'];
+const resolveTicker = (ticker: string) => known.find(x => x === ticker.toUpperCase());
+
+describe('parsePaste', () => {
+  it('reads a tab-separated paste with prices', () => {
+    const result = parsePaste('RAT\t100\t530\nDW\t50\t62.5', resolveTicker);
+    expect(result.errors).toEqual([]);
+    expect(result.delimiter).toBe('\t');
+    expect(result.rows).toEqual([
+      { ticker: 'RAT', amount: 100, price: 530 },
+      { ticker: 'DW', amount: 50, price: 62.5 },
+    ]);
+  });
+
+  it('accepts rows with and without a price in either order', () => {
+    const pricedFirst = parsePaste('DW,50,62.5\nRAT,100', resolveTicker);
+    expect(pricedFirst.errors).toEqual([]);
+    expect(pricedFirst.rows).toEqual([
+      { ticker: 'DW', amount: 50, price: 62.5 },
+      { ticker: 'RAT', amount: 100 },
+    ]);
+
+    const unpricedFirst = parsePaste('RAT,100\nDW,50,62.5', resolveTicker);
+    expect(unpricedFirst.errors).toEqual([]);
+    expect(unpricedFirst.rows).toEqual([
+      { ticker: 'RAT', amount: 100 },
+      { ticker: 'DW', amount: 50, price: 62.5 },
+    ]);
+  });
+
+  it('reports the failing row instead of discarding the paste', () => {
+    const result = parsePaste('RAT,100\nXYZ,50\nDW,25', resolveTicker);
+    expect(result.rows).toEqual([
+      { ticker: 'RAT', amount: 100 },
+      { ticker: 'DW', amount: 25 },
+    ]);
+    expect(result.errors).toEqual([{ line: 2, reason: 'unknown ticker "XYZ"' }]);
+  });
+
+  it('numbers rows by their position in the paste, blank rows included', () => {
+    const result = parsePaste('RAT,100\n\n\nXYZ,50', resolveTicker);
+    expect(result.errors.map(x => x.line)).toEqual([4]);
+  });
+
+  it('reads a quoted thousands separator inside a tab-separated paste', () => {
+    const result = parsePaste('RAT\t"1,600"\t530', resolveTicker);
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toEqual([{ ticker: 'RAT', amount: 1600, price: 530 }]);
+  });
+
+  it('reads semicolon-separated rows with comma decimals', () => {
+    const result = parsePaste('RAT;100;62,5', resolveTicker);
+    expect(result.errors).toEqual([]);
+    expect(result.delimiter).toBe(';');
+    expect(result.rows).toEqual([{ ticker: 'RAT', amount: 100, price: 62.5 }]);
+  });
+
+  it('reads a paste that uses bare carriage returns', () => {
+    const result = parsePaste('RAT,100\rDW,50', resolveTicker);
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(2);
+  });
+
+  it('rejects a price with more than three significant figures', () => {
+    const result = parsePaste('RAT,100,45.67', resolveTicker);
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        line: 1,
+        reason: 'price "45.67" has more than 3 significant figures (use 45.7)',
+      },
+    ]);
+  });
+
+  it('accepts prices whose extra digits are non-significant zeros', () => {
+    const result = parsePaste('RAT,100,530\nDW,50,123000000', resolveTicker);
+    expect(result.errors).toEqual([]);
+    expect(result.rows.map(x => x.price)).toEqual([530, 123000000]);
+  });
+
+  it('reads a grouped quantity but refuses a grouped price', () => {
+    // "1,600" is 1600 as a quantity — 1.6 is not a whole number — but as a
+    // price both readings are legal and the player has to disambiguate.
+    const quantity = parsePaste('RAT\t1,600', resolveTicker);
+    expect(quantity.errors).toEqual([]);
+    expect(quantity.rows).toEqual([{ ticker: 'RAT', amount: 1600 }]);
+
+    const price = parsePaste('RAT\t100\t1,600', resolveTicker);
+    expect(price.errors).toEqual([
+      { line: 1, reason: 'price "1,600" has ambiguous separators; write it without grouping' },
+    ]);
+  });
+
+  it('rejects a price with more than two decimal places', () => {
+    const result = parsePaste('RAT,100,0.125', resolveTicker);
+    expect(result.errors).toEqual([
+      { line: 1, reason: 'price "0.125" has more than two decimal places' },
+    ]);
+  });
+
+  it('rejects a fractional quantity', () => {
+    const result = parsePaste('RAT,10.5', resolveTicker);
+    expect(result.errors).toEqual([{ line: 1, reason: 'quantity "10.5" is not a whole number' }]);
+  });
+
+  it('rejects two different prices for one ticker but allows a repeated one', () => {
+    const conflicting = parsePaste('RAT,100,530\nRAT,50,540', resolveTicker);
+    expect(conflicting.rows).toHaveLength(1);
+    expect(conflicting.errors).toEqual([
+      { line: 2, reason: 'conflicting price for RAT; line 1 used 530' },
+    ]);
+
+    const repeated = parsePaste('RAT,100,530\nRAT,50,530', resolveTicker);
+    expect(repeated.errors).toEqual([]);
+    expect(repeated.rows).toHaveLength(2);
+  });
+
+  it('fails the whole paste when rows use different delimiters', () => {
+    const result = parsePaste('RAT,100\nDW;50', resolveTicker);
+    expect(result.fatal).toBe(
+      'Paste mixes comma-separated and semicolon-separated rows. Use one delimiter throughout.',
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects a row that is not two or three fields', () => {
+    const result = parsePaste('RAT\nDW,50,530,999', resolveTicker);
+    expect(result.errors).toEqual([
+      { line: 1, reason: 'expected TICKER, QUANTITY[, PRICE] (got 1 fields)' },
+      { line: 2, reason: 'expected TICKER, QUANTITY[, PRICE] (got 4 fields)' },
+    ]);
+  });
+});
+
+describe('parseMaterials', () => {
+  it('sums repeated tickers and keeps their price', () => {
+    const result = parseMaterials('RAT,100,530\nRAT,50,530\nDW,25', resolveTicker);
+    expect(result).toEqual({
+      materials: { RAT: 150, DW: 25 },
+      prices: { RAT: 530 },
+    });
+  });
+
+  it('omits prices entirely when no row carries one', () => {
+    expect(parseMaterials('RAT,100', resolveTicker)).toEqual({
+      materials: { RAT: 100 },
+      prices: undefined,
+    });
+  });
+
+  it('returns undefined when any row failed, so a partial bill never runs', () => {
+    expect(parseMaterials('RAT,100\nXYZ,50', resolveTicker)).toBeUndefined();
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(parseMaterials('', resolveTicker)).toBeUndefined();
+    expect(parseMaterials(undefined, resolveTicker)).toBeUndefined();
+  });
+});

--- a/src/features/XIT/ACT/material-groups/paste/paste-parse.ts
+++ b/src/features/XIT/ACT/material-groups/paste/paste-parse.ts
@@ -1,0 +1,285 @@
+// Pure parser for the Paste material group. Kept free of store and component
+// imports so it can be unit tested; callers inject the ticker lookup.
+
+export type Delimiter = '\t' | ';' | ',';
+
+export const delimiterNames: Record<Delimiter, string> = {
+  '\t': 'tab-separated',
+  ';': 'semicolon-separated',
+  ',': 'comma-separated',
+};
+
+// CXPO rounds an order price to this many significant figures, so a limit with
+// more of them is not the limit the game would place.
+export const maxPriceSignificantFigures = 3;
+
+export interface ParsedRow {
+  ticker: string;
+  amount: number;
+  price?: number;
+}
+
+export interface ParseError {
+  line: number;
+  reason: string;
+}
+
+export interface ParseResult {
+  rows: ParsedRow[];
+  errors: ParseError[];
+  delimiter?: Delimiter;
+  // Set when the paste cannot be read at all. Suppresses per-line errors.
+  fatal?: string;
+}
+
+// Resolves a pasted ticker to its canonical form, or undefined if unknown.
+export type ResolveTicker = (ticker: string) => string | undefined;
+
+// The characters of a line that sit outside double-quoted spans. A spreadsheet
+// paste quotes any field holding the delimiter ("1,600"), and that comma must
+// not be mistaken for a separator.
+function unquoted(line: string) {
+  let result = '';
+  let inQuotes = false;
+  for (const char of line) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (!inQuotes) {
+      result += char;
+    }
+  }
+  return result;
+}
+
+// Tab beats semicolon beats comma: a comma-decimal row written with semicolons
+// ("RAT;100;45,67") holds both, and only the semicolon separates its fields.
+function detectDelimiter(line: string): Delimiter {
+  const outside = unquoted(line);
+  if (outside.includes('\t')) {
+    return '\t';
+  }
+  if (outside.includes(';')) {
+    return ';';
+  }
+  return ',';
+}
+
+function splitFields(line: string, delimiter: Delimiter) {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      // A doubled quote inside a quoted field is a literal quote.
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (char === delimiter && !inQuotes) {
+      fields.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  fields.push(current);
+  return fields.map(x => x.trim());
+}
+
+// Each decimal convention permits the other separator, but only in groups of
+// three digits — that is what makes "1.600" a thousand and "1.6" a fraction.
+const dotDecimalPattern = /^\+?(?:(?:\d+|[1-9]\d{0,2}(?:,\d{3})+)(?:\.\d+)?|\.\d+)$/;
+const commaDecimalPattern = /^\+?(?:(?:\d+|[1-9]\d{0,2}(?:\.\d{3})+)(?:,\d+)?|,\d+)$/;
+
+function normalizeDecimal(value: string) {
+  return value
+    .replace(/^\+/, '')
+    .replace(/^\./, '0.')
+    .replace(/^0+(?=\d)/, '')
+    .replace(/(\.\d*?)0+$/, '$1')
+    .replace(/\.$/, '');
+}
+
+interface ParsedNumber {
+  value: number;
+  normalized: string;
+}
+
+// Both readings of the raw text, deduplicated. A value with no separators
+// normalizes the same way under either convention and yields one candidate.
+function numberCandidates(raw: string) {
+  const candidates = new Set<string>();
+  if (dotDecimalPattern.test(raw)) {
+    candidates.add(normalizeDecimal(raw.replaceAll(',', '')));
+  }
+  if (commaDecimalPattern.test(raw)) {
+    candidates.add(normalizeDecimal(raw.replaceAll('.', '').replace(',', '.')));
+  }
+  return [...candidates];
+}
+
+function toParsedNumber(normalized: string, raw: string): ParsedNumber | { error: string } {
+  const value = Number(normalized);
+  if (!Number.isFinite(value) || value <= 0 || value > Number.MAX_SAFE_INTEGER) {
+    return { error: `"${raw}" is not a finite positive number` };
+  }
+  return { value, normalized };
+}
+
+function parseQuantity(raw: string): { amount: number } | { error: string } {
+  const candidates = numberCandidates(raw);
+  if (candidates.length === 0) {
+    return { error: `"${raw}" is not a supported number` };
+  }
+  // A quantity is always whole, which settles "1,600" — 1.6 is not a candidate
+  // reading of it, so a spreadsheet's grouping separator needs no ceremony.
+  const whole = candidates.filter(x => !x.includes('.'));
+  if (whole.length !== 1) {
+    return { error: `quantity "${raw}" is not a whole number` };
+  }
+  const parsed = toParsedNumber(whole[0], raw);
+  if ('error' in parsed) {
+    return parsed;
+  }
+  if (!Number.isSafeInteger(parsed.value)) {
+    return { error: `quantity "${raw}" is not a whole number` };
+  }
+  return { amount: parsed.value };
+}
+
+function parsePrice(raw: string): { price: number } | { error: string } {
+  const candidates = numberCandidates(raw);
+  if (candidates.length === 0) {
+    return { error: `"${raw}" is not a supported number` };
+  }
+  // A price can be fractional, so grouping cannot be told from a decimal here.
+  if (candidates.length > 1) {
+    return { error: `price "${raw}" has ambiguous separators; write it without grouping` };
+  }
+  const parsed = toParsedNumber(candidates[0], raw);
+  if ('error' in parsed) {
+    return parsed;
+  }
+  // CXPO_BUY writes the limit through fixed02. Do not accept one it would round.
+  if ((parsed.normalized.split('.')[1]?.length ?? 0) > 2) {
+    return { error: `price "${raw}" has more than two decimal places` };
+  }
+  const digits = parsed.normalized.replace('.', '').replace(/^0+/, '').replace(/0+$/, '');
+  if (digits.length > maxPriceSignificantFigures) {
+    const suggestion = Number(parsed.value.toPrecision(maxPriceSignificantFigures));
+    return {
+      error: `price "${raw}" has more than ${maxPriceSignificantFigures} significant figures (use ${suggestion})`,
+    };
+  }
+  return { price: parsed.value };
+}
+
+export function parsePaste(input: string | undefined, resolveTicker: ResolveTicker): ParseResult {
+  const result: ParseResult = { rows: [], errors: [] };
+  if (input === undefined || input.trim().length === 0) {
+    return result;
+  }
+
+  const prices = new Map<string, { price: number; line: number }>();
+
+  // Split on every line-ending combination — a paste can arrive with \r alone.
+  const lines = input.split(/\r\n|\r|\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i].trim();
+    if (raw.length === 0) {
+      continue;
+    }
+    const line = i + 1;
+
+    const delimiter = detectDelimiter(raw);
+    if (result.delimiter !== undefined && result.delimiter !== delimiter) {
+      result.fatal = `Paste mixes ${delimiterNames[result.delimiter]} and ${delimiterNames[delimiter]} rows. Use one delimiter throughout.`;
+      result.rows = [];
+      result.errors = [];
+      return result;
+    }
+    result.delimiter = delimiter;
+
+    const fields = splitFields(raw, delimiter);
+    if (fields.length < 2 || fields.length > 3) {
+      result.errors.push({
+        line,
+        reason: `expected TICKER, QUANTITY[, PRICE] (got ${fields.length} fields)`,
+      });
+      continue;
+    }
+
+    const [tickerRaw, quantityRaw, priceRaw] = fields;
+    const ticker = resolveTicker(tickerRaw);
+    if (ticker === undefined) {
+      result.errors.push({ line, reason: `unknown ticker "${tickerRaw}"` });
+      continue;
+    }
+    const quantity = parseQuantity(quantityRaw);
+    if ('error' in quantity) {
+      result.errors.push({ line, reason: quantity.error });
+      continue;
+    }
+
+    const row: ParsedRow = { ticker, amount: quantity.amount };
+    if (priceRaw !== undefined && priceRaw.length > 0) {
+      const price = parsePrice(priceRaw);
+      if ('error' in price) {
+        result.errors.push({ line, reason: price.error });
+        continue;
+      }
+      // One ticker cannot carry two limits: the second row would silently win.
+      const previous = prices.get(ticker);
+      if (previous !== undefined && previous.price !== price.price) {
+        result.errors.push({
+          line,
+          reason: `conflicting price for ${ticker}; line ${previous.line} used ${previous.price}`,
+        });
+        continue;
+      }
+      if (previous === undefined) {
+        prices.set(ticker, { price: price.price, line });
+      }
+      row.price = price.price;
+    }
+    result.rows.push(row);
+  }
+  return result;
+}
+
+export interface MaterialBill {
+  materials: Record<string, number>;
+  prices?: Record<string, number>;
+}
+
+// Collapses a clean parse into the group's material bill. Returns undefined
+// when anything failed to parse, so a partial paste never reaches the game.
+export function parseMaterials(
+  input: string | undefined,
+  resolveTicker: ResolveTicker,
+): MaterialBill | undefined {
+  const { rows, errors, fatal } = parsePaste(input, resolveTicker);
+  if (fatal !== undefined || errors.length > 0 || rows.length === 0) {
+    return undefined;
+  }
+  const materials: Record<string, number> = {};
+  let prices: Record<string, number> | undefined;
+  for (const row of rows) {
+    materials[row.ticker] = (materials[row.ticker] ?? 0) + row.amount;
+    if (!Number.isSafeInteger(materials[row.ticker])) {
+      return undefined;
+    }
+    if (row.price !== undefined) {
+      prices ??= {};
+      prices[row.ticker] = row.price;
+    }
+  }
+  return { materials, prices };
+}

--- a/src/features/XIT/ACT/material-groups/paste/paste.ts
+++ b/src/features/XIT/ACT/material-groups/paste/paste.ts
@@ -2,103 +2,13 @@ import { act } from '@src/features/XIT/ACT/act-registry';
 import Edit from '@src/features/XIT/ACT/material-groups/paste/Edit.vue';
 import Configure from '@src/features/XIT/ACT/material-groups/paste/Configure.vue';
 import { Config } from '@src/features/XIT/ACT/material-groups/paste/config';
+import {
+  parseMaterials,
+  ResolveTicker,
+} from '@src/features/XIT/ACT/material-groups/paste/paste-parse';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 
-interface ParseResult {
-  materials: Record<string, number>;
-  prices?: Record<string, number>;
-}
-
-function isValidPrice(n: number): boolean {
-  if (n <= 0 || !isFinite(n)) {
-    return false;
-  }
-  // At most 2 fractional digits.
-  if (Math.round(n * 100) !== n * 100) {
-    return false;
-  }
-  return true;
-}
-
-function stripQuotes(s: string): string {
-  if (s.length >= 2 && s[0] === '"' && s[s.length - 1] === '"') {
-    return s.slice(1, -1);
-  }
-  return s;
-}
-
-// Remove thousand separators (commas) from numeric strings: "1,600" → "1600"
-function stripThousands(s: string): string {
-  return s.replace(/,/g, '');
-}
-
-interface SplitResult {
-  parts: string[];
-  isTabSeparated: boolean;
-}
-
-function splitLine(line: string): SplitResult {
-  // Tab-separated (from spreadsheets) takes priority.
-  if (line.includes('\t')) {
-    return {
-      parts: line.split('\t').map(x => stripQuotes(x.trim())),
-      isTabSeparated: true,
-    };
-  }
-  return {
-    parts: line.split(',').map(x => stripQuotes(x.trim())),
-    isTabSeparated: false,
-  };
-}
-
-function parseNumber(value: string, isTabSeparated: boolean): number {
-  // Only strip thousand-separator commas in tab-separated data,
-  // where commas are unambiguously inside values.
-  return Number(isTabSeparated ? stripThousands(value) : value);
-}
-
-export function parseMaterials(input: string | undefined): ParseResult | undefined {
-  if (!input) {
-    return undefined;
-  }
-  const lines = input.split('\n').filter(x => x.trim().length > 0);
-  if (lines.length === 0) {
-    return undefined;
-  }
-  const materials: Record<string, number> = {};
-  let prices: Record<string, number> | undefined;
-  let hasPrice = false;
-  for (const line of lines) {
-    const { parts, isTabSeparated } = splitLine(line);
-    if (parts.length < 2 || parts.length > 3) {
-      return undefined;
-    }
-    const [ticker, amountStr] = parts;
-    const material = materialsStore.getByTicker(ticker.toUpperCase());
-    if (!material) {
-      return undefined;
-    }
-    const amount = parseNumber(amountStr, isTabSeparated);
-    if (!Number.isFinite(amount) || amount <= 0 || Math.floor(amount) !== amount) {
-      return undefined;
-    }
-    materials[material.ticker] = (materials[material.ticker] ?? 0) + amount;
-
-    if (parts.length === 3) {
-      const price = parseNumber(parts[2], isTabSeparated);
-      if (!isValidPrice(price)) {
-        return undefined;
-      }
-      prices ??= {};
-      prices[material.ticker] = price;
-      hasPrice = true;
-    } else if (hasPrice) {
-      // Mixed rows: some have prices, some don't — invalid.
-      return undefined;
-    }
-  }
-  return { materials, prices };
-}
+export const resolveTicker: ResolveTicker = ticker => materialsStore.getByTicker(ticker)?.ticker;
 
 act.addMaterialGroup<Config>({
   type: 'Paste',
@@ -109,9 +19,9 @@ act.addMaterialGroup<Config>({
   editComponent: Edit,
   configureComponent: Configure,
   needsConfigure: () => true,
-  isValidConfig: (_data, config) => parseMaterials(config.materials) !== undefined,
+  isValidConfig: (_data, config) => parseMaterials(config.materials, resolveTicker) !== undefined,
   generateMaterialBill: async ({ config, log, setPrices }) => {
-    const result = parseMaterials(config.materials);
+    const result = parseMaterials(config.materials, resolveTicker);
     if (!result) {
       log.error('Invalid or missing pasted materials.');
       return undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,6 +29,14 @@ export function changeInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(changeEvent);
 }
 
+// Replaces an input's whole value: focusing and selecting first means a field
+// that already holds text is overwritten rather than appended to.
+export function selectAndChangeInputValue(input: HTMLInputElement, value: string) {
+  focusElement(input);
+  input.select();
+  changeInputValue(input, value);
+}
+
 export function changeTextAreaValue(textarea: HTMLTextAreaElement, value: string) {
   // React overrides the native property, so we can't use it directly.
   const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value');


### PR DESCRIPTION
Adopts the fixes upstream made to these features during six months of review on `refined-prun#212` (Paste material group, merged Sep 6) and `#164` (CONT Ship/Trade, merged Sep 7). This fork took erendrake's WIP branch back in Feb–Mar (`a82de5c1`), so the two have diverged; each upstream change was judged on its own and ported onto this fork's shape rather than taking their diffs wholesale.

## CONT step defects

- **`cont-utils` warned and carried on where it should stop.** A missing name input, material selector, add button, amount input, deadline input, currency select or save button was a `log.warning` + `continue`. A partial DOM match built and saved a contract with materials or a deadline missing, and the run reported success. All are assertions now.
- **No server confirmation on the three writes that matter.** `saveDraftDetails` / `applyTemplate` / `saveConditions` clicked and moved on — `applyTemplate` only watched a CSS `disabled` class, which flickers on any re-render. They now poll `contractDraftsStore.getByNaturalId` until the name/preamble actually persisted, until conditions arrive, and until `status === 'VALID'`.
- **`addMaterials` wrote every row into `groups.at(-1)`.** Safe only while each row is created by the add button; a template rendering more than one row up front collapsed them all into the last. Indexes by row.
- **Two `await $()` calls could hang the run.** `$` has no timeout, so `setDraftNameAndPreamble` and `openTemplate` would wait forever instead of failing. Both poll with a deadline.
- Contract name/preamble truncated to the game's 50/250 form limits.
- The `CONTD` open follows a `waitAct`, so it passes `actGate: false` per `feature-patterns.md` rather than charging a second ACT click.

## CONT Trade could send a free trade

`cont-trade.ts` asserted only that the group had *a* prices object. Combined with the Paste bug below, a group with a price on one row and none on another passed, and the unpriced material went into the contract with a blank price. Every traded material now needs a price from 0.01 to 100000000 — checked at generation, and again before each price field is written.

## Form fixes

Days to Fulfill was capped at 30 where the game takes 99; `validate()` never checked the saved origin/destination were still offered (a base sold since then silently stayed selected); `save()` stored the raw input rather than a number. The currency list was hard-coded `['NCC','CIS','AIC','ICA']` and now reads `balancesStore.currencies`. A material group with no planet is no longer offered as a location target, since it resolves to nothing at run time. CONT Ship no longer forces a configure dialog when nothing in it is settable.

## Paste parser

Rewritten and moved to `paste-parse.ts` with the ticker lookup injected, so it is unit testable.

- **Per-row errors.** It was all-or-nothing: one bad row in a 40-row spreadsheet paste gave a red border and no clue which row. It now reports `Row 12: unknown ticker "XYZ"`.
- **Mixed priced/unpriced rows.** The old guard was order-dependent — `hasPrice` only set after the first priced row, so an unpriced row coming first slipped through. That is the source of the CONT Trade defect above. Mixed rows are now supported properly.
- **Price validation.** CXPO's three-significant-figure cap (confirmed by the repo owner), a two-decimal cap, and conflicting-price detection for a repeated ticker.
- Semicolon delimiters, bare-`\r` line endings, a safe-integer guard, and an explicit error when rows mix delimiters.
- Grouped quantities like `"1,600"` resolve by wholeness rather than erroring as ambiguous — 1.6 is not a candidate reading of a quantity. Grouped *prices* still have to be disambiguated, since both readings are legal there.

Done without adding `papaparse`; upstream took the dependency, this uses a small quote-aware splitter.

## Deliberately not taken

- **Their `selectLocation`** is a plain lowercase substring match on the autosuggest portal. This fork's `select-address.ts` already does station-id→name translation and word-boundary matching so `OT-580` cannot click `OT-580e`. Kept.
- **The `MaterialBill` refactor** (`{quantity, price?}` replacing `setPrices`/`getMaterialGroupPrices`) is functionally identical to what this fork already does — `cx-buy.ts:45` already gives group prices precedence. Eight files of churn, no user-visible change.
- **Localized button text** needs upstream's Localization API (`#222`), absent here.
- **Dropping `totalMaterials`** — upstream never had it; `action-runner.ts:121` uses it.
- **`waitActionFeedback` after each server click.** Upstream added these. `waitActionFeedback` starts with `await $(tile.frame, C.ActionFeedback.overlay)`, which has no timeout, and I could not confirm from the docs that CONTD's save/create buttons render that overlay at all. A hang is a worse failure than the bug, and the store polling above is stronger evidence anyway. Worth revisiting if someone verifies the overlay live.

## Checks

At `92e231a1` with a clean worktree:

- `pnpm run compile` — exit 0
- `pnpm run test` — 171/171
- `vue-tsc --noEmit` — 6 errors repo-wide, **identical to the baseline measured at `e54bb806`** (DISPATCH, GOVBURN, REP, STO, TODO), none in files this PR touches. `tsc` alone does not check `.vue` script blocks, and it missed a real break here that `vue-tsc` caught.
- 19 new parser tests. Each guard was shown failing against a deliberately mutated parser — sig-figs, per-row reporting, quantity grouping, conflicting price, two-decimal cap, mixed delimiters — so none is vacuously green.

**Not verified in the live game.** The CONT step changes are DOM-driving code on a screen whose flow ends in a real contract; the assertions and store polling are reasoned from `docs/game/screens-contracts.md` and the `ContractDraft` type, not exercised against APEX. Worth one run of a CONT Trade package before trusting it with a real contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
