### PR TITLE
XIT FLT: capitalize Fuel header button and bump label size

### DIFF
--- a/src/features/XIT/FLT/FuelHeaderButton.vue
+++ b/src/features/XIT/FLT/FuelHeaderButton.vue
@@ -7,7 +7,13 @@ const emit = defineEmits<{ refuel: [] }>();
 
 <template>
   <span :class="$style.container">
-    <PrunButton dark inline @click.stop="emit('refuel')">{{ FLT_FUEL_HEADER_LABEL }}</PrunButton>
+    <PrunButton
+      dark
+      inline
+      :class="[$style.button, C.fonts.fontRegular, C.type.typeRegular]"
+      @click.stop="emit('refuel')">
+      {{ FLT_FUEL_HEADER_LABEL }}
+    </PrunButton>
     <slot />
   </span>
 </template>
@@ -19,5 +25,9 @@ const emit = defineEmits<{ refuel: [] }>();
   width: 100%;
   white-space: nowrap;
   gap: 6px;
+}
+
+.button {
+  font-size: 12px;
 }
 </style>

--- a/src/features/XIT/FLT/defaults.test.ts
+++ b/src/features/XIT/FLT/defaults.test.ts
@@ -65,8 +65,11 @@ describe('XIT FLT fuel header', () => {
     expect(flt).not.toMatch(/>\s*REFUEL\s*</);
     expect(flt).toMatch(/colProblems[\s\S]*?>\s*Problems\s*</);
 
-    expect(FLT_FUEL_HEADER_LABEL).toBe('fuel');
+    expect(FLT_FUEL_HEADER_LABEL).toBe('Fuel');
     expect(header).toContain('{{ FLT_FUEL_HEADER_LABEL }}');
+    expect(header).toContain('C.fonts.fontRegular');
+    expect(header).toContain('C.type.typeRegular');
+    expect(header).toContain('font-size: 12px');
     expect(header).toMatch(/<PrunButton[^>]*@click\.stop="emit\('refuel'\)"/);
     expect(header).not.toMatch(/>\s*REFUEL\s*</);
   });

--- a/src/features/XIT/FLT/defaults.ts
+++ b/src/features/XIT/FLT/defaults.ts
@@ -13,7 +13,7 @@ export type LayoutMode = 'compact' | 'whitespace' | 'cargo' | 'legacy';
 export type FuelAlertThreshold = '75' | '50' | '35' | '25' | '10';
 export type FuelAlertFilter = 'any' | FuelAlertThreshold;
 
-export const FLT_FUEL_HEADER_LABEL = 'fuel';
+export const FLT_FUEL_HEADER_LABEL = 'Fuel';
 export const FLT_REFUEL_BUFFER_COMMAND = 'XIT REFUELACT';
 
 export const DEFAULT_SORT_DIRECTION_BY_KEY: Record<SortKey, SortDirection> = {


### PR DESCRIPTION
## Summary
- Fuel column header button now reads `Fuel` (Title Case, matching Name / Cargo / Repair).
- Label is one type step larger: game `typeRegular` plus a `12px` override so the game's inline-button CSS cannot keep the old size.

Follow-up to #190. No reviewer requested.

## Test plan
- [ ] Open `XIT FLT` and confirm the fuel-column header button says Fuel and is one size larger than before
- [ ] Click the button and confirm it still opens `XIT REFUELACT`
- [ ] Toggle Columns → FUEL off and confirm the button hides with the column

Made with [Cursor](https://cursor.com)