### PR TITLE
[RPR] NOTS: shift-click mark-read no longer selects the page text

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -1086,6 +1086,8 @@ PrUn stacks floating windows with an inline `z-index` (live `C.Window.window` no
 
 `nots-ship-arrival-inventory` must ignore shift-clicks so it cannot `showBuffer('SHPI …')` on the same gesture.
 
+The browser's own shift-click default is separate from the game's handler: shift-**mousedown** extends the document text selection from the last caret position to the row, so the gesture painted most of the page blue. A capture `mousedown` listener on the same containers calls `preventDefault()` for the same shift+left-button classification and nothing else. That cancels only the selection default — `click` still fires, so the alert is still marked read, and `preventDefault` does not stop propagation, so `focus-buffers-on-click`'s window `mousedown` listener still runs. Do not `stopPropagation` here for the same reason the click handler must not.
+
 ---
 
 ## CSS

--- a/src/features/basic/nots-shift-click-mark-read/nots-shift-click-mark-read.ts
+++ b/src/features/basic/nots-shift-click-mark-read/nots-shift-click-mark-read.ts
@@ -19,8 +19,21 @@ const SETTLE_MS = 400;
 
 function onTileReady(tile: PrunTile) {
   subscribe($$(tile.anchor, C.AlertListItem.container), container => {
+    container.addEventListener('mousedown', onNotificationMouseDown, true);
     container.addEventListener('click', onNotificationClick, true);
   });
+}
+
+// Shift-mousedown extends the document text selection from wherever the caret
+// last sat to the notification row, painting most of the page blue on every
+// mark-read gesture. Suppressing the mousedown default cancels only that
+// selection: the click still reaches the game, so the alert is still marked
+// read, and listeners such as focus-buffers-on-click still run.
+function onNotificationMouseDown(event: MouseEvent) {
+  if (!isNotificationMarkReadClick(event)) {
+    return;
+  }
+  event.preventDefault();
 }
 
 function onNotificationClick(event: MouseEvent) {


### PR DESCRIPTION
Follow-up to #191. Shift-clicking a notification to mark it read also extended the browser's text selection from the last caret position to the clicked row, painting most of the page blue.

The selection is the browser's default action for shift-**mousedown**, not anything the game or the feature does. A capture `mousedown` listener on the same `C.AlertListItem.container` elements calls `preventDefault()` for the same shift + left-button classification the click handler already uses, and does nothing else.

That cancels only the selection default:
- `click` still fires, so the game still opens the notification's target and marks the alert read.
- `preventDefault` does not stop propagation, so `focus-buffers-on-click`'s window `mousedown` listener still runs.
- No `stopPropagation`, for the same reason the click handler must not use one.

## Verification

Live, in the harness browser with the unpacked build, A/B on the same read notification and the same page state:

- **Before (origin/main build):** shift-click highlighted a large swath of the page across three windows and the NOTS list.
- **After (this build):** no selection anywhere; the notification's target buffer still stays hidden.

The click still reaching the game was confirmed without a server write, using PrUn's buffer counter: two consecutive `open-buffer` calls increment the id by 1 (3 → 4), while a shift-click between two opens leaves a gap (4 → 6) — id 5 was the notification's own window, opened by the game's click handler and then closed by the feature.

`pnpm run compile` → 0; `pnpm run test` → 0 (20 files, 176 passed) at `a74a5eee`.
