### PR TITLE
XIT FLT: match fuel header text to other columns; default undocked width 500

### DIFF
--- a/src/features/XIT/FLT/FLEET.ts
+++ b/src/features/XIT/FLT/FLEET.ts
@@ -5,4 +5,5 @@ xit.add({
   name: 'FLEET',
   description: 'Enhanced fleet table with detailed status, cargo, fuel, and quick actions.',
   component: () => FLT,
+  bufferSize: [500, 300],
 });

--- a/src/features/XIT/FLT/FuelHeaderButton.vue
+++ b/src/features/XIT/FLT/FuelHeaderButton.vue
@@ -7,11 +7,7 @@ const emit = defineEmits<{ refuel: [] }>();
 
 <template>
   <span :class="$style.container">
-    <PrunButton
-      dark
-      inline
-      :class="[$style.button, C.fonts.fontRegular, C.type.typeRegular]"
-      @click.stop="emit('refuel')">
+    <PrunButton :class="$style.button" @click.stop="emit('refuel')">
       {{ FLT_FUEL_HEADER_LABEL }}
     </PrunButton>
     <slot />
@@ -27,7 +23,26 @@ const emit = defineEmits<{ refuel: [] }>();
   gap: 6px;
 }
 
-.button {
-  font-size: 12px;
+/* Beat Button__btn so the label inherits Name / Cargo / Repair header text. */
+.container .button,
+.container .button:hover,
+.container .button:focus,
+.container .button:active {
+  appearance: none;
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  min-height: 0;
+  min-width: 0;
+  font: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  text-transform: none;
+  cursor: pointer;
 }
 </style>

--- a/src/features/XIT/FLT/defaults.test.ts
+++ b/src/features/XIT/FLT/defaults.test.ts
@@ -67,10 +67,19 @@ describe('XIT FLT fuel header', () => {
 
     expect(FLT_FUEL_HEADER_LABEL).toBe('Fuel');
     expect(header).toContain('{{ FLT_FUEL_HEADER_LABEL }}');
-    expect(header).toContain('C.fonts.fontRegular');
-    expect(header).toContain('C.type.typeRegular');
-    expect(header).toContain('font-size: 12px');
+    expect(header).toContain('font: inherit');
+    expect(header).toContain('font-size: inherit');
+    expect(header).toContain('color: inherit');
+    expect(header).toContain('text-transform: none');
+    expect(header).not.toContain('C.type.typeRegular');
+    expect(header).not.toContain('font-size: 12px');
     expect(header).toMatch(/<PrunButton[^>]*@click\.stop="emit\('refuel'\)"/);
     expect(header).not.toMatch(/>\s*REFUEL\s*</);
+  });
+});
+
+describe('XIT FLT undocked buffer size', () => {
+  it('defaults undocked width to 500 and keeps height at the generic 300', () => {
+    expect(productSource('FLEET.ts')).toContain('bufferSize: [500, 300]');
   });
 });


### PR DESCRIPTION
## Summary
- Fuel header stays a button (still opens `XIT REFUELACT`) but inherits Name / Cargo / Repair header text styling — same size, weight, and color, no button chrome.
- Undocked `XIT FLT` / `XIT FLEET` now defaults to 500×300. An XIT SET buffer-size rule still wins.

Follow-up to #199. No reviewer requested.

## Test plan
- [ ] Open undocked `XIT FLT` with no SET rule and confirm width is 500px
- [ ] Confirm Fuel header text matches Name / Cargo / Repair (size and style) and still opens `XIT REFUELACT` on click
- [ ] Add an XIT SET buffer rule for `XIT FLT` and confirm that size wins
- [ ] Toggle Columns → FUEL off and confirm the button hides with the column

Made with [Cursor](https://cursor.com)