### PR TITLE
XIT FLT: restore dark inline chrome on the fuel header button

### DIFF
--- a/src/features/XIT/FLT/FuelHeaderButton.vue
+++ b/src/features/XIT/FLT/FuelHeaderButton.vue
@@ -23,13 +23,12 @@ const emit = defineEmits<{ refuel: [] }>();
   gap: 6px;
 }
 
-/* Keep header size/weight; leave Button__dark color (#666) and fill (#333). */
+/* Keep header size; leave Button bold/color (#666) and fill (#333). */
 .container .button,
 .container .button:hover,
 .container .button:focus,
 .container .button:active {
   font-size: inherit;
-  font-weight: inherit;
   line-height: inherit;
   letter-spacing: inherit;
   text-transform: none;

--- a/src/features/XIT/FLT/FuelHeaderButton.vue
+++ b/src/features/XIT/FLT/FuelHeaderButton.vue
@@ -7,7 +7,7 @@ const emit = defineEmits<{ refuel: [] }>();
 
 <template>
   <span :class="$style.container">
-    <PrunButton :class="$style.button" @click.stop="emit('refuel')">
+    <PrunButton dark inline :class="$style.button" @click.stop="emit('refuel')">
       {{ FLT_FUEL_HEADER_LABEL }}
     </PrunButton>
     <slot />
@@ -23,19 +23,11 @@ const emit = defineEmits<{ refuel: [] }>();
   gap: 6px;
 }
 
-/* Beat Button__btn so the label inherits Name / Cargo / Repair header text. */
+/* Keep header typography; leave dark/inline chrome from Button__btn. */
 .container .button,
 .container .button:hover,
 .container .button:focus,
 .container .button:active {
-  appearance: none;
-  background: none;
-  border: none;
-  box-shadow: none;
-  padding: 0;
-  margin: 0;
-  min-height: 0;
-  min-width: 0;
   font: inherit;
   font-size: inherit;
   font-weight: inherit;

--- a/src/features/XIT/FLT/FuelHeaderButton.vue
+++ b/src/features/XIT/FLT/FuelHeaderButton.vue
@@ -23,15 +23,13 @@ const emit = defineEmits<{ refuel: [] }>();
   gap: 6px;
 }
 
-/* Keep header typography; leave dark/inline chrome from Button__btn. */
+/* Keep header size/weight; leave Button__dark color (#666) and fill (#333). */
 .container .button,
 .container .button:hover,
 .container .button:focus,
 .container .button:active {
-  font: inherit;
   font-size: inherit;
   font-weight: inherit;
-  color: inherit;
   line-height: inherit;
   letter-spacing: inherit;
   text-transform: none;

--- a/src/features/XIT/FLT/defaults.test.ts
+++ b/src/features/XIT/FLT/defaults.test.ts
@@ -67,10 +67,12 @@ describe('XIT FLT fuel header', () => {
 
     expect(FLT_FUEL_HEADER_LABEL).toBe('Fuel');
     expect(header).toContain('{{ FLT_FUEL_HEADER_LABEL }}');
+    expect(header).toMatch(/<PrunButton[^>]*dark[^>]*inline/);
     expect(header).toContain('font: inherit');
     expect(header).toContain('font-size: inherit');
     expect(header).toContain('color: inherit');
     expect(header).toContain('text-transform: none');
+    expect(header).not.toContain('background: none');
     expect(header).not.toContain('C.type.typeRegular');
     expect(header).not.toContain('font-size: 12px');
     expect(header).toMatch(/<PrunButton[^>]*@click\.stop="emit\('refuel'\)"/);

--- a/src/features/XIT/FLT/defaults.test.ts
+++ b/src/features/XIT/FLT/defaults.test.ts
@@ -68,10 +68,10 @@ describe('XIT FLT fuel header', () => {
     expect(FLT_FUEL_HEADER_LABEL).toBe('Fuel');
     expect(header).toContain('{{ FLT_FUEL_HEADER_LABEL }}');
     expect(header).toMatch(/<PrunButton[^>]*dark[^>]*inline/);
-    expect(header).toContain('font: inherit');
     expect(header).toContain('font-size: inherit');
-    expect(header).toContain('color: inherit');
+    expect(header).toContain('font-weight: inherit');
     expect(header).toContain('text-transform: none');
+    expect(header).not.toContain('color: inherit');
     expect(header).not.toContain('background: none');
     expect(header).not.toContain('C.type.typeRegular');
     expect(header).not.toContain('font-size: 12px');

--- a/src/features/XIT/FLT/defaults.test.ts
+++ b/src/features/XIT/FLT/defaults.test.ts
@@ -69,8 +69,8 @@ describe('XIT FLT fuel header', () => {
     expect(header).toContain('{{ FLT_FUEL_HEADER_LABEL }}');
     expect(header).toMatch(/<PrunButton[^>]*dark[^>]*inline/);
     expect(header).toContain('font-size: inherit');
-    expect(header).toContain('font-weight: inherit');
     expect(header).toContain('text-transform: none');
+    expect(header).not.toContain('font-weight: inherit');
     expect(header).not.toContain('color: inherit');
     expect(header).not.toContain('background: none');
     expect(header).not.toContain('C.type.typeRegular');


### PR DESCRIPTION
## Summary
- Restore the gray `dark inline` chrome on the XIT FLT Fuel header button (same pattern as other XIT action buttons).
- Keep header font size via inherit, but use the native dark-button label color and bold weight so the chip matches other buttons.
- Leave inline padding unchanged.

## Test plan
- [ ] Open XIT FLT and confirm the Fuel header is a gray button (not plain text).
- [ ] Compare fill/weight with other `dark inline` buttons (e.g. BURN/PROD header actions).
- [ ] Confirm Fuel label size still aligns with nearby FLT headers (Name/Cargo/Repair).
- [ ] Click Fuel and confirm it still opens `XIT REFUELACT`.

Made with [Cursor](https://cursor.com)