### PR TITLE
[RPR] XIT BS: combined burn+repair threshold-proximity sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `XIT BS`: Adds a NEED sort that ranks bases by the closer of burn days and repair age to their red thresholds, while Planet / Burn / Rep keep their raw-value sorts.
 - `ship-unload-to-warehouse`: Shift-click a landed ship's Unload control to move its cargo into the local warehouse.
 
 ### Changed

--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -860,6 +860,13 @@ case 'cargo':
 Decide deliberately whether the final fallback is multiplied by the primary direction. Leaving
 it unmultiplied (XIT FLT) means full ties always read A→Z, even under a descending primary.
 
+### Combining Heterogeneous Sort Factors
+
+When two columns measure different units (XIT BS burn days remaining vs repair age), do not
+rank by either raw value. Convert each to days-until-its-red-threshold, then rank by the
+most urgent of the two (`Math.min`). Keep the raw-value sorts as separate keys so a click
+on Burn or Rep still means that column.
+
 ---
 
 ## Opening Panels Programmatically

--- a/src/features/XIT/BS/BS.vue
+++ b/src/features/XIT/BS/BS.vue
@@ -14,9 +14,12 @@ import {
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { comparePlanets } from '@src/util';
 import { useTileState } from '@src/store/user-data-tiles';
+import { userData } from '@src/store/user-data';
 import { getPlanetBurn } from '@src/core/burn';
+import { getRepairThreshold } from '@src/core/buildings';
 import { countDays } from '@src/features/XIT/BURN/utils';
 import { getPlanetRepairAge } from '@src/features/XIT/REP/entries';
+import { compareBases, type SortDirection, type SortKey } from '@src/features/XIT/BS/base-sort';
 import { timestampEachMinute } from '@src/utils/dayjs';
 import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { findWithQuery } from '@src/utils/find-with-query';
@@ -28,9 +31,6 @@ function findSite(term: string, parts: string[]) {
   const naturalId = convertToPlanetNaturalId(term, parts);
   return sitesStore.getByPlanetNaturalId(naturalId);
 }
-
-type SortKey = 'name' | 'burn' | 'repair';
-type SortDirection = 'asc' | 'desc';
 
 const sortKey = useTileState<SortKey>('sortKey', 'burn');
 const sortDirection = useTileState<SortDirection>('sortDirection', 'asc');
@@ -69,6 +69,8 @@ interface BaseEntry {
   storeId: string;
   days: number | undefined;
   repairDays: number | undefined;
+  burnThreshold: number;
+  repairThreshold: number;
 }
 
 const bases = computed<BaseEntry[] | undefined>(() => {
@@ -81,36 +83,21 @@ const bases = computed<BaseEntry[] | undefined>(() => {
   const entries = sites
     .map(site => {
       const burn = getPlanetBurn(site.siteId);
+      const naturalId = getEntityNaturalIdFromAddress(site.address) ?? '';
       return {
         siteId: site.siteId,
-        naturalId: getEntityNaturalIdFromAddress(site.address) ?? '',
+        naturalId,
         planetName: getEntityNameFromAddress(site.address) ?? '',
         storeId: storagesStore.getByAddressableId(site.siteId)?.[0]?.id ?? '',
         days: burn ? countDays(burn.burn) : undefined,
         repairDays: getPlanetRepairAge(site.siteId, now),
+        burnThreshold: userData.settings.burn.red,
+        repairThreshold: getRepairThreshold(naturalId),
       };
     })
     .filter(x => x.naturalId);
 
-  const dir = sortDirection.value === 'asc' ? 1 : -1;
-
-  entries.sort((a, b) => {
-    if (sortKey.value === 'burn') {
-      const daysA = a.days ?? Infinity;
-      const daysB = b.days ?? Infinity;
-      if (daysA !== daysB) {
-        return (daysA - daysB) * dir;
-      }
-    }
-    if (sortKey.value === 'repair') {
-      const repA = a.repairDays ?? -Infinity;
-      const repB = b.repairDays ?? -Infinity;
-      if (repA !== repB) {
-        return (repB - repA) * dir;
-      }
-    }
-    return comparePlanets(a.naturalId, b.naturalId) * dir;
-  });
+  entries.sort((a, b) => compareBases(a, b, sortKey.value, sortDirection.value, comparePlanets));
 
   return entries;
 });
@@ -167,6 +154,15 @@ const filteredBases = computed(() => {
       <RadioItem v-model="showRepair" horizontal>REPAIR</RadioItem>
       <RadioItem v-model="showInv" horizontal>INV</RadioItem>
       <RadioItem v-model="showWar" horizontal>WAR</RadioItem>
+      <div
+        :class="$style.sortable"
+        data-tooltip="Sort by the closer of burn and repair to their thresholds"
+        @click="setSort('proximity')">
+        NEED
+        <span :class="isSorted('proximity') ? $style.sortActive : $style.sortInactive">{{
+          getSortIndicator('proximity')
+        }}</span>
+      </div>
       <div :class="$style.spacer" />
       <PrunButton primary @click="showBuffer('XIT AGENT')">AGENT</PrunButton>
       <PrunButton primary @click="showBuffer('XIT DISPATCH')">DISPATCH</PrunButton>

--- a/src/features/XIT/BS/base-sort.test.ts
+++ b/src/features/XIT/BS/base-sort.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  combinedDaysUntilThreshold,
+  compareBases,
+  daysUntilBurnThreshold,
+  daysUntilRepairThreshold,
+  type SortKey,
+  type SortableBase,
+} from './base-sort';
+
+function base(partial: Partial<SortableBase> & Pick<SortableBase, 'naturalId'>): SortableBase {
+  return {
+    days: 10,
+    repairDays: 20,
+    burnThreshold: 3,
+    repairThreshold: 60,
+    ...partial,
+  };
+}
+
+function compareNames(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function order(entries: SortableBase[], key: SortKey, direction: 'asc' | 'desc' = 'asc') {
+  return [...entries]
+    .sort((a, b) => compareBases(a, b, key, direction, compareNames))
+    .map(x => x.naturalId);
+}
+
+// Comfortable burn, repair one day from the red threshold.
+const repairUrgent = base({ naturalId: 'AA-001a', days: 20, repairDays: 59 });
+// Low burn days, buildings far from the repair threshold.
+const burnUrgent = base({ naturalId: 'ZZ-999z', days: 5, repairDays: 10 });
+
+describe('daysUntilBurnThreshold', () => {
+  it('is days remaining minus the red burn line', () => {
+    expect(daysUntilBurnThreshold(8, 3)).toBe(5);
+  });
+
+  it('is undefined when burn days are unknown', () => {
+    expect(daysUntilBurnThreshold(undefined, 3)).toBeUndefined();
+  });
+});
+
+describe('daysUntilRepairThreshold', () => {
+  it('is the red repair line minus building age', () => {
+    expect(daysUntilRepairThreshold(50, 60)).toBe(10);
+  });
+
+  it('is undefined when repair age is unknown', () => {
+    expect(daysUntilRepairThreshold(undefined, 60)).toBeUndefined();
+  });
+});
+
+describe('combinedDaysUntilThreshold', () => {
+  it('takes the more urgent of the two factors', () => {
+    expect(combinedDaysUntilThreshold(20, 3, 59, 60)).toBe(1);
+    expect(combinedDaysUntilThreshold(5, 3, 10, 60)).toBe(2);
+  });
+
+  it('omits a missing factor', () => {
+    expect(combinedDaysUntilThreshold(undefined, 3, 59, 60)).toBe(1);
+    expect(combinedDaysUntilThreshold(5, 3, undefined, 60)).toBe(2);
+  });
+
+  it('is Infinity when both factors are missing', () => {
+    expect(combinedDaysUntilThreshold(undefined, 3, undefined, 60)).toBe(Infinity);
+  });
+});
+
+describe('compareBases', () => {
+  const pair = [repairUrgent, burnUrgent];
+
+  it('keeps the raw burn sort', () => {
+    expect(order(pair, 'burn')).toEqual(['ZZ-999z', 'AA-001a']);
+  });
+
+  it('keeps the raw repair sort', () => {
+    expect(order(pair, 'repair')).toEqual(['AA-001a', 'ZZ-999z']);
+  });
+
+  it('keeps the name sort', () => {
+    expect(order(pair, 'name')).toEqual(['AA-001a', 'ZZ-999z']);
+  });
+
+  it('ranks by the closer threshold, not by one raw factor', () => {
+    expect(order(pair, 'proximity')).toEqual(['AA-001a', 'ZZ-999z']);
+  });
+
+  it('does not rank proximity by raw burn days', () => {
+    const proximity = order(pair, 'proximity');
+    const burn = order(pair, 'burn');
+    expect(proximity).not.toEqual(burn);
+  });
+
+  it('reverses proximity when asked', () => {
+    expect(order(pair, 'proximity', 'desc')).toEqual(['ZZ-999z', 'AA-001a']);
+  });
+
+  it('falls through to the name comparator on a proximity tie', () => {
+    const tied = [
+      base({ naturalId: 'ZZ-999z', days: 10, repairDays: 10 }),
+      base({ naturalId: 'AA-001a', days: 10, repairDays: 10 }),
+    ];
+    expect(order(tied, 'proximity')).toEqual(['AA-001a', 'ZZ-999z']);
+  });
+
+  it('sorts a base with no known factors last on ascending proximity', () => {
+    const unknown = base({
+      naturalId: 'MM-500c',
+      days: undefined,
+      repairDays: undefined,
+    });
+    expect(order([unknown, burnUrgent], 'proximity')).toEqual(['ZZ-999z', 'MM-500c']);
+  });
+});

--- a/src/features/XIT/BS/base-sort.ts
+++ b/src/features/XIT/BS/base-sort.ts
@@ -1,0 +1,85 @@
+export type SortKey = 'name' | 'burn' | 'repair' | 'proximity';
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortableBase {
+  naturalId: string;
+  days: number | undefined;
+  repairDays: number | undefined;
+  burnThreshold: number;
+  repairThreshold: number;
+}
+
+export function daysUntilBurnThreshold(days: number | undefined, threshold: number) {
+  if (days === undefined) {
+    return undefined;
+  }
+  return days - threshold;
+}
+
+export function daysUntilRepairThreshold(age: number | undefined, threshold: number) {
+  if (age === undefined) {
+    return undefined;
+  }
+  return threshold - age;
+}
+
+// Most urgent of the two: fewer days until a red threshold ranks first.
+// A missing factor is omitted so one known value still ranks the base.
+export function combinedDaysUntilThreshold(
+  days: number | undefined,
+  burnThreshold: number,
+  age: number | undefined,
+  repairThreshold: number,
+) {
+  const burn = daysUntilBurnThreshold(days, burnThreshold);
+  const repair = daysUntilRepairThreshold(age, repairThreshold);
+  if (burn === undefined) {
+    return repair ?? Infinity;
+  }
+  if (repair === undefined) {
+    return burn;
+  }
+  return Math.min(burn, repair);
+}
+
+export function compareBases(
+  a: SortableBase,
+  b: SortableBase,
+  key: SortKey,
+  direction: SortDirection,
+  compareNames: (left: string, right: string) => number,
+) {
+  const dir = direction === 'asc' ? 1 : -1;
+  if (key === 'burn') {
+    const daysA = a.days ?? Infinity;
+    const daysB = b.days ?? Infinity;
+    if (daysA !== daysB) {
+      return (daysA - daysB) * dir;
+    }
+  }
+  if (key === 'repair') {
+    const repA = a.repairDays ?? -Infinity;
+    const repB = b.repairDays ?? -Infinity;
+    if (repA !== repB) {
+      return (repB - repA) * dir;
+    }
+  }
+  if (key === 'proximity') {
+    const proxA = combinedDaysUntilThreshold(
+      a.days,
+      a.burnThreshold,
+      a.repairDays,
+      a.repairThreshold,
+    );
+    const proxB = combinedDaysUntilThreshold(
+      b.days,
+      b.burnThreshold,
+      b.repairDays,
+      b.repairThreshold,
+    );
+    if (proxA !== proxB) {
+      return (proxA - proxB) * dir;
+    }
+  }
+  return compareNames(a.naturalId, b.naturalId) * dir;
+}


### PR DESCRIPTION
Closes JAC-31.

XIT BS still sorts Planet / Burn / Rep by their raw values. A new NEED control ranks each base by the closer of two threshold proximities: days until `settings.burn.red`, and days until `getRepairThreshold(naturalId)`. Missing burn or repair is omitted from the min; both missing sorts last.

## Verification

At `67c336f0a66502fdc1d1bbcabb0472b1abe6ce1a`, same shell:

- `pnpm run compile` → exit 0
- `pnpm run test` → exit 0 (24 files, 205 passed / 1 skipped)

The "does not rank proximity by raw burn days" test fails when `compareBases` proximity is mutated to sort by raw burn days.
